### PR TITLE
wait_for_async_request to make sure request finishes before test ends

### DIFF
--- a/test/system/credits_as_prerequisites_test.rb
+++ b/test/system/credits_as_prerequisites_test.rb
@@ -47,6 +47,8 @@ class CreditsAsPrerequisitesTest < ApplicationSystemTestCase
     check "checkbox_#{@gal1.id}_course_approved", visible: :all
     wait_for_async_request
     check "checkbox_#{@gal1.id}_exam_approved", visible: :all
+    wait_for_async_request
+
     assert_no_text "GAL 3"
   end
 


### PR DESCRIPTION
Running tests with this seed `rails test test/system/credits_as_prerequisites_test.rb --seed 57596` was causing the session from `student cant see subjects without enough group credits ` to be leaked into the next test. Because checking the exam checbox triggers an ajax request, and then asserts `GAL 3` doesn't exist (which didn't exist before), so the test ends immediately, while the ajax request is still loading. Then capybara resets the session and starts the next test, but the previous ajax request finishes and contaminates the session for the new test