### PR TITLE
Fix Google SSO button with wrong styles on mobile devices

### DIFF
--- a/app/assets/stylesheets/_google_sso.scss
+++ b/app/assets/stylesheets/_google_sso.scss
@@ -14,9 +14,11 @@
 
     .google-sign-in-text {
       padding-right: 5px;
+      font-weight: 400;
       font-size: 14px;
       color: #3c4043;
       font-family: "Roboto-Medium";
+      white-space: nowrap;
     }
 
     .google-icon {


### PR DESCRIPTION
Trello: https://trello.com/c/mnaNH7vM/181-google-sso-button-with-wrong-styles-for-mobile-devices

## What

We weren't setting the `font-weight` so in mobile the default was being set to `700` which caused the button to appear in `bold`. Also added the `white-space: nowrap` so that the text is not wrapped.

## Screenshots

### Before

<img src="https://user-images.githubusercontent.com/46354312/214450652-07f394a6-c73c-4424-ab8f-b5feccc4cef3.png" width="350"/>

### After

<img src="https://user-images.githubusercontent.com/46354312/214450647-aa99d8af-a49b-4ab8-a256-c8e4dcc3de17.png" width="350"/>