### PR TITLE
Enable Traefik access logs

### DIFF
--- a/config/deploy.yml
+++ b/config/deploy.yml
@@ -25,6 +25,7 @@ traefik:
     volume:
       - "/home/ubuntu/letsencrypt/acme.json:/letsencrypt/acme.json"
   args:
+    accesslog: true
     entryPoints.web.address: ":80"
     entryPoints.websecure.address: ":443"
     entryPoints.web.http.redirections.entryPoint.to: websecure


### PR DESCRIPTION
## Motivation

This PR enables `Traefik` access logs so we can investigate the incoming requests to `Traefik` in an attempt to help debugging when the site is down