### PR TITLE
Actualizar el curso de IIO

### DIFF
--- a/db/data/subject_overrides.yml
+++ b/db/data/subject_overrides.yml
@@ -718,6 +718,11 @@ GP7:
   eva_id: '994'
   openfing_id: iio-2024
   short_name: IIO
+  category: 'inactive'
+'1650':
+  eva_id: '994'
+  openfing_id: iio-2024
+  short_name: IIO
   category: 'fifth_semester'
 '1629':
   category: 'inactive'


### PR DESCRIPTION
Las previas del curso de IIO cambiaron, el nuevo código de la asignatura es 1650. 
IIO 1610 quedó inactiva.