### PR TITLE
Fix missing `activerecord.error.messages.record_invalid` translation

### DIFF
--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -1,4 +1,8 @@
 es:
+  activerecord:
+    errors:
+      messages:
+        record_invalid: 'La validación falló: %{errors}'
   errors:
     format: "%{attribute} %{message}"
     messages:


### PR DESCRIPTION
## Why

It was causing an error when a validation fail thus we weren't able to see what validation was failing on which model.