### PR TITLE
Fix deprecation warning

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,7 +3,7 @@ class User < ApplicationRecord
          :recoverable, :rememberable, :validatable,
          :omniauthable, omniauth_providers: [:google_oauth2]
 
-  serialize :approvals, Array
+  serialize :approvals, type: Array
 
   def self.from_omniauth(auth, cookie)
     # check that user with same email exists


### PR DESCRIPTION
DEPRECATION WARNING: Passing the class as positional argument is deprecated and will be removed in Rails 7.2.

Please pass the class as a keyword argument:

  serialize :approvals, type: Array
 (called from <class:User> at ~/mi_carrera/app/models/user.rb:6)