### PR TITLE
Fix puma vulnerability

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,7 +12,7 @@ gem "omniauth", "~> 2.1"
 gem "omniauth-google-oauth2", '~> 1.1'
 gem "omniauth-rails_csrf_protection", '~> 1.0'
 gem 'pg', '~> 1.1'
-gem 'puma', '~> 4.3.0'
+gem 'puma', '~> 4.3'
 gem 'rollbar', '~> 2.19'
 gem 'sass-rails', '~> 6.0'
 gem 'serviceworker-rails', '~> 0.6'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -288,7 +288,7 @@ DEPENDENCIES
   omniauth-google-oauth2 (~> 1.1)
   omniauth-rails_csrf_protection (~> 1.0)
   pg (~> 1.1)
-  puma (~> 4.3.0)
+  puma (~> 4.3)
   rails (~> 6.0.6)
   rollbar (~> 2.19)
   rubocop (~> 0.67.0)


### PR DESCRIPTION
Vulnerability:

Name: puma
Version: 3.12.6
CVE: CVE-2022-24790
GHSA: GHSA-h99w-9q5r-gjq9
Criticality: Critical
URL: https://github.com/puma/puma/security/advisories/GHSA-h99w-9q5r-gjq9
Title: HTTP Request Smuggling in puma
Solution: upgrade to '~> 4.3.12', '>= 5.6.4'