### PR TITLE
fix: red disappears from fields with errors when clicking it

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -155,14 +155,6 @@ body {
   margin-top: 10px;
 }
 
-.invalid-feedback {
-  color: red;
-}
-
-.is-invalid {
-  border-color: red;
-}
-
 .menu-user-info {
   padding: 0 16px;
 }
@@ -201,4 +193,12 @@ body {
 .list-item {
   padding-top: 10px;
   padding-bottom: 10px;
+}
+
+.w-100 {
+  width: 100%;
+}
+
+.helper-line-padding {
+  padding: 0 16px;
 }

--- a/app/views/devise/passwords/edit.html.erb
+++ b/app/views/devise/passwords/edit.html.erb
@@ -6,11 +6,13 @@
       <%= f.hidden_field :reset_password_token %>
 
       <li class="form-input-container">
-        <div class="mdc-text-field <%='mdc-text-field--invalid mdc-text-field--with-trailing-icon' if resource.errors[:password].any? %>" data-controller="textfield">
-          <%= render 'shared/invalid_icon', resource: resource, field: :password %>
-          <%= f.label :password, "Nueva contraseña", class: "mdc-floating-label" %>
-          <%= f.password_field :password, class: "mdc-text-field__input", autofocus: true %>
-          <div class="mdc-line-ripple"></div>
+        <div class="<%='mdc-text-field--invalid mdc-text-field--with-trailing-icon' if resource.errors[:password].any? %>">
+          <div class="w-100 mdc-text-field" data-controller="textfield">
+            <%= render 'shared/invalid_icon', resource: resource, field: :password %>
+            <%= f.label :password, "Nueva contraseña", class: "mdc-floating-label" %>
+            <%= f.password_field :password, class: "mdc-text-field__input", autofocus: true %>
+            <div class="mdc-line-ripple"></div>
+          </div>
         </div>
         <%= render 'shared/info_and_errors', resource: resource, field: :password, text: "#{@minimum_password_length} caracteres mínimo" %>
       </li>

--- a/app/views/devise/passwords/new.html.erb
+++ b/app/views/devise/passwords/new.html.erb
@@ -5,11 +5,13 @@
     <%= form_with(model: resource, url: password_path(resource_name), method: :post, local: true) do |f| %>
 
       <li class="form-input-container">
-        <div class="mdc-text-field <%='mdc-text-field--invalid mdc-text-field--with-trailing-icon' if resource.errors[:email].any? %>" data-controller="textfield">
-          <%= render 'shared/invalid_icon', resource: resource, field: :email %>
-          <%= f.label :email, "Correo electrónico", class: "mdc-floating-label" %>
-          <%= f.email_field :email, class: "mdc-text-field__input", autofocus: true %>
-          <div class="mdc-line-ripple"></div>
+        <div class="<%='mdc-text-field--invalid mdc-text-field--with-trailing-icon' if resource.errors[:email].any? %>">
+          <div class="w-100 mdc-text-field" data-controller="textfield">
+            <%= render 'shared/invalid_icon', resource: resource, field: :email %>
+            <%= f.label :email, "Correo electrónico", class: "mdc-floating-label" %>
+            <%= f.email_field :email, class: "mdc-text-field__input", autofocus: true %>
+            <div class="mdc-line-ripple"></div>
+          </div>
         </div>
         <%= render 'shared/info_and_errors', resource: resource, field: :email, text: '' %>
       </li>

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -5,36 +5,43 @@
     <%= form_with(model: resource, url: registration_path(resource_name), method: :put, local: true) do |f| %>
 
       <li class="form-input-container">
-        <div class="mdc-text-field <%='mdc-text-field--invalid mdc-text-field--with-trailing-icon' if resource.errors[:email].any? %>" data-controller="textfield">
-          <%= render 'shared/invalid_icon', resource: resource, field: :email %>
-          <%= f.label :email, "Correo electrónico", class: "mdc-floating-label" %>
-          <%= f.email_field :email, class: "mdc-text-field__input", required: true, autofocus: true, autocomplete: "email" %>
-          <div class="mdc-line-ripple"></div>
+        <div class="<%='mdc-text-field--invalid mdc-text-field--with-trailing-icon' if resource.errors[:email].any? %>">
+          <div class="w-100 mdc-text-field" data-controller="textfield">
+            <%= render 'shared/invalid_icon', resource: resource, field: :email %>
+            <%= f.label :email, "Correo electrónico", class: "mdc-floating-label" %>
+            <%= f.email_field :email, class: "mdc-text-field__input", required: true, autofocus: true, autocomplete: "email" %>
+            <div class="mdc-line-ripple"></div>
+          </div>
         </div>
         <%= render 'shared/info_and_errors', resource: resource, field: :email, text:  current_user.oauth_user? ?
             "Si cambias tu correo electrónico, perderás el acceso con Google" :
             "" %>
       </li>
       <li class="form-input-container">
-        <div class="mdc-text-field <%='mdc-text-field--invalid mdc-text-field--with-trailing-icon' if resource.errors[:password].any? %>" data-controller="textfield">
-          <%= render 'shared/invalid_icon', resource: resource, field: :password %>
-          <%= f.label :password, "Nueva contraseña", class: "mdc-floating-label" %>
-          <%= f.password_field :password, class: "mdc-text-field__input", autofocus: true, autocomplete: "new-password" %>
-          <div class="mdc-line-ripple"></div>
+        <div class="<%='mdc-text-field--invalid mdc-text-field--with-trailing-icon' if resource.errors[:password].any? %>">
+          <div class="w-100 mdc-text-field" data-controller="textfield">
+            <%= render 'shared/invalid_icon', resource: resource, field: :password %>
+            <%= f.label :password, "Nueva contraseña", class: "mdc-floating-label" %>
+            <%= f.password_field :password, class: "mdc-text-field__input", autofocus: true, autocomplete: "new-password" %>
+            <div class="mdc-line-ripple"></div>
+          </div>
         </div>
         <%= render 'shared/info_and_errors', resource: resource, field: :password, text: "#{@minimum_password_length} caracteres mínimo. Dejar en blanco si no lo quieres cambiar." %>
       </li>
       <li class="form-input-container">
-        <div class="mdc-text-field <%='mdc-text-field--invalid mdc-text-field--with-trailing-icon' if resource.errors[:password_confirmation].any? %>" data-controller="textfield">
-          <%= render 'shared/invalid_icon', resource: resource, field: :password_confirmation %>
-          <%= f.label :password_confirmation, "Confirma tu nueva contraseña", class: "mdc-floating-label" %>
-          <%= f.password_field :password_confirmation, class: "mdc-text-field__input", autofocus: true, autocomplete: "new-password" %>
-          <div class="mdc-line-ripple"></div>
+        <div class="<%='mdc-text-field--invalid mdc-text-field--with-trailing-icon' if resource.errors[:password_confirmation].any? %>">
+          <div class="w-100 mdc-text-field" data-controller="textfield">
+            <%= render 'shared/invalid_icon', resource: resource, field: :password_confirmation %>
+            <%= f.label :password_confirmation, "Confirma tu nueva contraseña", class: "mdc-floating-label" %>
+            <%= f.password_field :password_confirmation, class: "mdc-text-field__input", autofocus: true, autocomplete: "new-password" %>
+            <div class="mdc-line-ripple"></div>
+          </div>
         </div>
         <%= render 'shared/info_and_errors', resource: resource, field: :password_confirmation, text: '' %>
       </li>
       <li class="form-input-container">
-        <div class="mdc-text-field <%='mdc-text-field--invalid mdc-text-field--with-trailing-icon' if resource.errors[:current_password].any? %>" data-controller="textfield">
+         <div class="<%='mdc-text-field--invalid mdc-text-field--with-trailing-icon' if resource.errors[:current_password].any? %>">
+          <div class="w-100 mdc-text-field" data-controller="textfield">
           <%= render 'shared/invalid_icon', resource: resource, field: :current_password %>
           <%= f.label :current_password, "Contraseña actual", class: "mdc-floating-label" %>
           <%= f.password_field :current_password, class: "mdc-text-field__input", required: true, autofocus: true, autocomplete: 'current-password' %>

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -21,29 +21,35 @@
       </li>
 
       <li class="form-input-container">
-        <div class="mdc-text-field <%='mdc-text-field--invalid mdc-text-field--with-trailing-icon' if resource.errors[:email].any? %>" data-controller="textfield">
-          <%= render 'shared/invalid_icon', resource: resource, field: :email %>
-          <%= f.label :email, "Correo electrónico", class: "mdc-floating-label" %>
-          <%= f.email_field :email, class: "mdc-text-field__input", required: true %>
-          <div class="mdc-line-ripple"></div>
+        <div class="<%='mdc-text-field--invalid mdc-text-field--with-trailing-icon' if resource.errors[:email].any? %>">
+          <div class="w-100 mdc-text-field" data-controller="textfield">
+            <%= render 'shared/invalid_icon', resource: resource, field: :email %>
+            <%= f.label :email, "Correo electrónico", class: "mdc-floating-label" %>
+            <%= f.email_field :email, class: "mdc-text-field__input", required: true %>
+            <div class="mdc-line-ripple"></div>
+          </div>
         </div>
         <%= render 'shared/info_and_errors', resource: resource, field: :email, text: '' %>
       </li>
       <li class="form-input-container">
-        <div class="mdc-text-field <%='mdc-text-field--invalid mdc-text-field--with-trailing-icon' if resource.errors[:password].any? %>" data-controller="textfield">
-          <%= render 'shared/invalid_icon', resource: resource, field: :password %>
-          <%= f.label :password, "Nueva contraseña", class: "mdc-floating-label" %>
-          <%= f.password_field :password, class: "mdc-text-field__input", required: true, autocomplete: "new-password"  %>
-          <div class="mdc-line-ripple"></div>
+        <div class="<%='mdc-text-field--invalid mdc-text-field--with-trailing-icon' if resource.errors[:password].any? %>">
+          <div class="w-100 mdc-text-field" data-controller="textfield">
+            <%= render 'shared/invalid_icon', resource: resource, field: :password %>
+            <%= f.label :password, "Nueva contraseña", class: "mdc-floating-label" %>
+            <%= f.password_field :password, class: "mdc-text-field__input", required: true, autocomplete: "new-password" %>
+            <div class="mdc-line-ripple"></div>
+          </div>
         </div>
         <%= render 'shared/info_and_errors', resource: resource, field: :password, text: "#{@minimum_password_length} caracteres mínimo." %>
       </li>
       <li class="form-input-container">
-        <div class="mdc-text-field <%='mdc-text-field--invalid mdc-text-field--with-trailing-icon' if resource.errors[:password_confirmation].any? %>" data-controller="textfield">
-          <%= render 'shared/invalid_icon', resource: resource, field: :password_confirmation %>
-          <%= f.label :password_confirmation, "Confirma tu nueva contraseña", class: "mdc-floating-label" %>
-          <%= f.password_field :password_confirmation, class: "mdc-text-field__input", required: true, autocomplete: "new-password"  %>
-          <div class="mdc-line-ripple"></div>
+        <div class="<%='mdc-text-field--invalid mdc-text-field--with-trailing-icon' if resource.errors[:password_confirmation].any? %>">
+          <div class="w-100 mdc-text-field" data-controller="textfield">
+            <%= render 'shared/invalid_icon', resource: resource, field: :password_confirmation %>
+            <%= f.label :password_confirmation, "Confirma tu nueva contraseña", class: "mdc-floating-label" %>
+            <%= f.password_field :password_confirmation, class: "mdc-text-field__input", required: true, autocomplete: "new-password" %>
+            <div class="mdc-line-ripple"></div>
+          </div>
         </div>
         <%= render 'shared/info_and_errors', resource: resource, field: :password_confirmation, text: '' %>
       </li>

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -21,20 +21,24 @@
         Ingresar con tu correo electrónico
       </li>
       <li class="form-input-container">
-        <div class="mdc-text-field <%='mdc-text-field--invalid mdc-text-field--with-trailing-icon' if resource.errors[:email].any? %>" data-controller="textfield">
-          <%= render 'shared/invalid_icon', resource: resource, field: :email %>
-          <%= f.label :email, "Correo electrónico", class: "mdc-floating-label" %>
-          <%= f.email_field :email, class: "mdc-text-field__input", required: true, autofocus: true %>
-          <div class="mdc-line-ripple"></div>
+        <div class="<%='mdc-text-field--invalid mdc-text-field--with-trailing-icon' if resource.errors[:email].any? %>">
+          <div class="w-100 mdc-text-field" data-controller="textfield">
+            <%= render 'shared/invalid_icon', resource: resource, field: :email %>
+            <%= f.label :email, "Correo electrónico", class: "mdc-floating-label" %>
+            <%= f.email_field :email, class: "mdc-text-field__input", required: true, autofocus: true %>
+            <div class="mdc-line-ripple"></div>
+          </div>
         </div>
         <%= render 'shared/info_and_errors', resource: resource, field: :email, text: '' %>
       </li>
       <li class="form-input-container">
-        <div class="mdc-text-field <%='mdc-text-field--invalid mdc-text-field--with-trailing-icon' if resource.errors[:password].any? %>" data-controller="textfield">
-          <%= render 'shared/invalid_icon', resource: resource, field: :password %>
-          <%= f.label :password, "Contraseña", class: "mdc-floating-label" %>
-          <%= f.password_field :password, class: "mdc-text-field__input", required: true, autofocus: true, autocomplete: "current-password"  %>
-          <div class="mdc-line-ripple"></div>
+        <div class="<%='mdc-text-field--invalid mdc-text-field--with-trailing-icon' if resource.errors[:password].any? %>">
+          <div class="w-100 mdc-text-field" data-controller="textfield">
+            <%= render 'shared/invalid_icon', resource: resource, field: :password %>
+            <%= f.label :password, "Contraseña", class: "mdc-floating-label" %>
+            <%= f.password_field :password, class: "mdc-text-field__input", required: true, autofocus: true, autocomplete: "current-password" %>
+            <div class="mdc-line-ripple"></div>
+          </div>
         </div>
         <%= render 'shared/info_and_errors', resource: resource, field: :password, text: '' %>
       </li>

--- a/app/views/shared/_info_and_errors.html.erb
+++ b/app/views/shared/_info_and_errors.html.erb
@@ -1,4 +1,4 @@
-<div class='mdc-text-field-helper-line'>
+<div class='mdc-text-field-helper-line helper-line-padding'>
   <div class="mdc-text-field-helper-text mdc-text-field-helper-text--persistent">
     <% if resource.errors[field].any? %>
       <span class='mdc-text-field-helper-text--validation-msg' role='alert'>


### PR DESCRIPTION
Associated ticket: https://trello.com/c/5rhVSMHc/136-when-clicking-field-with-error-red-disappears