### PR TITLE
Update `staging_deploy` Github action name

### DIFF
--- a/.github/workflows/staging_deploy.yml
+++ b/.github/workflows/staging_deploy.yml
@@ -1,4 +1,4 @@
-name: cd
+name: Staging Deploy
 
 on:
   push:
@@ -12,7 +12,7 @@ on:
         default: "master"
 
 jobs:
-  staging_deploy:
+  deploy:
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
Make the name a little bit more descriptive of what it actually does. 

Currently we have:

<img width="328" alt="image" src="https://github.com/cedarcode/mi_carrera/assets/46354312/068418fa-f716-4817-9426-cff9e4fc3aa2">

Which doesn't really tell if the CD is for `production` or `staging`.