### PR TITLE
Add GitHub action for running scraper

### DIFF
--- a/.github/workflows/scraper.yml
+++ b/.github/workflows/scraper.yml
@@ -1,0 +1,25 @@
+name: Scraper
+on:
+  push:
+    branches:
+      - 'scraper'
+jobs:
+  scrape:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - uses: ruby/setup-ruby@v1
+      with:
+        bundler-cache: true
+    - name: Run scraper
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        bundle exec rake scraper
+        git add db/data
+        git commit -m 'chore: update scraped subjects data'
+        git push -f origin HEAD:scraper
+        gh pr create \
+            --title "Update scraped subjects data" \
+            --body "This PR runs `rails scraper` to update scraped subjects' data" \
+            --head scraper

--- a/.github/workflows/scraper.yml
+++ b/.github/workflows/scraper.yml
@@ -1,8 +1,7 @@
 name: Scraper
 on:
-  push:
-    branches:
-      - 'scraper'
+  schedule:
+    - cron:  '0 11 * * MON'
 jobs:
   scrape:
     runs-on: ubuntu-latest

--- a/.github/workflows/scraper.yml
+++ b/.github/workflows/scraper.yml
@@ -16,6 +16,7 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
         bundle exec rake scraper
+        sed -i -e 's/ $//' db/data/*.yml
         git add db/data
         git commit -m 'chore: update scraped subjects data'
         git push -f origin HEAD:scraper

--- a/.github/workflows/scraper.yml
+++ b/.github/workflows/scraper.yml
@@ -22,10 +22,15 @@ jobs:
         then
             git commit -m 'chore: update scraped subjects data'
             git push -f origin HEAD:scraper
-            gh pr create \
-                --title "Update scraped subjects data" \
-                --body "This PR runs `rails scraper` to update scraped subjects' data" \
-                --head scraper
+            if ! gh pr view scraper > /dev/null;
+            then
+                gh pr create \
+                    --title "Update scraped subjects data" \
+                    --body "This PR runs `rails scraper` to update scraped subjects' data" \
+                    --head scraper
+            else
+                echo "A PR already exists and was correctly updated."
+            fi
         else
             echo "There were no changes. Nothing to do."
         fi

--- a/.github/workflows/scraper.yml
+++ b/.github/workflows/scraper.yml
@@ -18,9 +18,14 @@ jobs:
         bundle exec rake scraper
         sed -i -e 's/ $//' db/data/*.yml
         git add db/data
-        git commit -m 'chore: update scraped subjects data'
-        git push -f origin HEAD:scraper
-        gh pr create \
-            --title "Update scraped subjects data" \
-            --body "This PR runs `rails scraper` to update scraped subjects' data" \
-            --head scraper
+        if ! git diff --cached --quiet;
+        then
+            git commit -m 'chore: update scraped subjects data'
+            git push -f origin HEAD:scraper
+            gh pr create \
+                --title "Update scraped subjects data" \
+                --body "This PR runs `rails scraper` to update scraped subjects' data" \
+                --head scraper
+        else
+            echo "There were no changes. Nothing to do."
+        fi

--- a/.github/workflows/scraper.yml
+++ b/.github/workflows/scraper.yml
@@ -2,6 +2,7 @@ name: Scraper
 on:
   schedule:
     - cron:  '0 11 * * MON'
+  workflow_dispatch:
 jobs:
   scrape:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

This PR adds a GitHub action for automatically running the scraper. This action can be manually triggered or else it will run automatically every Monday at 11:00AM UTC. If there are no changes after running the scraper it display a `There were no changes. Nothing to do.` message. Otherwise, if there are changes after running the scraper, it will checkout a new `scraper` branch and open a PR. If a PR is already open it will just force push the already open branch.