### PR TITLE
Stop setting Subject `D87` as inactive

### DIFF
--- a/db/data/subject_overrides.yml
+++ b/db/data/subject_overrides.yml
@@ -21,8 +21,6 @@ SRN03:
   category: 'outside_montevideo'
 1025T:
   category: 'inactive'
-D87:
-  category: 'inactive'
 MI2:
   category: 'first_semester'
 M09:


### PR DESCRIPTION
This subject (`D87 - Teoría de Juegos`) should be active, so removing it from the `inactive` category.