### PR TITLE
Add subjects search

### DIFF
--- a/app/assets/stylesheets/_search.scss
+++ b/app/assets/stylesheets/_search.scss
@@ -1,0 +1,19 @@
+#searchbar {
+  width: 100%;
+
+  form {
+    height: 100%;
+    width: 100%;
+  }
+
+  .mdc-text-field {
+    width: 100%;
+    height: 100%;
+    padding: 0 21px;
+    border-radius: 0;
+  }
+
+  i.mdc-text-field__icon--trailing {
+    padding: 0;
+  }
+}

--- a/app/assets/stylesheets/_search.scss
+++ b/app/assets/stylesheets/_search.scss
@@ -17,3 +17,13 @@
     padding: 0;
   }
 }
+
+.search-no-results {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  margin-top: 45px;
+  color: darkgray;
+  font-size: 24px;
+  font-weight: 100;
+}

--- a/app/assets/stylesheets/_utility.scss
+++ b/app/assets/stylesheets/_utility.scss
@@ -5,3 +5,7 @@
 .color-green {
   color: #19a819 !important;
 }
+
+.d-none {
+  display: none !important;
+}

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -213,3 +213,7 @@ body {
 .subject-group-credits-unmet {
   color: red !important;
 }
+
+#butInstall {
+  padding-left: 0px;
+}

--- a/app/controllers/subjects_controller.rb
+++ b/app/controllers/subjects_controller.rb
@@ -13,7 +13,7 @@ class SubjectsController < ApplicationController
   end
 
   def all
-    @subjects = TreePreloader.new.preload
+    @subjects = TreePreloader.new.preload(name: params[:search])
   end
 
   private

--- a/app/controllers/subjects_controller.rb
+++ b/app/controllers/subjects_controller.rb
@@ -13,15 +13,12 @@ class SubjectsController < ApplicationController
   end
 
   def all
-    @subjects =
-      begin
-        subjects =
-          if params[:search].present?
-            Subject.where("lower(unaccent(name)) LIKE lower(unaccent(?))", "%#{params[:search]}%")
-          end
-
-        TreePreloader.new(subjects).preload
+    subjects =
+      if params[:search].present?
+        Subject.where("lower(unaccent(name)) LIKE lower(unaccent(?))", "%#{params[:search]}%")
       end
+
+    @subjects = TreePreloader.new(subjects).preload
   end
 
   private

--- a/app/controllers/subjects_controller.rb
+++ b/app/controllers/subjects_controller.rb
@@ -13,7 +13,15 @@ class SubjectsController < ApplicationController
   end
 
   def all
-    @subjects = TreePreloader.new.preload(name: params[:search])
+    @subjects =
+      begin
+        subjects =
+          if params[:search].present?
+            Subject.where("lower(unaccent(name)) LIKE ?", "%#{I18n.transliterate(params[:search].downcase)}%")
+          end
+
+        TreePreloader.new(subjects).preload
+      end
   end
 
   private

--- a/app/controllers/subjects_controller.rb
+++ b/app/controllers/subjects_controller.rb
@@ -17,7 +17,7 @@ class SubjectsController < ApplicationController
       begin
         subjects =
           if params[:search].present?
-            Subject.where("lower(unaccent(name)) LIKE ?", "%#{I18n.transliterate(params[:search].downcase)}%")
+            Subject.where("lower(unaccent(name)) LIKE lower(unaccent(?))", "%#{params[:search]}%")
           end
 
         TreePreloader.new(subjects).preload

--- a/app/javascript/controllers/search_controller.js
+++ b/app/javascript/controllers/search_controller.js
@@ -1,0 +1,10 @@
+import { Controller } from "@hotwired/stimulus";
+
+export default class extends Controller {
+  static targets = ["appBar", "searchbar"];
+
+  toggle() {
+    this.appBarTarget.classList.toggle("d-none")
+    this.searchbarTarget.classList.toggle("d-none")
+  }
+}

--- a/app/javascript/controllers/search_controller.js
+++ b/app/javascript/controllers/search_controller.js
@@ -1,10 +1,13 @@
 import { Controller } from "@hotwired/stimulus";
 
 export default class extends Controller {
-  static targets = ["appBar", "searchbar"];
+  static targets = ["appBar", "searchbar", "searchInput"];
 
   toggle() {
     this.appBarTarget.classList.toggle("d-none")
     this.searchbarTarget.classList.toggle("d-none")
+    if (!this.searchbarTarget.classList.contains("d-none")) {
+      this.searchInputTarget.focus()
+    }
   }
 }

--- a/app/services/tree_preloader.rb
+++ b/app/services/tree_preloader.rb
@@ -1,8 +1,11 @@
 class TreePreloader
-  def preload(**filters)
+  def initialize(subjects = nil)
+    @subjects = subjects || Subject.all
+  end
+
+  def preload
     # rubocop:disable Rails/FindEach
-    Subject
-      .where("lower(unaccent(name)) LIKE ?", "%#{I18n.transliterate(filters[:name]&.downcase)}%")
+    subjects
       .ordered_by_category_and_name
       .includes(
         course: :prerequisite_tree,
@@ -15,6 +18,8 @@ class TreePreloader
   end
 
   private
+
+  attr_reader :subjects
 
   def preload_prerequisite(prereq)
     case prereq

--- a/app/services/tree_preloader.rb
+++ b/app/services/tree_preloader.rb
@@ -2,7 +2,7 @@ class TreePreloader
   def preload(**filters)
     # rubocop:disable Rails/FindEach
     Subject
-      .where("lower(name) LIKE ?", "%#{filters[:name]&.downcase}%")
+      .where("lower(unaccent(name)) LIKE ?", "%#{I18n.transliterate(filters[:name]&.downcase)}%")
       .ordered_by_category_and_name
       .includes(
         course: :prerequisite_tree,

--- a/app/services/tree_preloader.rb
+++ b/app/services/tree_preloader.rb
@@ -1,7 +1,8 @@
 class TreePreloader
-  def preload
+  def preload(**filters)
     # rubocop:disable Rails/FindEach
     Subject
+      .where("lower(name) LIKE ?", "%#{filters[:name]&.downcase}%")
       .ordered_by_category_and_name
       .includes(
         course: :prerequisite_tree,

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -39,23 +39,15 @@
   <body class="mdc-typography" data-controller='navigation-drawer'>
     <%= render 'shared/menu' %>
     <div class="mdc-drawer-app-content">
-      <header id='app-bar' class="mdc-top-app-bar">
-        <div class="mdc-top-app-bar__row">
+      <header id='app-bar' class="mdc-top-app-bar" data-controller='search'>
+        <div class="mdc-top-app-bar__row" data-search-target="appBar">
           <section class="mdc-top-app-bar__section mdc-top-app-bar__section--align-start">
             <button class="material-icons mdc-top-app-bar__navigation-icon mdc-icon-button" data-action='click->navigation-drawer#open'>menu</button>
             <%= yield :navigation_icon %>
             <%= link_to 'MiCarrera', root_path, class: 'home-button'%>
           </section>
           <section class="mdc-top-app-bar__section mdc-top-app-bar__section--align-end" role="toolbar">
-            <div id="searchbox" class="">
-              <%= form_with(url: all_subjects_path, method: :get, local: true) do |f| %>
-                <div class="mdc-text-field mdc-text-field--filled mdc-text-field--label-floating mdc-text-field--no-label">
-                  <span class="mdc-text-field__ripple"></span>
-                  <%= f.text_field :search, value: params[:search], class: "mdc-text-field__input", placeholder: "Search", autofocus: true %>
-                  <span class="mdc-line-ripple"></span>
-                </div>
-              <% end %>
-            </div>
+            <button id="searchIcon" class="material-icons mdc-top-app-bar__action-item mdc-icon-button" data-action="search#toggle">search</button>
             <span hidden>
               <button id="butInstall" class="material-icons mdc-top-app-bar__action-item mdc-icon-button">cloud_download</button>
             </span>
@@ -73,6 +65,16 @@
               <%= render 'shared/user_menu' %>
             </div>
           </section>
+        </div>
+        <div id="searchbar" class="mdc-top-app-bar__row d-none" data-search-target="searchbar">
+          <%= form_with(url: all_subjects_path, method: :get, local: true) do |f| %>
+            <div class="mdc-text-field mdc-text-field--filled mdc-text-field--label-floating mdc-text-field--no-label mdc-text-field--with-trailing-icon">
+              <span class="mdc-text-field__ripple"></span>
+              <%= f.text_field :search, value: params[:search], class: "mdc-text-field__input", placeholder: "Search", autofocus: true %>
+              <i class="material-icons mdc-text-field__icon mdc-text-field__icon--trailing" data-action="click->search#toggle" tabindex="0" role="button">close</i>
+              <span class="mdc-line-ripple"></span>
+            </div>
+          <% end %>
         </div>
       </header>
       <main class="mdc-top-app-bar--fixed-adjust main-content" id='main-content'>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -47,6 +47,15 @@
             <%= link_to 'MiCarrera', root_path, class: 'home-button'%>
           </section>
           <section class="mdc-top-app-bar__section mdc-top-app-bar__section--align-end" role="toolbar">
+            <div id="searchbox" class="">
+              <%= form_with(url: all_subjects_path, method: :get, local: true) do |f| %>
+                <div class="mdc-text-field mdc-text-field--filled mdc-text-field--label-floating mdc-text-field--no-label">
+                  <span class="mdc-text-field__ripple"></span>
+                  <%= f.text_field :search, value: params[:search], class: "mdc-text-field__input", placeholder: "Search", autofocus: true %>
+                  <span class="mdc-line-ripple"></span>
+                </div>
+              <% end %>
+            </div>
             <span hidden>
               <button id="butInstall" class="material-icons mdc-top-app-bar__action-item mdc-icon-button">cloud_download</button>
             </span>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -40,7 +40,8 @@
     <%= render 'shared/menu' %>
     <div class="mdc-drawer-app-content">
       <header id='app-bar' class="mdc-top-app-bar" data-controller='search'>
-        <div class="mdc-top-app-bar__row" data-search-target="appBar">
+        <% show_search_bar = params[:search].present? %>
+        <div class="mdc-top-app-bar__row <%= show_search_bar ? 'd-none' : '' %>" data-search-target="appBar">
           <section class="mdc-top-app-bar__section mdc-top-app-bar__section--align-start">
             <button class="material-icons mdc-top-app-bar__navigation-icon mdc-icon-button" data-action='click->navigation-drawer#open'>menu</button>
             <%= yield :navigation_icon %>
@@ -66,7 +67,7 @@
             </div>
           </section>
         </div>
-        <div id="searchbar" class="mdc-top-app-bar__row d-none" data-search-target="searchbar">
+        <div id="searchbar" class="mdc-top-app-bar__row <%= show_search_bar ? '' : 'd-none' %>" data-search-target="searchbar">
           <%= form_with(url: all_subjects_path, method: :get, local: true) do |f| %>
             <div class="mdc-text-field mdc-text-field--filled mdc-text-field--label-floating mdc-text-field--no-label mdc-text-field--with-trailing-icon">
               <span class="mdc-text-field__ripple"></span>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -71,7 +71,7 @@
           <%= form_with(url: all_subjects_path, method: :get, local: true) do |f| %>
             <div class="mdc-text-field mdc-text-field--filled mdc-text-field--label-floating mdc-text-field--no-label mdc-text-field--with-trailing-icon">
               <span class="mdc-text-field__ripple"></span>
-              <%= f.text_field :search, value: params[:search], class: "mdc-text-field__input", placeholder: "Search", autofocus: true %>
+              <%= f.text_field :search, value: params[:search], class: "mdc-text-field__input", placeholder: "Search", autofocus: true, data: { 'search-target': "searchInput" } %>
               <i class="material-icons mdc-text-field__icon mdc-text-field__icon--trailing" data-action="click->search#toggle" tabindex="0" role="button">close</i>
               <span class="mdc-line-ripple"></span>
             </div>

--- a/app/views/subjects/all.html.erb
+++ b/app/views/subjects/all.html.erb
@@ -3,13 +3,20 @@
 <% end %>
 
 <div class="mdc-deprecated-list-group subjects-list">
-  <% @subjects.group_by(&:category).each do |category, subjects| %>
-    <h3 class="mdc-deprecated-list-group__subheader mdc-typography--subtitle2">
-      <%= formatted_category(category) %>
-    </h3>
+  <% if @subjects.any? %>
+    <% @subjects.group_by(&:category).each do |category, subjects| %>
+      <h3 class="mdc-deprecated-list-group__subheader mdc-typography--subtitle2">
+        <%= formatted_category(category) %>
+      </h3>
 
-    <%= render partial: "subjects/subjects_list", locals: { subjects: subjects } %>
+      <%= render partial: "subjects/subjects_list", locals: { subjects: subjects } %>
 
-    <hr class="mdc-deprecated-list-divider">
+      <hr class="mdc-deprecated-list-divider">
+    <% end %>
+  <% else %>
+    <div class="search-no-results">
+      <i class="material-icons">search</i>
+      No hay resultados
+    </div>
   <% end %>
 </div>

--- a/db/migrate/20240222002214_add_unaccent_postgres_extension.rb
+++ b/db/migrate/20240222002214_add_unaccent_postgres_extension.rb
@@ -1,0 +1,5 @@
+class AddUnaccentPostgresExtension < ActiveRecord::Migration[7.1]
+  def change
+    enable_extension 'unaccent'
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,10 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2023_12_10_213256) do
+ActiveRecord::Schema[7.1].define(version: 2024_02_22_002214) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+  enable_extension "unaccent"
 
   create_table "approvables", force: :cascade do |t|
     t.integer "subject_id", null: false

--- a/test/application_system_test_case.rb
+++ b/test/application_system_test_case.rb
@@ -20,4 +20,8 @@ class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
   def click_user_menu
     find("#user-menu[data-controller-connected='true']").click
   end
+
+  def click_search_trigger
+    find("#searchIcon").click
+  end
 end

--- a/test/services/tree_preloader_test.rb
+++ b/test/services/tree_preloader_test.rb
@@ -36,7 +36,7 @@ class TreePreloaderTest < ActiveSupport::TestCase
     s2 = create :subject, :with_exam, name: "s2"
     create :subject_prerequisite, approvable: s2.course, approvable_needed: s1.course
 
-    subjects = TreePreloader.new.preload(name: 's2')
+    subjects = TreePreloader.new(Subject.where(id: s2)).preload
 
     assert_equal 1, subjects.count
     assert_equal "s2", subjects.first.name
@@ -44,7 +44,11 @@ class TreePreloaderTest < ActiveSupport::TestCase
     assert_equal SubjectPrerequisite, subjects.first.course.prerequisite_tree.class
     assert_equal s1.course, subjects.first.course.prerequisite_tree.approvable_needed
 
-    subjects = TreePreloader.new.preload(name: '')
+    subjects = TreePreloader.new(Subject.where(name: 'does_not_exist')).preload
+
+    assert_equal 0, subjects.count
+
+    subjects = TreePreloader.new(nil).preload
 
     assert_equal 2, subjects.count
     assert_equal "s1", subjects.first.name
@@ -52,9 +56,5 @@ class TreePreloaderTest < ActiveSupport::TestCase
 
     assert_equal SubjectPrerequisite, subjects.last.course.prerequisite_tree.class
     assert_equal s1.course, subjects.last.course.prerequisite_tree.approvable_needed
-
-    subjects = TreePreloader.new.preload(name: 'this subject does not exist')
-
-    assert_equal 0, subjects.count
   end
 end

--- a/test/services/tree_preloader_test.rb
+++ b/test/services/tree_preloader_test.rb
@@ -30,4 +30,31 @@ class TreePreloaderTest < ActiveSupport::TestCase
     assert_equal SubjectPrerequisite, subjects.last.course.prerequisite_tree.class
     assert_equal s1.course, subjects.last.course.prerequisite_tree.approvable_needed
   end
+
+  test "subjects should be filtered by name" do
+    s1 = create :subject, :with_exam, name: "s1"
+    s2 = create :subject, :with_exam, name: "s2"
+    create :subject_prerequisite, approvable: s2.course, approvable_needed: s1.course
+
+    subjects = TreePreloader.new.preload(name: 's2')
+
+    assert_equal 1, subjects.count
+    assert_equal "s2", subjects.first.name
+
+    assert_equal SubjectPrerequisite, subjects.first.course.prerequisite_tree.class
+    assert_equal s1.course, subjects.first.course.prerequisite_tree.approvable_needed
+
+    subjects = TreePreloader.new.preload(name: '')
+
+    assert_equal 2, subjects.count
+    assert_equal "s1", subjects.first.name
+    assert_equal "s2", subjects.last.name
+
+    assert_equal SubjectPrerequisite, subjects.last.course.prerequisite_tree.class
+    assert_equal s1.course, subjects.last.course.prerequisite_tree.approvable_needed
+
+    subjects = TreePreloader.new.preload(name: 'this subject does not exist')
+
+    assert_equal 0, subjects.count
+  end
 end

--- a/test/system/subjects_test.rb
+++ b/test/system/subjects_test.rb
@@ -31,6 +31,7 @@ class SubjectsTest < ApplicationSystemTestCase
     assert_no_text "GAL 1"
     assert_no_text "GAL 2"
     assert_no_text "Taller"
+    assert_text "No hay resultados"
 
     fill_in 'search', with: " \n"
 

--- a/test/system/subjects_test.rb
+++ b/test/system/subjects_test.rb
@@ -1,0 +1,40 @@
+require "application_system_test_case"
+
+class SubjectsTest < ApplicationSystemTestCase
+  test "can search for subjects" do
+    gal1 = create :subject, :with_exam, name: "GAL 1", credits: 9, code: "1030"
+    create :subject_prerequisite, approvable: gal1.exam, approvable_needed: gal1.course
+
+    gal2 = create :subject, :with_exam, name: "GAL 2", credits: 10
+    create :and_prerequisite, approvable: gal2.course, operands_prerequisites: [
+      create(:subject_prerequisite, approvable_needed: gal1.course),
+      create(:subject_prerequisite, approvable_needed: gal1.exam),
+    ]
+
+    create :subject, name: "Taller", credits: 11
+
+    visit all_subjects_path
+
+    assert_text "GAL 1"
+    assert_text "GAL 2"
+    assert_text "Taller"
+
+    fill_in 'search', with: "Taller\n"
+
+    assert_no_text "GAL 1"
+    assert_no_text "GAL 2"
+    assert_text "Taller"
+
+    fill_in 'search', with: "This subject does not exist\n"
+
+    assert_no_text "GAL 1"
+    assert_no_text "GAL 2"
+    assert_no_text "Taller"
+
+    fill_in 'search', with: " \n"
+
+    assert_text "GAL 1"
+    assert_text "GAL 2"
+    assert_text "Taller"
+  end
+end

--- a/test/system/subjects_test.rb
+++ b/test/system/subjects_test.rb
@@ -19,6 +19,7 @@ class SubjectsTest < ApplicationSystemTestCase
     assert_text "GAL 2"
     assert_text "Taller"
 
+    click_search_trigger
     fill_in 'search', with: "Taller\n"
 
     assert_no_text "GAL 1"


### PR DESCRIPTION
## Summary

This PR adds a pretty basic subjects search functionality so that users don't have to rely on the browser search functionality – which is sometimes even not available for example when using the PWA, leaving the users with no capability of searching subjects.

The searbar can be triggered by clicking on the search icon in the app bar – which will turn the app bar into a search bar. After searching, users will be redirected to the all subjects page with only the subjects that match the criteria. In case no subjects match the criteria, an appropriate message will be shown.

## TODO

We could probably add some transitions to make it look smoother but I'd leave for a separate PR.

## Screenshots

https://github.com/cedarcode/mi_carrera/assets/46354312/364a2cc3-ae19-45bb-97b5-4ffde5b8fd34



