### PR TITLE
Prevent credits text from splitting into two lines

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -50,7 +50,8 @@ body {
 }
 
 .credits-counter {
-  padding: 0 12px;
+  padding: 0 12px 0 0;
+  white-space: nowrap;
 }
 
 .handle-account {


### PR DESCRIPTION
## Screenshots

### Before

<img width="390" alt="image" src="https://user-images.githubusercontent.com/46354312/217251736-17195a6b-a81c-41a1-ba95-70f80d35214b.png">

### After

<img width="391" alt="image" src="https://user-images.githubusercontent.com/46354312/217251330-950dd57f-a334-4498-970c-3969fb6cd703.png">