### PR TITLE
Fix: Stop setting Subject `2415` as inactive

### DIFF
--- a/db/data/subject_overrides.yml
+++ b/db/data/subject_overrides.yml
@@ -41,8 +41,6 @@ MA020:
   category: 'revalid'
 CAL12:
   category: 'revalid'
-'2415':
-  category: 'inactive'
 CAL10:
   category: 'revalid'
 CP7:


### PR DESCRIPTION
Fix for https://github.com/cedarcode/mi_carrera/issues/379.
Apparently, that subject is not inactive.

@santiagorodriguez96 would you mind testing this out?
As we discussed today, I'm having some issues with Ruby 3.3.0. Thanks!