### PR TITLE
bugfix: green check prerequisite

### DIFF
--- a/app/views/approvals/update.turbo_stream.erb
+++ b/app/views/approvals/update.turbo_stream.erb
@@ -2,6 +2,11 @@
   <%= turbo_stream.replace "approvables" do %>
     <%= render 'subjects/approvables' %>
   <% end %>
+  <%= turbo_stream.replace "exam-prerequisites" do %>
+      <div class="mdc-deprecated-list" id="exam-prerequisites">
+      <%= render @subject.exam.prerequisite_tree, negative: false %>
+    </div>
+  <% end %>
 <% else %>
   <%= turbo_stream.replace "credits" do %>
     <%= render 'shared/credits_counter' %>

--- a/app/views/approvals/update.turbo_stream.erb
+++ b/app/views/approvals/update.turbo_stream.erb
@@ -2,10 +2,12 @@
   <%= turbo_stream.replace "approvables" do %>
     <%= render 'subjects/approvables' %>
   <% end %>
-  <%= turbo_stream.replace "exam-prerequisites" do %>
+  <% if @subject.exam&.prerequisite_tree %>
+    <%= turbo_stream.replace "exam-prerequisites" do %>
       <div class="mdc-deprecated-list" id="exam-prerequisites">
-      <%= render @subject.exam.prerequisite_tree, negative: false %>
-    </div>
+        <%= render @subject.exam.prerequisite_tree, negative: false %>
+      </div>
+    <% end %>
   <% end %>
 <% else %>
   <%= turbo_stream.replace "credits" do %>

--- a/app/views/subjects/show.html.erb
+++ b/app/views/subjects/show.html.erb
@@ -63,7 +63,7 @@
     <span class="mdc-deprecated-list-group__subheader mdc-typography--subtitle1 prerequisite-type">
       Del examen:
     </span>
-    <div class="mdc-deprecated-list">
+    <div class="mdc-deprecated-list" id="exam-prerequisites">
       <%= render @subject.exam.prerequisite_tree, negative: false %>
     </div>
   <% end %>


### PR DESCRIPTION
### Purpose
In the show subject page when marking a subject's 'Curso' as passed, the Exam prerequisites were not updated properly.

### Artefact 
[Card](https://trello.com/c/BNGAFlG4/235-green-check-in-prerequisites-should-be-reloaded-after-checking-an-approval-in-subject-show-page)