### PR TITLE
fix: error checking course of subject without exam

### DIFF
--- a/app/views/subjects/show.html.erb
+++ b/app/views/subjects/show.html.erb
@@ -34,7 +34,12 @@
       </span>
 
       <span class="mdc-list-item__meta">
-        <%= form_with(model: @subject, url: approve_subject_path(@subject), data: @subject.exam ? { controller: "autosave-check", action: "ajax:success->exam-visibility#approvalChange" } : { controller: "autosave-check" }) do |form| %>
+        <% if @subject.exam %>
+          <% form_data = { controller: "autosave-check", action: "ajax:success->exam-visibility#approvalChange" } %>
+        <% else %>
+          <% form_data = { controller: "autosave-check" } %>
+        <% end %>
+        <%= form_with(model: @subject, url: approve_subject_path(@subject), data: form_data) do |form| %>
           <div class="mdc-checkbox">
             <%= form.check_box :course_approved, { id: "checkbox_course_approved", class: "mdc-checkbox__native-control", checked: bedel.approved?(@subject.course), disabled: !bedel.able_to_do?(@subject.course), data: { action: "autosave-check#update" } }, "yes", "no" %>
             <div class="mdc-checkbox__background">


### PR DESCRIPTION
When checking the course of a subject without exam from its 'show' view
the console would log an error related to a Stimulus action