### PR TITLE
Upload system test screenshots when using Github Actions

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -40,3 +40,11 @@ jobs:
       run: |
         bundle exec rake db:create db:schema:load
         bundle exec rake
+
+    - name: Upload screenshots
+      if: failure()
+      uses: actions/upload-artifact@v3
+      with:
+        name: system_test_screenshots
+        path: ./tmp/screenshots
+        retention-days: 2


### PR DESCRIPTION
So that we can see the screenshot when system tests fail in the CI

Example: https://github.com/cedarcode/student/actions/runs/4068943193