### PR TITLE
Fix search with leading whitespaces

### DIFF
--- a/app/controllers/subjects_controller.rb
+++ b/app/controllers/subjects_controller.rb
@@ -15,7 +15,7 @@ class SubjectsController < ApplicationController
   def all
     subjects =
       if params[:search].present?
-        Subject.where("lower(unaccent(name)) LIKE lower(unaccent(?))", "%#{params[:search]}%")
+        Subject.where("lower(unaccent(name)) LIKE lower(unaccent(?))", "%#{params[:search].strip}%")
       end
 
     @subjects = TreePreloader.new(subjects).preload

--- a/test/system/subjects_test.rb
+++ b/test/system/subjects_test.rb
@@ -32,6 +32,12 @@ class SubjectsTest < ApplicationSystemTestCase
     assert_no_text "GAL 2"
     assert_text "Taller"
 
+    fill_in 'search', with: "Taller \n"
+
+    assert_no_text "GAL 1"
+    assert_no_text "GAL 2"
+    assert_text "Taller"
+
     fill_in 'search', with: "This subject does not exist\n"
 
     assert_no_text "GAL 1"

--- a/test/system/subjects_test.rb
+++ b/test/system/subjects_test.rb
@@ -26,6 +26,12 @@ class SubjectsTest < ApplicationSystemTestCase
     assert_no_text "GAL 2"
     assert_text "Taller"
 
+    fill_in 'search', with: " Taller\n"
+
+    assert_no_text "GAL 1"
+    assert_no_text "GAL 2"
+    assert_text "Taller"
+
     fill_in 'search', with: "This subject does not exist\n"
 
     assert_no_text "GAL 1"


### PR DESCRIPTION
## Summary

Search was not removing trailing whitespaces so that if you fill in the search input with string starting with whitespaces, the results will have those whitespaces into account.

This PR changes the behavior of the subjects search so that the leading and trailing whitespaces are removed from the search input when searching.