### PR TITLE
feature: change account circle when user signs in

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -197,3 +197,11 @@ body {
   padding-top: 10px;
   padding-bottom: 10px;
 }
+
+.logged-in-account-circle {
+  border-radius: 50%;
+  background-color: cadetblue;
+  line-height: 24px;
+  font-size: 15px;
+  font-family: Roboto;
+}

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -51,8 +51,14 @@
             </span>
             <%= yield :credits %>
             <div class="mdc-menu-surface--anchor" data-controller='user-menu'>
-              <button class="material-icons mdc-top-app-bar__action-item mdc-icon-button" data-user-menu-target='trigger' data-action='user-menu#open'>
-                account_circle
+              <button id="user-menu" class="material-icons mdc-top-app-bar__action-item mdc-icon-button" data-user-menu-target='trigger' data-action='user-menu#open'>
+                <% if current_user %>
+                  <div class='logged-in-account-circle'>
+                    <%= current_user.email.first.capitalize %>
+                  </div>
+                <% else %>
+                  account_circle
+                <% end %>
               </button>
               <%= render 'shared/user_menu' %>
             </div>

--- a/test/application_system_test_case.rb
+++ b/test/application_system_test_case.rb
@@ -18,6 +18,6 @@ class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
   end
 
   def click_user_menu
-    find(".mdc-icon-button[data-controller-connected='true']", text: 'account_circle').click
+    find("#user-menu[data-controller-connected='true']").click
   end
 end


### PR DESCRIPTION
## Description

This PR is a follow-up to #300. It changes the user menu link to be a letter with users's first letter of their email.

## Motivation and context

Make it clear to the user whether they have already signed in or not.

## Screenshots

### Before

<img width="1440" alt="image" src="https://github.com/cedarcode/mi_carrera/assets/46354312/95ce42b0-05c1-4a35-8042-fe901513b82b">

### After

<img width="1440" alt="image" src="https://github.com/cedarcode/mi_carrera/assets/46354312/5b2d7694-36a0-4084-a7c0-4c663c49c4d5">

## Future work

In the near future we want to sue users' Google profile pic instead of a letter if they have signed in using Google SSO.