### PR TITLE
Run dependabot weekly for all dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,15 +3,4 @@ updates:
   - package-ecosystem: "bundler"
     directory: "/"
     schedule:
-      interval: "daily"
-    ignore:
-      - dependency-name: "rubocop-rails"
-      - dependency-name: "rubocop"
-
-  - package-ecosystem: "bundler"
-    directory: "/"
-    schedule:
-      interval: "monthly"
-    allow:
-      - dependency-name: "rubocop-rails"
-      - dependency-name: "rubocop"
+      interval: "weekly"


### PR DESCRIPTION
They don't support having different schedules for the same package-ecosystem

We were getting this error:

```
Dependabot encountered the following error when parsing your .github/dependabot.yml:
The property '#/updates/1' is a duplicate. Update configs must have a unique combination of 'package-ecosystem', 'directory', and 'target-branch'
```