### PR TITLE
Show full word Curso and Examen

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -61,7 +61,10 @@ body {
 .two-checkboxes {
   display: flex;
   height: 40px;
-  width: 80px;
+  width: 100px;
+  form {
+    margin: 0 5px;
+  }
 }
 
 .toggle-collapse {
@@ -188,7 +191,7 @@ body {
 
 .checkbox-header {
   height: 40px;
-  width: 40px;
+  width: 50px;
   display: flex;
   justify-content: center;
   align-items: center;

--- a/app/views/subjects/_subjects_bulk_approve.html.erb
+++ b/app/views/subjects/_subjects_bulk_approve.html.erb
@@ -3,8 +3,8 @@
     <div class='mdc-deprecated-list-group__subheader subject-group-header'>
       <h3 class="mdc-typography--subtitle2"><%= semester.present? ? semester_to_text(semester) + " semestre" : "Materias optativas" %></h3>
       <div class='mdc-typography--subtitle2 d-flex'>
-        <h3 class='checkbox-header' title='Curso'>C</h3>
-        <h3 class='checkbox-header' title='Examen'>E</h3>
+        <h3 class='checkbox-header'>Curso</h3>
+        <h3 class='checkbox-header'>Examen</h3>
       </div>
     </div>
     <div class="mdc-deprecated-list">


### PR DESCRIPTION
https://trello.com/c/tdyVdOvM/184-investigate-how-ui-looks-like-for-mobile-if-we-display-curso-and-examen-instead-of-c-and-e-in-subjects-list

<img width="1552" alt="image" src="https://user-images.githubusercontent.com/972779/215923428-422c48b5-c2cf-4bfe-8af7-26315aee9169.png">

<img width="1552" alt="image" src="https://user-images.githubusercontent.com/972779/215923445-c4c2fb35-fbab-4486-92e0-28353dfcdcdf.png">
