### PR TITLE
Fix credits not being instantly awarded in some cases

### DIFF
--- a/app/models/bedel.rb
+++ b/app/models/bedel.rb
@@ -14,6 +14,8 @@ class Bedel
       else
         store[:approved_courses] += [approvable.subject_id]
       end
+
+      force_credits_recalculation!
     else
       false
     end
@@ -31,6 +33,7 @@ class Bedel
       store[:approved_courses] -= [approvable.subject_id]
     end
 
+    force_credits_recalculation!
     refresh_approvals
   end
 
@@ -65,6 +68,7 @@ class Bedel
     end
 
     if new_count != original_count
+      force_credits_recalculation!
       refresh_approvals
     end
   end
@@ -129,6 +133,11 @@ class Bedel
       .includes(:exam)
       .where(approvables: { subject_id: nil }, subjects: { id: store[:approved_courses] })
       .sum(:credits)
+  end
+
+  def force_credits_recalculation!
+    @exam_credits = nil
+    @course_credits = nil
   end
 
   def subject_scope(group)


### PR DESCRIPTION
## What

When marking a Subject that has a total number of credits as prerequisite as approved, the credits are not instantly awarded – you’ll have to reload the page first.

This is important because the subject Proyecto de Grado has credits prerequisites, so it could be affected in some cases by this bug.

#### Steps to reproduce:

- Mark Programación 1 as approved

- Fill in with other subjects until you get to 100 credits

- Mark Butia: Robótica Educativa as approved

#### Expected behavior:

The subject is marked as approved and 8 credits are instantly added to your number of credits

#### Actual behavior:

The subject is marked as approved but the credits are not added

https://user-images.githubusercontent.com/46354312/211044128-0f10af66-e8e8-4541-a222-d7ca3748f1ca.mov

## Why

This is happening because we are memoizing exam_credits and course_credits which are added to get the total number of credits – [link](https://github.com/cedarcode/student/blob/81df950/app/models/bedel.rb#L73).

The problem with this approach is that, for these subjects that have credits prerequisites, we ask for the number of credits that the users have – as we need to know if they can enroll to the subject – which causes that the total number gets memoized so it doesn’t get updated once the course is added to the users' list of approved_courses.


## How

In order to fix this we just have to force credits to be recalculated by deleting the credits memoization