### PR TITLE
Show checkmark next to met prereq

### DIFF
--- a/app/assets/stylesheets/_utility.scss
+++ b/app/assets/stylesheets/_utility.scss
@@ -1,3 +1,7 @@
 .position-relative {
   position: relative;
 }
+
+.color-green {
+  color: #19a819 !important;
+}

--- a/app/models/base_student.rb
+++ b/app/models/base_student.rb
@@ -25,6 +25,7 @@ class BaseStudent
   def total_credits = Subject.approved_credits(ids)
   def welcome_banner_viewed? = raise NotImplementedError
   def welcome_banner_mark_as_viewed! = raise NotImplementedError
+  def met?(prerequisite) = prerequisite.met?(ids)
 
   private
 

--- a/app/views/credits_prerequisites/_credits_prerequisite.html.erb
+++ b/app/views/credits_prerequisites/_credits_prerequisite.html.erb
@@ -7,4 +7,6 @@
     <%= credits_prerequisite.credits_needed %> créditos totales
   <% end %>
   </span>
+
+  <%= render 'prerequisites/met_checkmark', prerequisite: credits_prerequisite %>
 </label>

--- a/app/views/logical_prerequisites/_logical_prerequisite.html.erb
+++ b/app/views/logical_prerequisites/_logical_prerequisite.html.erb
@@ -10,6 +10,8 @@
       <% elsif logical_prerequisite.logical_operator == "not" %>
         No debe tener
       <% end %>
+
+      <%= render 'prerequisites/met_checkmark', prerequisite: logical_prerequisite %>
     </div>
   </a>
   <div class="logical-prerequisite-operands" data-prerequisite-target="collapsable" >

--- a/app/views/prerequisites/_met_checkmark.html.erb
+++ b/app/views/prerequisites/_met_checkmark.html.erb
@@ -1,0 +1,5 @@
+<% if current_student.met?(prerequisite) %>
+  <span class="mdc-deprecated-list-item__meta mdc-deprecated-list-item__graphic material-icons color-green">
+    done
+  </span>
+<% end %>

--- a/app/views/subject_prerequisites/_subject_prerequisite.html.erb
+++ b/app/views/subject_prerequisites/_subject_prerequisite.html.erb
@@ -1,4 +1,6 @@
 <%= link_to subject_path(subject_prerequisite.approvable_needed.subject), class: 'mdc-deprecated-list-item' do %>
   <span class="mdc-deprecated-list-item__ripple"></span>
   <span class="mdc-deprecated-list-item__text"><%= display_subject_prerequisite(subject_prerequisite) %> </span>
+
+  <%= render 'prerequisites/met_checkmark', prerequisite: subject_prerequisite %>
 <% end %>

--- a/test/models/session_student_test.rb
+++ b/test/models/session_student_test.rb
@@ -118,4 +118,12 @@ class SessionStudentTest < ActiveSupport::TestCase
 
     assert_equal [subject.exam.id, subject.course.id], session[:approved_approvable_ids]
   end
+
+  test "#met? returns true if prerequisite met" do
+    subject1 = create :subject, :with_exam
+    prereq = create(:subject_prerequisite, approvable: subject1.exam, approvable_needed: subject1.course)
+
+    assert_not SessionStudent.new({ approved_approvable_ids: [] }).met?(prereq)
+    assert SessionStudent.new({ approved_approvable_ids: [subject1.course.id] }).met?(prereq)
+  end
 end

--- a/test/models/user_student_test.rb
+++ b/test/models/user_student_test.rb
@@ -120,4 +120,12 @@ class UserStudentTest < ActiveSupport::TestCase
 
     assert_equal [subject.exam.id, subject.course.id], user.reload.approvals
   end
+
+  test "#met? returns true if prerequisite met" do
+    subject1 = create :subject, :with_exam
+    prereq = create(:subject_prerequisite, approvable: subject1.exam, approvable_needed: subject1.course)
+
+    assert_not UserStudent.new(create :user, approvals: []).met?(prereq)
+    assert UserStudent.new(create :user, approvals: [subject1.course.id]).met?(prereq)
+  end
 end


### PR DESCRIPTION
https://trello.com/c/qgNhcOCD/91-add-visual-cue-when-displaying-a-subjects-prerequisite-to-show-which-ones-are-already-met

![image](https://user-images.githubusercontent.com/972779/218198196-f9808693-da29-42b0-8a33-cbabe53cfccd.png)
