### PR TITLE
Remove 'black background when hover on list' hack

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -80,10 +80,10 @@ body {
   }
 }
 
- .total-credits {
-   font-weight: bold;
-   font-size: larger;
- }
+.total-credits {
+ font-weight: bold;
+ font-size: larger;
+}
 
 // Make ellipsis work on list item (https://github.com/material-components/material-components-web/issues/1912)
 .mdc-list-item__text {


### PR DESCRIPTION
Remove hack introduced in https://github.com/cedarcode/student/pull/52.
The problem was fixed on https://github.com/material-components/material-components-web/pull/4695.