### PR TITLE
Fix nokogiri vulnerabilities

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,6 @@ gem 'rails', '~> 6.0.6'
 gem 'bootsnap', '~> 1.4', require: false
 gem 'devise', '~> 4.8'
 gem 'jbuilder', '~> 2.9'
-gem 'nokogiri', '~> 1.13.0'
 gem "omniauth", "~> 2.1"
 gem "omniauth-google-oauth2", '~> 1.1'
 gem "omniauth-rails_csrf_protection", '~> 1.0'
@@ -20,6 +19,7 @@ gem 'serviceworker-rails', '~> 0.6'
 gem 'turbolinks', '~> 5.2'
 gem 'uglifier', '~> 4.1'
 gem 'webpacker', '~> 4.0'
+
 group :development, :test do
   gem 'byebug', '~> 11.0', platforms: [:mri, :mingw, :x64_mingw]
   gem "dotenv-rails", "~> 2.7"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -286,7 +286,6 @@ DEPENDENCIES
   jbuilder (~> 2.9)
   letter_opener (~> 1.7)
   listen (~> 3.1)
-  nokogiri (~> 1.13.0)
   omniauth (~> 2.1)
   omniauth-google-oauth2 (~> 1.1)
   omniauth-rails_csrf_protection (~> 1.0)


### PR DESCRIPTION
Name: nokogiri
Version: 1.10.10
CVE: CVE-2021-41098
GHSA: GHSA-2rr5-8q37-2w7h
Criticality: High
URL: https://github.com/sparklemotion/nokogiri/security/advisories/GHSA-2rr5-8q37-2w7h
Title: Improper Restriction of XML External Entity Reference (XXE) in Nokogiri on JRuby
Solution: upgrade to '>= 1.12.5'

Name: nokogiri
Version: 1.10.10
GHSA: GHSA-2qc6-mcvw-92cw
Criticality: Unknown
URL: https://github.com/sparklemotion/nokogiri/security/advisories/GHSA-2qc6-mcvw-92cw
Title: Update bundled libxml2 to v2.10.3 to resolve multiple CVEs
Solution: upgrade to '>= 1.13.9'

Name: nokogiri
Version: 1.10.10
GHSA: GHSA-cgx6-hpwq-fhv5
Criticality: High
URL: https://github.com/sparklemotion/nokogiri/security/advisories/GHSA-cgx6-hpwq-fhv5
Title: Integer Overflow or Wraparound in libxml2 affects Nokogiri
Solution: upgrade to '>= 1.13.5'

Name: nokogiri
Version: 1.10.10
CVE: CVE-2022-24839
GHSA: GHSA-gx8x-g87m-h5q6
Criticality: High
URL: https://github.com/sparklemotion/nekohtml/security/advisories/GHSA-9849-p7jc-9rmv
Title: Denial of Service (DoS) in Nokogiri on JRuby
Solution: upgrade to '>= 1.13.4'

Name: nokogiri
Version: 1.10.10
CVE: CVE-2022-23437
GHSA: GHSA-xxx9-3xcr-gjj3
Criticality: Medium
URL: https://github.com/sparklemotion/nokogiri/security/advisories/GHSA-xxx9-3xcr-gjj3
Title: XML Injection in Xerces Java affects Nokogiri
Solution: upgrade to '>= 1.13.4'

Name: nokogiri
Version: 1.10.10
CVE: CVE-2021-30560
GHSA: GHSA-fq42-c5rg-92c2
Criticality: High
URL: https://github.com/sparklemotion/nokogiri/security/advisories/GHSA-fq42-c5rg-92c2
Title: Update packaged libxml2 (2.9.12 → 2.9.13) and libxslt (1.1.34 → 1.1.35)
Solution: upgrade to '>= 1.13.2'

Name: nokogiri
Version: 1.10.10
GHSA: GHSA-7rrm-v45f-jp64
Criticality: High
URL: https://github.com/sparklemotion/nokogiri/security/advisories/GHSA-7rrm-v45f-jp64
Title: Update packaged dependency libxml2 from 2.9.10 to 2.9.12
Solution: upgrade to '>= 1.11.4'

Name: nokogiri
Version: 1.10.10
CVE: CVE-2018-25032
GHSA: GHSA-v6gp-9mmm-c6p5
Criticality: High
URL: https://github.com/sparklemotion/nokogiri/security/advisories/GHSA-v6gp-9mmm-c6p5
Title: Out-of-bounds Write in zlib affects Nokogiri
Solution: upgrade to '>= 1.13.4'

Name: nokogiri
Version: 1.10.10
CVE: CVE-2022-29181
GHSA: GHSA-xh29-r2w5-wx8m
Criticality: High
URL: https://github.com/sparklemotion/nokogiri/security/advisories/GHSA-xh29-r2w5-wx8m
Title: Improper Handling of Unexpected Data Type in Nokogiri
Solution: upgrade to '>= 1.13.6'

Name: nokogiri
Version: 1.10.10
CVE: CVE-2022-24836
GHSA: GHSA-crjr-9rc5-ghw8
Criticality: High
URL: https://github.com/sparklemotion/nokogiri/security/advisories/GHSA-crjr-9rc5-ghw8
Title: Inefficient Regular Expression Complexity in Nokogiri
Solution: upgrade to '>= 1.13.4'

Name: nokogiri
Version: 1.10.10
CVE: CVE-2020-26247
GHSA: GHSA-vr8q-g5c7-m54m
Criticality: Low
URL: https://github.com/sparklemotion/nokogiri/security/advisories/GHSA-vr8q-g5c7-m54m
Title: Nokogiri::XML::Schema trusts input by default, exposing risk of an XXE vulnerability
Solution: upgrade to '>= 1.11.0.rc4'