### PR TITLE
Add concurrency key to prevent concurrent deploys

### DIFF
--- a/.github/workflows/staging_deploy.yml
+++ b/.github/workflows/staging_deploy.yml
@@ -1,5 +1,8 @@
 name: Staging Deploy
 
+concurrency:
+  group: ${{ github.workflow }}
+
 on:
   push:
     branches:


### PR DESCRIPTION
https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#concurrency