### PR TITLE
Allow searching by subjects' short name

### DIFF
--- a/app/controllers/subjects_controller.rb
+++ b/app/controllers/subjects_controller.rb
@@ -15,7 +15,9 @@ class SubjectsController < ApplicationController
   def all
     subjects =
       if params[:search].present?
-        Subject.where("lower(unaccent(name)) LIKE lower(unaccent(?))", "%#{params[:search].strip}%")
+        Subject
+          .where("lower(unaccent(name)) LIKE lower(unaccent(?))", "%#{params[:search].strip}%")
+          .or(Subject.where("lower(unaccent(short_name)) LIKE lower(unaccent(?))", "%#{params[:search].strip}%"))
       end
 
     @subjects = TreePreloader.new(subjects).preload

--- a/test/system/subjects_test.rb
+++ b/test/system/subjects_test.rb
@@ -11,44 +11,50 @@ class SubjectsTest < ApplicationSystemTestCase
       create(:subject_prerequisite, approvable_needed: gal1.exam),
     ]
 
-    create :subject, name: "Taller", credits: 11
+    create :subject, name: "Taller 1", short_name: 'T1', credits: 11
 
     visit all_subjects_path
 
     assert_text "GAL 1"
     assert_text "GAL 2"
-    assert_text "Taller"
+    assert_text "T1"
 
     click_search_trigger
     fill_in 'search', with: "Taller\n"
 
     assert_no_text "GAL 1"
     assert_no_text "GAL 2"
-    assert_text "Taller"
+    assert_text "T1"
 
     fill_in 'search', with: " Taller\n"
 
     assert_no_text "GAL 1"
     assert_no_text "GAL 2"
-    assert_text "Taller"
+    assert_text "T1"
 
     fill_in 'search', with: "Taller \n"
 
     assert_no_text "GAL 1"
     assert_no_text "GAL 2"
-    assert_text "Taller"
+    assert_text "T1"
+
+    fill_in 'search', with: "T1\n"
+
+    assert_no_text "GAL 1"
+    assert_no_text "GAL 2"
+    assert_text "T1"
 
     fill_in 'search', with: "This subject does not exist\n"
 
     assert_no_text "GAL 1"
     assert_no_text "GAL 2"
-    assert_no_text "Taller"
+    assert_no_text "T1"
     assert_text "No hay resultados"
 
     fill_in 'search', with: " \n"
 
     assert_text "GAL 1"
     assert_text "GAL 2"
-    assert_text "Taller"
+    assert_text "T1"
   end
 end


### PR DESCRIPTION
## Summary

This PR changes the behavior of the subjects search so that the search input is now compared against subjects' short name.