### PR TITLE
Remove webdrivers

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -35,5 +35,4 @@ end
 group :test do
   gem 'capybara', '~> 3.39'
   gem 'selenium-webdriver', '~> 4.10'
-  gem "webdrivers", '~> 5.2'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -287,10 +287,6 @@ GEM
       activemodel (>= 6.0.0)
       bindex (>= 0.4.0)
       railties (>= 6.0.0)
-    webdrivers (5.2.0)
-      nokogiri (~> 1.6)
-      rubyzip (>= 1.3.0)
-      selenium-webdriver (~> 4.0)
     websocket (1.2.9)
     websocket-driver (0.7.5)
       websocket-extensions (>= 0.1.0)
@@ -326,7 +322,6 @@ DEPENDENCIES
   stimulus-rails (~> 1.2)
   turbo-rails (~> 1.4)
   web-console (~> 4.0)
-  webdrivers (~> 5.2)
 
 RUBY VERSION
    ruby 3.2.2p53


### PR DESCRIPTION
Looks like this gem is not needed anymore, and was causing issues trying to find chromedriver 115

> With Google's new Chrome for Testing project, and Selenium's new Selenium Manager feature, what is required of this gem has changed..

> If you can update to to the latest version of Selenium, please do so and stop requiring this gem. Selenium 4.10 will work for Chrome v115 (ignore the warning), and Selenium 4.11 will work for everything going forward. Please provide feedback or raise issues with Selenium Project

Caused this error in system tests:

```
/home/runner/work/mi_carrera/mi_carrera/vendor/bundle/ruby/3.2.0/gems/webdrivers-5.2.0/lib/webdrivers/chromedriver.rb:83:in `rescue in latest_point_release': Unable to find latest point release version for 115.0.5790. You appear to be using a non-production version of Chrome. Please set `Webdrivers::Chromedriver.required_version = <desired driver version>` to a known chromedriver version: https://chromedriver.storage.googleapis.com/index.html (Webdrivers::VersionError)
	from /home/runner/work/mi_carrera/mi_carrera/vendor/bundle/ruby/3.2.0/gems/webdrivers-5.2.0/lib/webdrivers/chromedriver.rb:65:in `latest_point_release'
	from /home/runner/work/mi_carrera/mi_carrera/vendor/bundle/ruby/3.2.0/gems/webdrivers-5.2.0/lib/webdrivers/chromedriver.rb:39:in `block in latest_version'
	from /home/runner/work/mi_carrera/mi_carrera/vendor/bundle/ruby/3.2.0/gems/webdrivers-5.2.0/lib/webdrivers/common.rb:166:in `with_cache'
	from /home/runner/work/mi_carrera/mi_carrera/vendor/bundle/ruby/3.2.0/gems/webdrivers-5.2.0/lib/webdrivers/chromedriver.rb:37:in `latest_version'
	from /home/runner/work/mi_carrera/mi_carrera/vendor/bundle/ruby/3.2.0/gems/webdrivers-5.2.0/lib/webdrivers/common.rb:122:in `download_version'
	from /home/runner/work/mi_carrera/mi_carrera/vendor/bundle/ruby/3.2.0/gems/webdrivers-5.2.0/lib/webdrivers/common.rb:126:in `download_url'
	from /home/runner/work/mi_carrera/mi_carrera/vendor/bundle/ruby/3.2.0/gems/webdrivers-5.2.0/lib/webdrivers/common.rb:98:in `update'
	from /home/runner/work/mi_carrera/mi_carrera/vendor/bundle/ruby/3.2.0/gems/webdrivers-5.2.0/lib/webdrivers/chromedriver.rb:156:in `block in <main>'
	from /home/runner/work/mi_carrera/mi_carrera/vendor/bundle/ruby/3.2.0/gems/actionpack-7.0.6/lib/action_dispatch/system_testing/browser.rb:36:in `preload'
	from /home/runner/work/mi_carrera/mi_carrera/vendor/bundle/ruby/3.2.0/gems/actionpack-7.0.6/lib/action_dispatch/system_testing/driver.rb:27:in `initialize'
	from /home/runner/work/mi_carrera/mi_carrera/vendor/bundle/ruby/3.2.0/gems/actionpack-7.0.6/lib/action_dispatch/system_test_case.rb:159:in `new'
	from /home/runner/work/mi_carrera/mi_carrera/vendor/bundle/ruby/3.2.0/gems/actionpack-7.0.6/lib/action_dispatch/system_test_case.rb:159:in `driven_by'
	from /home/runner/work/mi_carrera/mi_carrera/test/application_system_test_case.rb:4:in `<class:ApplicationSystemTestCase>'
	from /home/runner/work/mi_carrera/mi_carrera/test/application_system_test_case.rb:3:in `<main>'
	from /home/runner/work/mi_carrera/mi_carrera/vendor/bundle/ruby/3.2.0/gems/bootsnap-1.16.0/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:[32](https://github.com/cedarcode/mi_carrera/actions/runs/5710537930/job/15470849333?pr=310#step:5:33):in `require'
	from /home/runner/work/mi_carrera/mi_carrera/vendor/bundle/ruby/3.2.0/gems/bootsnap-1.16.0/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:32:in `require'
	from /home/runner/work/mi_carrera/mi_carrera/test/system/approvals_test.rb:1:in `<main>'
	from /home/runner/work/mi_carrera/mi_carrera/vendor/bundle/ruby/3.2.0/gems/bootsnap-1.16.0/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:32:in `require'
	from /home/runner/work/mi_carrera/mi_carrera/vendor/bundle/ruby/3.2.0/gems/bootsnap-1.16.0/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:32:in `require'
	from /home/runner/work/mi_carrera/mi_carrera/vendor/bundle/ruby/3.2.0/gems/railties-7.0.6/lib/rails/test_unit/runner.rb:47:in `block in load_tests'
	from /home/runner/work/mi_carrera/mi_carrera/vendor/bundle/ruby/3.2.0/gems/railties-7.0.6/lib/rails/test_unit/runner.rb:47:in `each'
	from /home/runner/work/mi_carrera/mi_carrera/vendor/bundle/ruby/3.2.0/gems/railties-7.0.6/lib/rails/test_unit/runner.rb:47:in `load_tests'
	from /home/runner/work/mi_carrera/mi_carrera/vendor/bundle/ruby/3.2.0/gems/railties-7.0.6/lib/rails/test_unit/runner.rb:40:in `run'
	from /home/runner/work/mi_carrera/mi_carrera/vendor/bundle/ruby/3.2.0/gems/railties-7.0.6/lib/rails/commands/test/test_command.rb:[33](https://github.com/cedarcode/mi_carrera/actions/runs/5710537930/job/15470849333?pr=310#step:5:34):in `perform'
	from /home/runner/work/mi_carrera/mi_carrera/vendor/bundle/ruby/3.2.0/gems/thor-1.2.2/lib/thor/command.rb:27:in `run'
	from /home/runner/work/mi_carrera/mi_carrera/vendor/bundle/ruby/3.2.0/gems/thor-1.2.2/lib/thor/invocation.rb:127:in `invoke_command'
	from /home/runner/work/mi_carrera/mi_carrera/vendor/bundle/ruby/3.2.0/gems/thor-1.2.2/lib/thor.rb:[39](https://github.com/cedarcode/mi_carrera/actions/runs/5710537930/job/15470849333?pr=310#step:5:40)2:in `dispatch'
	from /home/runner/work/mi_carrera/mi_carrera/vendor/bundle/ruby/3.2.0/gems/railties-7.0.6/lib/rails/command/base.rb:87:in `perform'
	from /home/runner/work/mi_carrera/mi_carrera/vendor/bundle/ruby/3.2.0/gems/railties-7.0.6/lib/rails/command.rb:48:in `invoke'
	from /home/runner/work/mi_carrera/mi_carrera/vendor/bundle/ruby/3.2.0/gems/railties-7.0.6/lib/rails/commands.rb:18:in `<main>'
	from /home/runner/work/mi_carrera/mi_carrera/vendor/bundle/ruby/3.2.0/gems/bootsnap-1.16.0/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:32:in `require'
	from /home/runner/work/mi_carrera/mi_carrera/vendor/bundle/ruby/3.2.0/gems/bootsnap-1.16.0/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:32:in `require'
	from bin/rails:4:in `<main>'
```