### PR TITLE
Track group credits

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -205,3 +205,11 @@ body {
   font-size: 15px;
   font-family: Roboto;
 }
+
+.subject-group-credits-met {
+  color: green !important;
+}
+
+.subject-group-credits-unmet {
+  color: red !important;
+}

--- a/app/controllers/approvals_controller.rb
+++ b/app/controllers/approvals_controller.rb
@@ -6,9 +6,7 @@ class ApprovalsController < ApplicationController
 
     current_student.add(@approvable)
 
-    group_credits_met = SubjectGroup.all.all? { |group| current_student.group_credits_met?(group) }
-
-    @graduated = current_student.total_credits >= 450 && previous_total_credits < 450 && group_credits_met
+    @graduated = current_student.total_credits >= 450 && previous_total_credits < 450 && groups_credits_met?
 
     render_turbo_stream
   end

--- a/app/controllers/approvals_controller.rb
+++ b/app/controllers/approvals_controller.rb
@@ -2,11 +2,11 @@ class ApprovalsController < ApplicationController
   before_action :set_approvable
 
   def create
-    previous_total_credits = current_student.total_credits
+    previously_graduated = current_student.graduated?
 
     current_student.add(@approvable)
 
-    @graduated = current_student.total_credits >= 450 && previous_total_credits < 450 && groups_credits_met?
+    @graduated = current_student.graduated? && !previously_graduated
 
     render_turbo_stream
   end

--- a/app/controllers/approvals_controller.rb
+++ b/app/controllers/approvals_controller.rb
@@ -6,7 +6,9 @@ class ApprovalsController < ApplicationController
 
     current_student.add(@approvable)
 
-    @graduated = current_student.total_credits >= 450 && previous_total_credits < 450
+    group_credits_met = SubjectGroup.all.all? { |group| current_student.group_credits_met?(group) }
+
+    @graduated = current_student.total_credits >= 450 && previous_total_credits < 450 && group_credits_met
 
     render_turbo_stream
   end

--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -9,8 +9,8 @@ class ProfilesController < ApplicationController
       }
     end
 
-    @groups_credits_met = @groups_and_credits.all? { |group_and_credits| group_and_credits[:credits_needed_reached] }
-    @total_credits = @groups_and_credits.pluck(:credits).reduce :+
+    @all_group_credits_met = @groups_and_credits.all? { |group_and_credits| group_and_credits[:credits_needed_reached] }
+    @total_credits = @groups_and_credits.pluck(:credits).sum
 
     respond_to do |format|
       format.html

--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -1,8 +1,16 @@
 class ProfilesController < ApplicationController
   def show
     @groups_and_credits = SubjectGroup.find_each.map do |subject_group|
-      { subject_group:, credits: current_student.group_credits(subject_group) }
+      credits = current_student.group_credits(subject_group)
+      {
+        subject_group:,
+        credits:,
+        credits_needed_reached: credits >= subject_group.credits_needed,
+      }
     end
+
+    @groups_credits_met = @groups_and_credits.all? { |group_and_credits| group_and_credits[:credits_needed_reached] }
+    @total_credits = @groups_and_credits.pluck(:credits).reduce :+
 
     respond_to do |format|
       format.html

--- a/app/helpers/profile_helper.rb
+++ b/app/helpers/profile_helper.rb
@@ -1,0 +1,5 @@
+module ProfileHelper
+  def group_credits_class(met)
+    "subject-group-credits-#{met ? "met" : "unmet"}"
+  end
+end

--- a/app/models/base_student.rb
+++ b/app/models/base_student.rb
@@ -26,6 +26,7 @@ class BaseStudent
   def welcome_banner_viewed? = raise NotImplementedError
   def welcome_banner_mark_as_viewed! = raise NotImplementedError
   def met?(prerequisite) = prerequisite.met?(ids)
+  def group_credits_met?(group) = group_credits(group) >= group.credits_needed
 
   private
 

--- a/app/models/base_student.rb
+++ b/app/models/base_student.rb
@@ -27,6 +27,7 @@ class BaseStudent
   def welcome_banner_mark_as_viewed! = raise NotImplementedError
   def met?(prerequisite) = prerequisite.met?(ids)
   def group_credits_met?(group) = group_credits(group) >= group.credits_needed
+  def groups_credits_met? = SubjectGroup.all.all? { |group| group_credits_met?(group) }
 
   private
 

--- a/app/models/base_student.rb
+++ b/app/models/base_student.rb
@@ -28,6 +28,7 @@ class BaseStudent
   def met?(prerequisite) = prerequisite.met?(ids)
   def group_credits_met?(group) = group_credits(group) >= group.credits_needed
   def groups_credits_met? = SubjectGroup.all.all? { |group| group_credits_met?(group) }
+  def graduated? = total_credits >= 450 && groups_credits_met?
 
   private
 

--- a/app/services/yml_loader.rb
+++ b/app/services/yml_loader.rb
@@ -14,6 +14,7 @@ module YmlLoader
     subject_groups.each do |code, yml_group|
       subject_group = SubjectGroup.find_or_initialize_by(code:)
       subject_group.name = format_name(yml_group["name"])
+      subject_group.credits_needed = yml_group["min_credits"]
       subject_group.save!
     end
   end

--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -2,13 +2,20 @@
   <h3 class="mdc-deprecated-list-group__subheader mdc-typography--headline5">Resumen por Grupo</h3>
   <ul class="mdc-deprecated-list growing-text-list">
     <li role="separator" class="mdc-deprecated-list-divider"></li>
+    <% all_group_credits_met = true %>
     <% @groups_and_credits.each do |group| %>
       <li class="mdc-deprecated-list-item">
         <%= link_to subject_group_path(group[:subject_group]), :class => "mdc-deprecated-list-item__text" do %>
           <%= group[:subject_group].name %>
         <% end %>
-        <span class="mdc-deprecated-list-item__meta">
-          <%= group[:credits] %>
+
+        <% 
+          credits_needed_reached = group[:credits] >= group[:subject_group].credits_needed 
+          all_group_credits_met = false unless credits_needed_reached
+          group_credits_class = "subject-group-credits-#{credits_needed_reached ? "met" : "unmet"}" 
+        %>
+        <span class="mdc-deprecated-list-item__meta <%= group_credits_class %>">
+          <%= group[:credits] %> / <%= group[:subject_group].credits_needed %>
         </span>
       </li>
       <li role="separator" class="mdc-deprecated-list-divider"></li>
@@ -17,8 +24,14 @@
       <span class="mdc-deprecated-list-item__text">
         Total
       </span>
-      <span class="mdc-deprecated-list-item__meta">
-        <%= @groups_and_credits.pluck(:credits).reduce :+ %>
+
+      <% 
+        total_credits = @groups_and_credits.pluck(:credits).reduce :+
+        all_group_credits_met = all_group_credits_met && total_credits >= 450
+        total_credits_class = "subject-group-credits-#{all_group_credits_met ? "met" : "unmet"}" 
+      %>
+      <span class="mdc-deprecated-list-item__meta <%= total_credits_class %>">
+        <%= total_credits %> / 450
       </span>
     </li>
   </ul>

--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -2,19 +2,13 @@
   <h3 class="mdc-deprecated-list-group__subheader mdc-typography--headline5">Resumen por Grupo</h3>
   <ul class="mdc-deprecated-list growing-text-list">
     <li role="separator" class="mdc-deprecated-list-divider"></li>
-    <% all_group_credits_met = true %>
     <% @groups_and_credits.each do |group| %>
       <li class="mdc-deprecated-list-item">
         <%= link_to subject_group_path(group[:subject_group]), :class => "mdc-deprecated-list-item__text" do %>
           <%= group[:subject_group].name %>
         <% end %>
 
-        <% 
-          credits_needed_reached = group[:credits] >= group[:subject_group].credits_needed 
-          all_group_credits_met = false unless credits_needed_reached
-          group_credits_class = "subject-group-credits-#{credits_needed_reached ? "met" : "unmet"}" 
-        %>
-        <span class="mdc-deprecated-list-item__meta <%= group_credits_class %>">
+        <span class="mdc-deprecated-list-item__meta <%= group_credits_class(group[:credits_needed_reached]) %>">
           <%= group[:credits] %> / <%= group[:subject_group].credits_needed %>
         </span>
       </li>
@@ -25,13 +19,8 @@
         Total
       </span>
 
-      <% 
-        total_credits = @groups_and_credits.pluck(:credits).reduce :+
-        all_group_credits_met = all_group_credits_met && total_credits >= 450
-        total_credits_class = "subject-group-credits-#{all_group_credits_met ? "met" : "unmet"}" 
-      %>
-      <span class="mdc-deprecated-list-item__meta <%= total_credits_class %>">
-        <%= total_credits %> / 450
+      <span class="mdc-deprecated-list-item__meta <%= group_credits_class(@all_group_credits_met && @total_credits >= 450) %>">
+        <%= @total_credits %> / 450
       </span>
     </li>
   </ul>

--- a/db/migrate/20231210213256_add_credits_needed_to_subject_group.rb
+++ b/db/migrate/20231210213256_add_credits_needed_to_subject_group.rb
@@ -1,0 +1,5 @@
+class AddCreditsNeededToSubjectGroup < ActiveRecord::Migration[7.1]
+  def change
+    add_column :subject_groups, :credits_needed, :integer, default: 0, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_03_17_141005) do
+ActiveRecord::Schema[7.1].define(version: 2023_12_10_213256) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -37,6 +37,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_03_17_141005) do
     t.datetime "created_at", precision: nil, null: false
     t.datetime "updated_at", precision: nil, null: false
     t.string "code"
+    t.integer "credits_needed", default: 0, null: false
     t.index ["code"], name: "index_subject_groups_on_code", unique: true
   end
 

--- a/test/models/cookie_student_test.rb
+++ b/test/models/cookie_student_test.rb
@@ -130,4 +130,32 @@ class CookieStudentTest < ActiveSupport::TestCase
     assert_not build(:cookie_student, approved_approvable_ids: []).met?(prereq)
     assert build(:cookie_student, approved_approvable_ids: [subject1.course.id]).met?(prereq)
   end
+
+  test "#group_credits_met? returns true if group credits met" do
+    group = create :subject_group, credits_needed: 10
+    subject1 = create :subject, credits: 5, group: group
+    subject2 = create :subject, credits: 5, group: group
+    cookies = build(:cookie)
+    student = build(:cookie_student, cookies:)
+    student.add(subject1.course)
+
+    assert_not student.group_credits_met?(group)
+    student.add(subject2.course)
+    assert student.group_credits_met?(group)
+  end
+
+  test "#groups_credits_met? returns true if all groups credits met" do
+    group1 = create :subject_group, credits_needed: 10
+    group2 = create :subject_group, credits_needed: 10
+    subject1 = create :subject, credits: 10, group: group1
+    subject2 = create :subject, credits: 10, group: group2
+    cookies = build(:cookie)
+    student = build(:cookie_student, cookies:)
+
+    assert_not student.groups_credits_met?
+    student.add(subject1.course)
+    assert_not student.groups_credits_met?
+    student.add(subject2.course)
+    assert student.groups_credits_met?
+  end
 end

--- a/test/models/cookie_student_test.rb
+++ b/test/models/cookie_student_test.rb
@@ -158,4 +158,18 @@ class CookieStudentTest < ActiveSupport::TestCase
     student.add(subject2.course)
     assert student.groups_credits_met?
   end
+
+  test "#graduated? returns true if total credits >= 450 and all groups credits met" do
+    group = create :subject_group, credits_needed: 10
+    subject1 = create :subject, credits: 440, group: group
+    subject2 = create :subject, credits: 10, group: group
+    cookies = build(:cookie)
+    student = build(:cookie_student, cookies:)
+
+    assert_not student.graduated?
+    student.add(subject1.course)
+    assert_not student.graduated?
+    student.add(subject2.course)
+    assert student.graduated?
+  end
 end

--- a/test/models/user_student_test.rb
+++ b/test/models/user_student_test.rb
@@ -153,4 +153,17 @@ class UserStudentTest < ActiveSupport::TestCase
     user.approvals = [subject1.course.id, subject2.course.id]
     assert UserStudent.new(user).groups_credits_met?
   end
+
+  test "#graduated? returns true if total credits >= 450 and all groups credits met" do
+    group = create :subject_group, credits_needed: 10
+    subject1 = create :subject, credits: 440, group: group
+    subject2 = create :subject, credits: 10, group: group
+    user = create :user, approvals: []
+
+    assert_not UserStudent.new(user).graduated?
+    user.approvals = [subject1.course.id]
+    assert_not UserStudent.new(user).graduated?
+    user.approvals = [subject1.course.id, subject2.course.id]
+    assert UserStudent.new(user).graduated?
+  end
 end

--- a/test/models/user_student_test.rb
+++ b/test/models/user_student_test.rb
@@ -139,4 +139,18 @@ class UserStudentTest < ActiveSupport::TestCase
     user.approvals = [subject1.course.id, subject2.course.id]
     assert UserStudent.new(user).group_credits_met?(group)
   end
+
+  test "#groups_credits_met? returns true if all groups credits met" do
+    group1 = create :subject_group, credits_needed: 10
+    group2 = create :subject_group, credits_needed: 10
+    subject1 = create :subject, credits: 10, group: group1
+    subject2 = create :subject, credits: 10, group: group2
+    user = create :user, approvals: []
+
+    assert_not UserStudent.new(user).groups_credits_met?
+    user.approvals = [subject1.course.id]
+    assert_not UserStudent.new(user).groups_credits_met?
+    user.approvals = [subject1.course.id, subject2.course.id]
+    assert UserStudent.new(user).groups_credits_met?
+  end
 end

--- a/test/models/user_student_test.rb
+++ b/test/models/user_student_test.rb
@@ -128,4 +128,15 @@ class UserStudentTest < ActiveSupport::TestCase
     assert_not UserStudent.new(create :user, approvals: []).met?(prereq)
     assert UserStudent.new(create :user, approvals: [subject1.course.id]).met?(prereq)
   end
+
+  test "#group_credits_met? returns true if group credits met" do
+    group = create :subject_group, credits_needed: 10
+    subject1 = create :subject, credits: 5, group: group
+    subject2 = create :subject, credits: 5, group: group
+    user = create :user, approvals: [subject1.course.id]
+
+    assert_not UserStudent.new(user).group_credits_met?(group)
+    user.approvals = [subject1.course.id, subject2.course.id]
+    assert UserStudent.new(user).group_credits_met?(group)
+  end
 end


### PR DESCRIPTION
### Summary 
Track the amount of credits needed for each group, this data was already in the scrapped yaml. Display each limit in the `Resumen por Grupo` page. Also take them into account when verifying if the student has graduated.

Before:
![image](https://github.com/cedarcode/mi_carrera/assets/39157163/e06ca3f3-d8e0-42e6-b1e5-4ebc15a960f5)
After:
![image](https://github.com/cedarcode/mi_carrera/assets/39157163/f7fc8089-8b69-4182-aad6-ab12eee426fa)
