### PR TITLE
Change searchbar placeholder

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -71,7 +71,7 @@
           <%= form_with(url: all_subjects_path, method: :get, local: true) do |f| %>
             <div class="mdc-text-field mdc-text-field--filled mdc-text-field--label-floating mdc-text-field--no-label mdc-text-field--with-trailing-icon">
               <span class="mdc-text-field__ripple"></span>
-              <%= f.text_field :search, value: params[:search], class: "mdc-text-field__input", placeholder: "Search", autofocus: true, data: { 'search-target': "searchInput" } %>
+              <%= f.text_field :search, value: params[:search], class: "mdc-text-field__input", placeholder: "Buscar", autofocus: true, data: { 'search-target': "searchInput" } %>
               <i class="material-icons mdc-text-field__icon mdc-text-field__icon--trailing" data-action="click->search#toggle" tabindex="0" role="button">close</i>
               <span class="mdc-line-ripple"></span>
             </div>


### PR DESCRIPTION
### Summary 
Update searchbar placeholder to `Buscar` instead of `Search`

Before:
![image](https://github.com/cedarcode/mi_carrera/assets/39157163/fddd37e5-d074-480e-b341-f54613bb24a1)

After:
![image](https://github.com/cedarcode/mi_carrera/assets/39157163/30c63a31-956a-477a-9373-d696259f53d7)
