### PR TITLE
Set cookie domain to :all to support subdomains

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -24,5 +24,7 @@ module MiCarrera
     config.action_view.field_error_proc = Proc.new { |html_tag, _instance|
       html_tag
     }
+
+    config.session_store :cookie_store, key: "_mi_carrera_session", domain: :all
   end
 end


### PR DESCRIPTION
Rails sets it by default to `app.config.session_store :cookie_store, key: "_#{app_name}_session"` [here](https://github.com/rails/rails/blob/v7.0.4.2/railties/lib/rails/application/finisher.rb#L46-L47)

so the down side is that we have to hardcode the `key`.

We need to set `domain: :all` to allow the same cookie to be shared by all subdomains.

[Docs](https://github.com/rails/rails/blob/v7.0.4.2/actionpack/lib/action_dispatch/middleware/cookies.rb#L157-L170):

```
  # * <tt>:domain</tt> - The domain for which this cookie applies so you can
  #   restrict to the domain level. If you use a schema like www.example.com
  #   and want to share session with user.example.com set <tt>:domain</tt>
  #   to <tt>:all</tt>. To support multiple domains, provide an array, and
  #   the first domain matching <tt>request.host</tt> will be used. Make
  #   sure to specify the <tt>:domain</tt> option with <tt>:all</tt> or
  #   <tt>Array</tt> again when deleting cookies.
  #
  #     domain: nil  # Does not set cookie domain. (default)
  #     domain: :all # Allow the cookie for the top most level
  #                  # domain and subdomains.
  #     domain: %w(.example.com .example.org) # Allow the cookie
  #                                           # for concrete domain names.
```
