### PR TITLE
[Scraper] Support scrapping exam enrollment prerequisites

### DIFF
--- a/app/services/yml_loader.rb
+++ b/app/services/yml_loader.rb
@@ -86,7 +86,8 @@ module YmlLoader
       when 'exam' then SubjectPrerequisite.new(approvable_needed: subject.exam)
       when 'course' then SubjectPrerequisite.new(approvable_needed: subject.course)
       when 'all' then SubjectPrerequisite.new(approvable_needed: subject.exam || subject.course)
-      when 'enrollment' then EnrollmentPrerequisite.new(approvable_needed: subject.course)
+      when 'course_enrollment' then EnrollmentPrerequisite.new(approvable_needed: subject.course)
+      when 'exam_enrollment' then EnrollmentPrerequisite.new(approvable_needed: subject.exam)
       else raise "Unknown approvable needed: #{prerequisite["needs"]}"
       end
 

--- a/db/data/scraped_prerequisites.yml
+++ b/db/data/scraped_prerequisites.yml
@@ -1038,7 +1038,7 @@
     logical_operator: not
     operands:
     - type: subject
-      needs: enrollment
+      needs: course_enrollment
       subject_needed_code: '1445'
       subject_needed_name: TALLER DE ARQUITECTURA DE COMPUTADORAS
   - type: logical
@@ -1437,7 +1437,7 @@
       logical_operator: not
       operands:
       - type: subject
-        needs: enrollment
+        needs: course_enrollment
         subject_needed_code: MI2
         subject_needed_name: MATEMATICA INICIAL
     - type: subject
@@ -1547,7 +1547,7 @@
     logical_operator: not
     operands:
     - type: subject
-      needs: enrollment
+      needs: course_enrollment
       subject_needed_code: MI2
       subject_needed_name: MATEMATICA INICIAL
   - type: logical
@@ -6596,85 +6596,95 @@
     logical_operator: not
     operands:
     - type: subject
-      needs: enrollment
+      needs: course_enrollment
       subject_needed_code: GAL1P
       subject_needed_name: GEOMETRIA Y ALGEBRA LINEAL 1 INTERACTIVA
   subject_code: '1030'
   is_exam: false
 - type: logical
-  logical_operator: not
+  logical_operator: and
   operands:
   - type: logical
-    logical_operator: or
+    logical_operator: not
     operands:
     - type: subject
-      subject_needed_code: CM14
-      subject_needed_name: CREDITOS ASIGNADOS POR REVALIDA
-      needs: all
-    - type: subject
-      subject_needed_code: GAL7
-      subject_needed_name: CREDITOS ASIGNADOS POR REVALIDA
-      needs: all
-    - type: subject
-      subject_needed_code: MAT33
-      subject_needed_name: CREDITOS ASIGNADOS POR REVALIDA
-      needs: all
-    - type: subject
-      subject_needed_code: MA51
-      subject_needed_name: CREDITOS ASIGNADOS POR REVALIDA
-      needs: all
-    - type: subject
-      subject_needed_code: MA7
-      subject_needed_name: CREDITOS ASIGNADOS POR REVALIDA
-      needs: all
-    - type: subject
-      subject_needed_code: MC3
-      subject_needed_name: CREDITOS ASIGNADOS POR REVALIDA
-      needs: all
-    - type: subject
-      subject_needed_code: M24
-      subject_needed_name: CREDITOS ASIGNADOS POR REVALIDA
-      needs: all
-    - type: subject
-      subject_needed_code: M9
-      subject_needed_name: CREDITOS ASIGNADOS POR REVALIDA
-      needs: all
-    - type: subject
-      subject_needed_code: 1030P
-      subject_needed_name: CREDITOS NO ACUM GAL1
-      needs: all
-    - type: subject
-      subject_needed_code: CP2
-      subject_needed_name: GEOMETRIA Y ALGEBRA LINEAL
-      needs: all
-    - type: subject
-      subject_needed_code: CP23
-      subject_needed_name: GEOMETRIA Y ALGEBRA LINEAL (P. 74)
-      needs: all
-    - type: subject
-      subject_needed_code: CP46
-      subject_needed_name: GEOMETRIA Y ALGEBRA LINEAL (1ER.SEM.)
-      needs: all
-    - type: subject
-      subject_needed_code: '1071'
-      subject_needed_name: GEOMETRIA Y ALGEBRA LINEAL 1
-      needs: all
-    - type: subject
-      subject_needed_code: 171L
-      subject_needed_name: GEOMETRIA Y ALGEBRA LINEAL 1
-      needs: all
-    - type: subject
-      subject_needed_code: 171Q
-      subject_needed_name: GEOMETRIA Y ALGEBRA LINEAL 1
-      needs: all
-    - type: subject
-      subject_needed_code: '1053'
-      subject_needed_name: GEOMETRIA Y ALGEBRA LINEAL 1 (ANUAL)
-      needs: all
-    - type: subject
+      needs: exam_enrollment
       subject_needed_code: GAL1P
       subject_needed_name: GEOMETRIA Y ALGEBRA LINEAL 1 INTERACTIVA
-      needs: all
+  - type: logical
+    logical_operator: not
+    operands:
+    - type: logical
+      logical_operator: or
+      operands:
+      - type: subject
+        subject_needed_code: CM14
+        subject_needed_name: CREDITOS ASIGNADOS POR REVALIDA
+        needs: exam
+      - type: subject
+        subject_needed_code: GAL7
+        subject_needed_name: CREDITOS ASIGNADOS POR REVALIDA
+        needs: exam
+      - type: subject
+        subject_needed_code: MAT33
+        subject_needed_name: CREDITOS ASIGNADOS POR REVALIDA
+        needs: exam
+      - type: subject
+        subject_needed_code: MA51
+        subject_needed_name: CREDITOS ASIGNADOS POR REVALIDA
+        needs: exam
+      - type: subject
+        subject_needed_code: MA7
+        subject_needed_name: CREDITOS ASIGNADOS POR REVALIDA
+        needs: exam
+      - type: subject
+        subject_needed_code: MC3
+        subject_needed_name: CREDITOS ASIGNADOS POR REVALIDA
+        needs: exam
+      - type: subject
+        subject_needed_code: M24
+        subject_needed_name: CREDITOS ASIGNADOS POR REVALIDA
+        needs: exam
+      - type: subject
+        subject_needed_code: M9
+        subject_needed_name: CREDITOS ASIGNADOS POR REVALIDA
+        needs: exam
+      - type: subject
+        subject_needed_code: 1030P
+        subject_needed_name: CREDITOS NO ACUM GAL1
+        needs: exam
+      - type: subject
+        subject_needed_code: CP2
+        subject_needed_name: GEOMETRIA Y ALGEBRA LINEAL
+        needs: exam
+      - type: subject
+        subject_needed_code: CP23
+        subject_needed_name: GEOMETRIA Y ALGEBRA LINEAL (P. 74)
+        needs: exam
+      - type: subject
+        subject_needed_code: CP46
+        subject_needed_name: GEOMETRIA Y ALGEBRA LINEAL (1ER.SEM.)
+        needs: exam
+      - type: subject
+        subject_needed_code: '1071'
+        subject_needed_name: GEOMETRIA Y ALGEBRA LINEAL 1
+        needs: exam
+      - type: subject
+        subject_needed_code: 171L
+        subject_needed_name: GEOMETRIA Y ALGEBRA LINEAL 1
+        needs: exam
+      - type: subject
+        subject_needed_code: 171Q
+        subject_needed_name: GEOMETRIA Y ALGEBRA LINEAL 1
+        needs: exam
+      - type: subject
+        subject_needed_code: '1053'
+        subject_needed_name: GEOMETRIA Y ALGEBRA LINEAL 1 (ANUAL)
+        needs: exam
+      - type: subject
+        subject_needed_code: GAL1P
+        subject_needed_name: GEOMETRIA Y ALGEBRA LINEAL 1 INTERACTIVA
+        needs: exam
   subject_code: '1030'
   is_exam: true
 - type: logical
@@ -6898,85 +6908,95 @@
     logical_operator: not
     operands:
     - type: subject
-      needs: enrollment
+      needs: course_enrollment
       subject_needed_code: '1030'
       subject_needed_name: GEOMETRIA Y ALGEBRA LINEAL 1
   subject_code: GAL1P
   is_exam: false
 - type: logical
-  logical_operator: not
+  logical_operator: and
   operands:
   - type: logical
-    logical_operator: or
+    logical_operator: not
+    operands:
+    - type: logical
+      logical_operator: or
+      operands:
+      - type: subject
+        subject_needed_code: CM14
+        subject_needed_name: CREDITOS ASIGNADOS POR REVALIDA
+        needs: exam
+      - type: subject
+        subject_needed_code: GAL7
+        subject_needed_name: CREDITOS ASIGNADOS POR REVALIDA
+        needs: exam
+      - type: subject
+        subject_needed_code: MAT33
+        subject_needed_name: CREDITOS ASIGNADOS POR REVALIDA
+        needs: exam
+      - type: subject
+        subject_needed_code: MA51
+        subject_needed_name: CREDITOS ASIGNADOS POR REVALIDA
+        needs: exam
+      - type: subject
+        subject_needed_code: MA7
+        subject_needed_name: CREDITOS ASIGNADOS POR REVALIDA
+        needs: exam
+      - type: subject
+        subject_needed_code: MC3
+        subject_needed_name: CREDITOS ASIGNADOS POR REVALIDA
+        needs: exam
+      - type: subject
+        subject_needed_code: M24
+        subject_needed_name: CREDITOS ASIGNADOS POR REVALIDA
+        needs: exam
+      - type: subject
+        subject_needed_code: M9
+        subject_needed_name: CREDITOS ASIGNADOS POR REVALIDA
+        needs: exam
+      - type: subject
+        subject_needed_code: 1030P
+        subject_needed_name: CREDITOS NO ACUM GAL1
+        needs: exam
+      - type: subject
+        subject_needed_code: CP2
+        subject_needed_name: GEOMETRIA Y ALGEBRA LINEAL
+        needs: exam
+      - type: subject
+        subject_needed_code: CP23
+        subject_needed_name: GEOMETRIA Y ALGEBRA LINEAL (P. 74)
+        needs: exam
+      - type: subject
+        subject_needed_code: CP46
+        subject_needed_name: GEOMETRIA Y ALGEBRA LINEAL (1ER.SEM.)
+        needs: exam
+      - type: subject
+        subject_needed_code: '1030'
+        subject_needed_name: GEOMETRIA Y ALGEBRA LINEAL 1
+        needs: exam
+      - type: subject
+        subject_needed_code: '1071'
+        subject_needed_name: GEOMETRIA Y ALGEBRA LINEAL 1
+        needs: exam
+      - type: subject
+        subject_needed_code: 171L
+        subject_needed_name: GEOMETRIA Y ALGEBRA LINEAL 1
+        needs: exam
+      - type: subject
+        subject_needed_code: 171Q
+        subject_needed_name: GEOMETRIA Y ALGEBRA LINEAL 1
+        needs: exam
+      - type: subject
+        subject_needed_code: '1053'
+        subject_needed_name: GEOMETRIA Y ALGEBRA LINEAL 1 (ANUAL)
+        needs: exam
+  - type: logical
+    logical_operator: not
     operands:
     - type: subject
-      subject_needed_code: CM14
-      subject_needed_name: CREDITOS ASIGNADOS POR REVALIDA
-      needs: all
-    - type: subject
-      subject_needed_code: GAL7
-      subject_needed_name: CREDITOS ASIGNADOS POR REVALIDA
-      needs: all
-    - type: subject
-      subject_needed_code: MAT33
-      subject_needed_name: CREDITOS ASIGNADOS POR REVALIDA
-      needs: all
-    - type: subject
-      subject_needed_code: MA51
-      subject_needed_name: CREDITOS ASIGNADOS POR REVALIDA
-      needs: all
-    - type: subject
-      subject_needed_code: MA7
-      subject_needed_name: CREDITOS ASIGNADOS POR REVALIDA
-      needs: all
-    - type: subject
-      subject_needed_code: MC3
-      subject_needed_name: CREDITOS ASIGNADOS POR REVALIDA
-      needs: all
-    - type: subject
-      subject_needed_code: M24
-      subject_needed_name: CREDITOS ASIGNADOS POR REVALIDA
-      needs: all
-    - type: subject
-      subject_needed_code: M9
-      subject_needed_name: CREDITOS ASIGNADOS POR REVALIDA
-      needs: all
-    - type: subject
-      subject_needed_code: 1030P
-      subject_needed_name: CREDITOS NO ACUM GAL1
-      needs: all
-    - type: subject
-      subject_needed_code: CP2
-      subject_needed_name: GEOMETRIA Y ALGEBRA LINEAL
-      needs: all
-    - type: subject
-      subject_needed_code: CP23
-      subject_needed_name: GEOMETRIA Y ALGEBRA LINEAL (P. 74)
-      needs: all
-    - type: subject
-      subject_needed_code: CP46
-      subject_needed_name: GEOMETRIA Y ALGEBRA LINEAL (1ER.SEM.)
-      needs: all
-    - type: subject
+      needs: exam_enrollment
       subject_needed_code: '1030'
       subject_needed_name: GEOMETRIA Y ALGEBRA LINEAL 1
-      needs: all
-    - type: subject
-      subject_needed_code: '1071'
-      subject_needed_name: GEOMETRIA Y ALGEBRA LINEAL 1
-      needs: all
-    - type: subject
-      subject_needed_code: 171L
-      subject_needed_name: GEOMETRIA Y ALGEBRA LINEAL 1
-      needs: all
-    - type: subject
-      subject_needed_code: 171Q
-      subject_needed_name: GEOMETRIA Y ALGEBRA LINEAL 1
-      needs: all
-    - type: subject
-      subject_needed_code: '1053'
-      subject_needed_name: GEOMETRIA Y ALGEBRA LINEAL 1 (ANUAL)
-      needs: all
   subject_code: GAL1P
   is_exam: true
 - type: logical
@@ -10114,7 +10134,7 @@
     logical_operator: not
     operands:
     - type: subject
-      needs: enrollment
+      needs: course_enrollment
       subject_needed_code: '1013'
       subject_needed_name: LOGICA MODALIDAD AL REVES
   - type: logical
@@ -10194,7 +10214,7 @@
     logical_operator: not
     operands:
     - type: subject
-      needs: enrollment
+      needs: course_enrollment
       subject_needed_code: '1027'
       subject_needed_name: LOGICA
   - type: subject
@@ -14904,7 +14924,7 @@
     logical_operator: not
     operands:
     - type: subject
-      needs: enrollment
+      needs: course_enrollment
       subject_needed_code: '1444'
       subject_needed_name: ASPECTOS AVANZ. DE ARQ.DE COMPUTADORAS
   - type: logical

--- a/lib/scraper/prerequisites_tree_page.rb
+++ b/lib/scraper/prerequisites_tree_page.rb
@@ -40,7 +40,9 @@ module Scraper
       # Examen aprobado de la U.C.B: CENURLN - SRN03 - ALGEBRA LINEAL I
       when 'Examen aprobado de la U.C.B:' then subject_prerequisite(content, 'exam')
       # Inscripción a Curso de la U.C.B: 1445 - TALLER DE ARQUITECTURA DE COMPUTADORAS
-      when 'Inscripción a Curso de la U.C.B:' then subject_prerequisite(content, 'enrollment')
+      when 'Inscripción a Curso de la U.C.B:' then subject_prerequisite(content, 'course_enrollment')
+      # Inscripción a Examen de la U.C.B: GAL1P - GEOMETRIA Y ALGEBRA LINEAL 1 INTERACTIVA
+      when 'Inscripción a Examen de la U.C.B:' then subject_prerequisite(content, 'exam_enrollment')
       # U.C.B Aprobada: 1424 - ARQUITECTURA DE COMPUTADORES 1
       when 'U.C.B Aprobada:' then subject_prerequisite(content, 'all')
       else raise "Unknown node title: #{title}"


### PR DESCRIPTION
## Summary

A new type of prerequisite was added in `Bedelia` that represents an enrollment to an exam – similar to the already existent course enrollment that we have. In `Bedelia` it's shown as `Inscripción a Examen de la U.C.B:`.

For example, here it is a screenshot of an exam enrollment prerequisite of the approvable `Examen de la U.C.B. - FING - 1030 - GEOMETRIA Y ALGEBRA LINEAL 1`:

![image](https://github.com/cedarcode/mi_carrera/assets/46354312/6e05ac08-abfd-413b-9a7b-d615afa2b2f1)

In order to fix it, we just have to discern between course and exam enrollments in `Bedelia` and store it in the `yaml` accordingly. Then, we also have to update the `YamlLoader` so that it correctly stores them in the database.