### PR TITLE
Set memory limit on server's docker containers

### DIFF
--- a/bin/docker-entrypoint
+++ b/bin/docker-entrypoint
@@ -3,6 +3,11 @@
 # If running the rails server then create or migrate existing database
 if [ "${1}" == "./bin/rails" ] && [ "${2}" == "server" ]; then
   ./bin/rails db:prepare
+
+  file="/rails/tmp/pids/server.pid"
+  if [ -f "$file" ] ; then
+    rm "$file"
+  fi
 fi
 
 exec "${@}"

--- a/bin/docker-entrypoint
+++ b/bin/docker-entrypoint
@@ -4,7 +4,7 @@
 if [ "${1}" == "./bin/rails" ] && [ "${2}" == "server" ]; then
   ./bin/rails db:prepare
 
-  file="/rails/tmp/pids/server.pid"
+  file="./tmp/pids/server.pid"
   if [ -f "$file" ] ; then
     rm "$file"
   fi

--- a/config/deploy.production.yml
+++ b/config/deploy.production.yml
@@ -8,6 +8,8 @@ servers:
       traefik.http.routers.micarrera_secure-web-production.rule: Host(`micarrera.uy`) || Host(`fing.micarrera.uy`) || Host(`www.micarrera.uy`)
       traefik.http.routers.micarrera_secure-web-production.tls: true
       traefik.http.routers.micarrera_secure-web-production.tls.certresolver: letsencrypt
+    options:
+      memory: 500MiB
 
 env:
   clear:

--- a/config/deploy.staging.yml
+++ b/config/deploy.staging.yml
@@ -8,6 +8,8 @@ servers:
       traefik.http.routers.micarrera_secure-web-staging.rule: Host(`staging.micarrera.uy`)
       traefik.http.routers.micarrera_secure-web-staging.tls: true
       traefik.http.routers.micarrera_secure-web-staging.tls.certresolver: letsencrypt
+    options:
+      memory: 120MiB
 
 env:
   clear:

--- a/config/deploy.staging.yml
+++ b/config/deploy.staging.yml
@@ -9,7 +9,7 @@ servers:
       traefik.http.routers.micarrera_secure-web-staging.tls: true
       traefik.http.routers.micarrera_secure-web-staging.tls.certresolver: letsencrypt
     options:
-      memory: 120MiB
+      memory: 250MiB
 
 env:
   clear:


### PR DESCRIPTION
## Motivation

We were running into issues where the docker containers were increasing the memory usage over time until after a couple of days taking too much memory from the server which causes the server to throttle and respond very slowly until eventually going down.

## Details

By adding a memory limit, docker will kill the container when it gets to the limit of memory usage and the docker container will be restarted – as its started up with the `--restart unless-stopped` option.

However, we need to add the logic for cleaning the `server.pid` if exists when starting the server given that when the docker container starts itself after being killed it runs into an error when starting the server as the `server.pid` already exists:

```
a server is already running (pid: 1, file: /rails/tmp/pids/server.pid)
```