### PR TITLE
fix: move require inside task

### DIFF
--- a/lib/tasks/scrape.rake
+++ b/lib/tasks/scrape.rake
@@ -1,8 +1,8 @@
-require 'bedelias_spider'
-
 namespace :scrape do
   desc "scrape subject groups, subjects and their prerequisites from bedelias.udelar.edu.uy to YAML file"
   task subjects: :environment do
+    require 'bedelias_spider'
+
     BedeliasSpider.new.parse_subjects_and_prerequisites
   end
 end


### PR DESCRIPTION
Selenium and capybara are in the test group, so when deploying with the `require 'bedelias_spider'` outside the task, errors are produced. Moving this require inside the task solves the issue.