### PR TITLE
Wait until foreground div disappears instead of doing a sleep

### DIFF
--- a/test/system/approval_test.rb
+++ b/test/system/approval_test.rb
@@ -9,7 +9,7 @@ class ApprovalTest < ApplicationSystemTestCase
     visit subject_path(@subject)
 
     check "Curso aprobado?", visible: :all
-    wait_for_async_request
+    wait_for_approvables_reloaded
     visit root_path
 
     assert_text "0 créditos"
@@ -22,7 +22,7 @@ class ApprovalTest < ApplicationSystemTestCase
     visit root_path
 
     find("#checkbox_#{@subject.id}_course_approved", visible: :all).click
-    wait_for_async_request
+    wait_for_approvables_reloaded
     visit root_path
 
     assert_text "0 créditos"
@@ -35,7 +35,7 @@ class ApprovalTest < ApplicationSystemTestCase
     visit subject_path(@subject)
 
     check "Examen aprobado?", visible: :all
-    wait_for_async_request
+    wait_for_approvables_reloaded
     visit root_path
 
     assert_text "9 créditos"
@@ -47,7 +47,7 @@ class ApprovalTest < ApplicationSystemTestCase
   test "student adds approved exam from index" do
     visit root_path
     find("#checkbox_#{@subject.id}_course_approved", visible: :all).click
-    wait_for_async_request
+    wait_for_approvables_reloaded
 
     find("#checkbox_#{@subject.id}_exam_approved", visible: :all).click
 
@@ -62,11 +62,11 @@ class ApprovalTest < ApplicationSystemTestCase
   test "student remove approved course from show" do
     visit subject_path(@subject)
     check "Curso aprobado?", visible: :all
-    wait_for_async_request
+    wait_for_approvables_reloaded
 
     visit subject_path(@subject)
     uncheck "Curso aprobado?", visible: :all
-    wait_for_async_request
+    wait_for_approvables_reloaded
     visit subject_path(@subject)
 
     assert page.has_unchecked_field?("Curso aprobado?", visible: :all)
@@ -77,11 +77,11 @@ class ApprovalTest < ApplicationSystemTestCase
   test "student remove approved course from index" do
     visit root_path
     find("#checkbox_#{@subject.id}_course_approved", visible: :all).click
-    wait_for_async_request
+    wait_for_approvables_reloaded
 
     visit root_path
     find("#checkbox_#{@subject.id}_course_approved", visible: :all).click
-    wait_for_async_request
+    wait_for_approvables_reloaded
     visit root_path
 
     assert page.has_unchecked_field?("checkbox_#{@subject.id}_course_approved", visible: :all)
@@ -92,13 +92,13 @@ class ApprovalTest < ApplicationSystemTestCase
   test "student remove approved exam from show" do
     visit subject_path(@subject)
     check "Curso aprobado?", visible: :all
-    wait_for_async_request
+    wait_for_approvables_reloaded
     check "Examen aprobado?", visible: :all
-    wait_for_async_request
+    wait_for_approvables_reloaded
 
     visit subject_path(@subject)
     uncheck "Examen aprobado?", visible: :all
-    wait_for_async_request
+    wait_for_approvables_reloaded
     visit subject_path(@subject)
 
     assert page.has_unchecked_field?("Examen aprobado?", visible: :all)
@@ -109,13 +109,13 @@ class ApprovalTest < ApplicationSystemTestCase
   test "student remove approved exam from index" do
     visit root_path
     find("#checkbox_#{@subject.id}_course_approved", visible: :all).click
-    wait_for_async_request
+    wait_for_approvables_reloaded
     find("#checkbox_#{@subject.id}_exam_approved", visible: :all).click
-    wait_for_async_request
+    wait_for_approvables_reloaded
 
     visit root_path
     find("#checkbox_#{@subject.id}_exam_approved", visible: :all).click
-    wait_for_async_request
+    wait_for_approvables_reloaded
     visit root_path
 
     assert_text "0 créditos"

--- a/test/system/auto_unapprove_test.rb
+++ b/test/system/auto_unapprove_test.rb
@@ -13,15 +13,15 @@ class AutoUnapprovalTest < ApplicationSystemTestCase
   test "unapproving Subject 1 unapproves the rest" do
     visit root_path
     find("#checkbox_#{@subject1.id}_course_approved", visible: :all).click
-    wait_for_async_request
+    wait_for_approvables_reloaded
     find("#checkbox_#{@subject2.id}_course_approved", visible: :all).click
-    wait_for_async_request
+    wait_for_approvables_reloaded
     find("#checkbox_#{@subject3.id}_course_approved", visible: :all).click
-    wait_for_async_request
+    wait_for_approvables_reloaded
 
     visit root_path
     find("#checkbox_#{@subject1.id}_course_approved", visible: :all).click
-    wait_for_async_request
+    wait_for_approvables_reloaded
     visit root_path
 
     assert_text "0 créditos"

--- a/test/system/compound_prerequisites_test.rb
+++ b/test/system/compound_prerequisites_test.rb
@@ -39,20 +39,20 @@ class CompoundPrerequisitesTest < ApplicationSystemTestCase
 
     assert_no_text "P2"
     check "checkbox_#{@gal1.id}_course_approved", visible: :all
-    wait_for_async_request
+    wait_for_approvables_reloaded
     check "checkbox_#{@gal1.id}_exam_approved", visible: :all
-    wait_for_async_request
+    wait_for_approvables_reloaded
     assert_no_text "P2"
   end
 
   test "student can see subjects if they meet the requirements of the first operand" do
     visit root_path
     check "checkbox_#{@gal1.id}_course_approved", visible: :all
-    wait_for_async_request
+    wait_for_approvables_reloaded
     check "checkbox_#{@gal1.id}_exam_approved", visible: :all
-    wait_for_async_request
+    wait_for_approvables_reloaded
     check "checkbox_#{@gal2.id}_course_approved", visible: :all
-    wait_for_async_request
+    wait_for_approvables_reloaded
     check "checkbox_#{@gal2.id}_exam_approved", visible: :all
 
     assert_text "P2"
@@ -61,9 +61,9 @@ class CompoundPrerequisitesTest < ApplicationSystemTestCase
   test "student can see subjects if they meet the requirements of the second operand" do
     visit root_path
     check "checkbox_#{@gal1.id}_course_approved", visible: :all
-    wait_for_async_request
+    wait_for_approvables_reloaded
     check "checkbox_#{@gal2.id}_course_approved", visible: :all
-    wait_for_async_request
+    wait_for_approvables_reloaded
     check "checkbox_#{@p1.id}_course_approved", visible: :all
 
     assert_text "P2"
@@ -72,11 +72,11 @@ class CompoundPrerequisitesTest < ApplicationSystemTestCase
   test "student can see subjects if they meet the requirements of the third operand" do
     visit root_path
     check "checkbox_#{@gal1.id}_course_approved", visible: :all
-    wait_for_async_request
+    wait_for_approvables_reloaded
     check "checkbox_#{@gal1.id}_exam_approved", visible: :all
-    wait_for_async_request
+    wait_for_approvables_reloaded
     check "checkbox_#{@p1.id}_course_approved", visible: :all
-    wait_for_async_request
+    wait_for_approvables_reloaded
     check "checkbox_#{@p1.id}_exam_approved", visible: :all
 
     assert_text "P2"

--- a/test/system/credits_as_prerequisites_test.rb
+++ b/test/system/credits_as_prerequisites_test.rb
@@ -23,7 +23,7 @@ class CreditsAsPrerequisitesTest < ApplicationSystemTestCase
   test "student can see subjects with enough credits" do
     visit root_path
     check "checkbox_#{@gal1.id}_course_approved", visible: :all
-    wait_for_async_request
+    wait_for_approvables_reloaded
     check "checkbox_#{@gal1.id}_exam_approved", visible: :all
 
     assert_text "GAL 2"
@@ -32,7 +32,7 @@ class CreditsAsPrerequisitesTest < ApplicationSystemTestCase
   test "student can hide subjects" do
     visit root_path
     check "checkbox_#{@gal1.id}_course_approved", visible: :all
-    wait_for_async_request
+    wait_for_approvables_reloaded
     check "checkbox_#{@gal1.id}_exam_approved", visible: :all
 
     assert_text "GAL 2"
@@ -45,9 +45,9 @@ class CreditsAsPrerequisitesTest < ApplicationSystemTestCase
 
     assert_no_text "GAL 3"
     check "checkbox_#{@gal1.id}_course_approved", visible: :all
-    wait_for_async_request
+    wait_for_approvables_reloaded
     check "checkbox_#{@gal1.id}_exam_approved", visible: :all
-    wait_for_async_request
+    wait_for_approvables_reloaded
 
     assert_no_text "GAL 3"
   end
@@ -55,11 +55,11 @@ class CreditsAsPrerequisitesTest < ApplicationSystemTestCase
   test "student can see subjects with enough group credits" do
     visit root_path
     check "checkbox_#{@gal1.id}_course_approved", visible: :all
-    wait_for_async_request
+    wait_for_approvables_reloaded
     check "checkbox_#{@gal1.id}_exam_approved", visible: :all
-    wait_for_async_request
+    wait_for_approvables_reloaded
     check "checkbox_#{@gal2.id}_course_approved", visible: :all
-    wait_for_async_request
+    wait_for_approvables_reloaded
     check "checkbox_#{@gal2.id}_exam_approved", visible: :all
 
     assert_text "GAL 3"

--- a/test/system/dependencies_test.rb
+++ b/test/system/dependencies_test.rb
@@ -46,7 +46,7 @@ class DependenciesTest < ApplicationSystemTestCase
   test "student can disable exams from show" do
     visit subject_path(@gal1)
     check "Curso aprobado?", visible: :all
-    wait_for_async_request
+    wait_for_approvables_reloaded
 
     uncheck "Curso aprobado?", visible: :all
 
@@ -58,7 +58,7 @@ class DependenciesTest < ApplicationSystemTestCase
   test "student can disable exams from index" do
     visit root_path
     find("#checkbox_#{@gal1.id}_course_approved", visible: :all).click
-    wait_for_async_request
+    wait_for_approvables_reloaded
 
     find("#checkbox_#{@gal1.id}_course_approved", visible: :all).click
 
@@ -76,7 +76,7 @@ class DependenciesTest < ApplicationSystemTestCase
   test "student can reaveal hidden subjects from show" do
     visit subject_path(@gal1)
     check "Curso aprobado?", visible: :all
-    wait_for_async_request
+    wait_for_approvables_reloaded
 
     visit root_path
     assert_text "GAL 2"
@@ -92,11 +92,11 @@ class DependenciesTest < ApplicationSystemTestCase
   test "student can hide subjects from show" do
     visit subject_path(@gal1)
     check "Curso aprobado?", visible: :all
-    wait_for_async_request
+    wait_for_approvables_reloaded
 
     visit subject_path(@gal1)
     uncheck "Curso aprobado?", visible: :all
-    wait_for_async_request
+    wait_for_approvables_reloaded
 
     visit root_path
     assert_no_text "GAL 2"
@@ -105,7 +105,7 @@ class DependenciesTest < ApplicationSystemTestCase
   test "student can hide subjects from index" do
     visit root_path
     find("#checkbox_#{@gal1.id}_course_approved", visible: :all).click
-    wait_for_async_request
+    wait_for_approvables_reloaded
 
     find("#checkbox_#{@gal1.id}_course_approved", visible: :all).click
 

--- a/test/system/subject_without_exam_test.rb
+++ b/test/system/subject_without_exam_test.rb
@@ -10,7 +10,7 @@ class SubjectWihoutExamTest < ApplicationSystemTestCase
 
     check "Curso aprobado?", visible: :all
 
-    wait_for_async_request
+    wait_for_approvables_reloaded
 
     click_on "Student"
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -44,10 +44,8 @@ class ActiveSupport::TestCase
     User.create!(email: email, password: password, provider: provider, uid: uid)
   end
 
-  def wait_for_async_request
-    # Ideally we would really wait for the request to complete instead of
-    # sleeping a fixed amount of time
-    sleep 1
+  def wait_for_approvables_reloaded
+    assert page.has_no_selector?('.foreground-layer')
   end
 
   def within_actions_menu


### PR DESCRIPTION
Use the foreground div that blocks click to detect when the async request has finished instead of slipping for 1 second

https://trello.com/c/wMDJiHJP/172-update-waitforasyncrequest-code-to-really-wait-for-async-requests-instead-of-just-suspendind-the-thread-for-1-second