### PR TITLE
Rename YML task loader in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ $ git clone https://github.com/cedarcode/mi_carrera.git
 $ cd mi_carrera/
 $ bundle install
 $ bin/rails db:setup
-$ bin/rails scrape:update_subjects
+$ bin/rails load_yml
 ```
 
 ### Levantar el servidor


### PR DESCRIPTION
The YML loader was refactored by https://github.com/cedarcode/mi_carrera/pull/254, so the old command in the README.md needs to be updated as well.