### PR TITLE
Avoid loading `dotenv` file in production

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -1,12 +1,10 @@
 require_relative 'boot'
 
 require 'rails/all'
-require 'dotenv'
 
 # Require the gems listed in Gemfile, including any gems
 # you've limited to :test, :development, or :production.
 Bundler.require(*Rails.groups)
-Dotenv.load('.env.local')
 
 module Student
   class Application < Rails::Application


### PR DESCRIPTION
## Why

There was an error when deploying to production caused because `dotenv` file was trying to be loaded which failed because the gem is not included in `production`.

```
remote:        Removing websocket-driver (0.7.3)
remote:        Removing actionpack (6.0.3.4)
remote:        Removing actionmailer (6.0.3.4)
remote:        Removing marcel (0.3.3)
remote:        Removing actiontext (6.0.3.4)
remote: -----> Detecting rake tasks
remote:
remote:  !
remote:  !     Could not detect rake tasks
remote:  !     ensure you can run `$ bundle exec rake -P` against your app
remote:  !     and using the production group of your Gemfile.
remote:  !     rake aborted!
remote:  !     LoadError: cannot load such file -- dotenv
remote:  !     /tmp/build_8be19026/vendor/bundle/ruby/2.7.0/gems/bootsnap-1.5.1/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:34:in `require'
remote:  !     /tmp/build_8be19026/vendor/bundle/ruby/2.7.0/gems/activesupport-6.0.6/lib/active_support/dependencies.rb:324:in `block in require'
remote:  !     /tmp/build_8be19026/vendor/bundle/ruby/2.7.0/gems/activesupport-6.0.6/lib/active_support/dependencies.rb:291:in `load_dependency'
remote:  !     /tmp/build_8be19026/vendor/bundle/ruby/2.7.0/gems/activesupport-6.0.6/lib/active_support/dependencies.rb:324:in `require'
remote:  !     /tmp/build_8be19026/config/application.rb:4:in `<main>'
```

## How

The fix is simply to remove the `require` given that `dotenv` is automatically initialized during the `before_configuration` callback.