### PR TITLE
Process prerequisites in scraper using multiple threads

### DIFF
--- a/app/services/scraper/bedelias.rb
+++ b/app/services/scraper/bedelias.rb
@@ -102,8 +102,6 @@ module Scraper::Bedelias
     go_to_prerequisites_page
 
     slice.flat_map do |page|
-      Rails.logger.info "Page #{page}"
-
       go_to_page(page, total_pages)
 
       # Need to iterate over row ids (data-ri) rather than the row nodes


### PR DESCRIPTION
By default uses 6 threads, but can be changed with the `THREADS` env var.

Without parallelization the scraper took around 7min. I tried with different threads configuration:

- 3 threads: 3:11
- 5 threads: 2:21
- 6 threads: 2:00
- 8 threads: 1:55