### PR TITLE
Update scraper GH action to run at midnight

### DIFF
--- a/.github/workflows/scraper.yml
+++ b/.github/workflows/scraper.yml
@@ -1,7 +1,7 @@
 name: Scraper
 on:
   schedule:
-    - cron:  '0 11 * * MON'
+    - cron:  '0 5 * * MON'
   workflow_dispatch:
 jobs:
   scrape:


### PR DESCRIPTION
That would prevent automatically running the scraper while changes are being made to `bedelia` so that we don't fetch an intermediate state.