### PR TITLE
Fix: back arrow

### DIFF
--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -1,5 +1,5 @@
 <% content_for :navigation_icon do %>
-  <%= nav_icon("arrow_back", (request.referer || root_path)) %>
+  <%= nav_icon("arrow_back", (request.referer ? 'javascript:history.back()' : root_path)) %>
 <% end %>
 <div class="mdc-list-group">
   <h3 class="mdc-list-group__subheader mdc-typography--headline5">Avance de carrera</h3>

--- a/app/views/subject_groups/show.html.erb
+++ b/app/views/subject_groups/show.html.erb
@@ -1,5 +1,5 @@
 <% content_for :navigation_icon do %>
-  <%= nav_icon("arrow_back", (request.referer || root_path)) %>
+  <%= nav_icon("arrow_back", (request.referer ? 'javascript:history.back()' : root_path)) %>
 <% end %>
 
 <% content_for :credits do %>

--- a/app/views/subjects/all.html.erb
+++ b/app/views/subjects/all.html.erb
@@ -1,5 +1,5 @@
 <% content_for :navigation_icon do %>
-  <%= nav_icon("arrow_back", (request.referer || root_path)) %>
+  <%= nav_icon("arrow_back", (request.referer ? 'javascript:history.back()' : root_path)) %>
 <% end %>
 
 <% content_for :credits do %>

--- a/app/views/subjects/show.html.erb
+++ b/app/views/subjects/show.html.erb
@@ -1,5 +1,5 @@
 <% content_for :navigation_icon do %>
-  <%= nav_icon("arrow_back", (request.referer || root_path)) %>
+  <%= nav_icon("arrow_back", (request.referer ? 'javascript:history.back()' : root_path)) %>
 <% end %>
 
 <div class="mdc-list-group">


### PR DESCRIPTION
Back arrow wasn't properly working as it should.
Now, it goes back on browser's history if there's a request, otherwise redirects to the root path.