### PR TITLE
Fix scraper Github action not opening a PR even if no PR already opened.

### DIFF
--- a/.github/workflows/scraper.yml
+++ b/.github/workflows/scraper.yml
@@ -24,7 +24,7 @@ jobs:
             git config --global user.name "MiCarrera"
             git commit -m 'chore: update scraped subjects data'
             git push -f origin HEAD:scraper
-            if ! gh pr view scraper > /dev/null;
+            if [ $(gh pr list --head scraper --json title --jq 'length') == '0' ];
             then
                 gh pr create \
                     --title "Update scraped subjects data" \


### PR DESCRIPTION
## Summary

Its saying that a PR is already open but the PR was merged some days ago. 

We have to ensure that the PR that it detects its not merged or closed. In order to that we can use the [`gh pr list` command](https://cli.github.com/manual/gh_pr_list). Worth noting that by default it only lists PRs with `open` state.

