### PR TITLE
Update rubocop monthly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,14 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    ignore:
+      - dependency-name: "rubocop-rails"
+      - dependency-name: "rubocop"
+
+  - package-ecosystem: "bundler"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    allow:
+      - dependency-name: "rubocop-rails"
+      - dependency-name: "rubocop"


### PR DESCRIPTION
Feels like they release new versions too often.
I don't think we need to keep up to date that frequently