### PR TITLE
Subject controller - little optimization

### DIFF
--- a/app/controllers/subjects_controller.rb
+++ b/app/controllers/subjects_controller.rb
@@ -2,7 +2,10 @@ class SubjectsController < ApplicationController
   helper_method :bedel
 
   def index
-    @subjects = Subject.order(:semester).select { |subject| bedel.able_to_do?(subject.course) }
+    @subjects = Subject
+                .includes(course: :prerequisite_tree)
+                .order(:semester)
+                .select { |subject| bedel.able_to_do?(subject.course) }
   end
 
   def approve
@@ -39,7 +42,10 @@ class SubjectsController < ApplicationController
   end
 
   def list_subjects
-    @subjects = Subject.order(:semester).select { |subject| bedel.able_to_do?(subject.course) }
+    @subjects = Subject
+                .includes(course: :prerequisite_tree)
+                .order(:semester)
+                .select { |subject| bedel.able_to_do?(subject.course) }
     respond_to do |format|
       format.html { render '_subjects_bulk_approve', layout: false }
     end


### PR DESCRIPTION
This is a little PR to try to avoid doing so many queries in the `index` and in the `list_subjects` methods on the subjects controller (we are still doing a lot but much less).
The only thing i'm doing here is adding and `includes` when fetching the subjects so the query includes the `course` and the `prerequisite_tree` of the course that we use later so we don't have to fetch them one by one.