### PR TITLE
Setup Github Actions cache for Kamal deploys

### DIFF
--- a/.github/workflows/production_deploy.yml
+++ b/.github/workflows/production_deploy.yml
@@ -39,5 +39,11 @@ jobs:
       - name: Install kamal
         run: gem install kamal -v 1.3.0
 
+      - name: Set up Docker Buildx for cache
+        uses: docker/setup-buildx-action@v3
+
+      - name: Expose GitHub Runtime for cache
+        uses: crazy-max/ghaction-github-runtime@v3
+
       - name: Run deploy command
         run: kamal deploy -d production

--- a/.github/workflows/staging_deploy.yml
+++ b/.github/workflows/staging_deploy.yml
@@ -42,5 +42,11 @@ jobs:
       - name: Install kamal
         run: gem install kamal -v 1.3.0
 
+      - name: Set up Docker Buildx for cache
+        uses: docker/setup-buildx-action@v3
+
+      - name: Expose GitHub Runtime for cache
+        uses: crazy-max/ghaction-github-runtime@v3
+
       - name: Run deploy command
         run: kamal deploy -d staging

--- a/config/deploy.yml
+++ b/config/deploy.yml
@@ -17,6 +17,8 @@ ssh:
 
 builder:
   multiarch: false
+  cache:
+    type: gha
 
 traefik:
   options:


### PR DESCRIPTION
## Background / Motivation

Our deploys currently take between three and four minutes to complete when triggering them using Github Actions given that we weren't triggering Docker build cache.

Turns out that there's a way of [using Docker build cache when using Github Actions](https://docs.docker.com/build/cache/backends/gha/) and [Kamal supports it](https://kamal-deploy.org/docs/configuration/builders/#using-multistage-builder-cache).

In order to use it, we have to use [`docker/setup-buildx-action`](https://github.com/docker/setup-buildx-action) and [`crazy-max/ghaction-github-runtime`](https://github.com/crazy-max/ghaction-github-runtime) actions as stated in [Kamal's docs](https://kamal-deploy.org/docs/configuration/builders/#gha-cache-configuration).

## Details

After the caches are hot, deploys take about one minute to finish:

#### Cold cache

<img width="1058" alt="image" src="https://github.com/cedarcode/mi_carrera/assets/46354312/6488acd0-1884-4af2-8daa-76fe1219da50">

#### Hot cache

<img width="1055" alt="image" src="https://github.com/cedarcode/mi_carrera/assets/46354312/622cec75-165f-40ce-b3fb-e175295dd3db">

NOTE: This seems to not affect local deploys as I was able to warm my docker build cache locally too.