### PR TITLE
Avoid harcoding `kamal`'s version in deploy gh action

### DIFF
--- a/.github/workflows/production_deploy.yml
+++ b/.github/workflows/production_deploy.yml
@@ -15,6 +15,9 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
 
+    env:
+      BUNDLE_ONLY: 'deploy'
+
     steps:
       - name: Check out repository code
         uses: actions/checkout@v4
@@ -35,9 +38,8 @@ jobs:
 
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
-
-      - name: Install kamal
-        run: gem install kamal -v 1.3.0
+        with:
+          bundler-cache: true
 
       - name: Set up Docker Buildx for cache
         uses: docker/setup-buildx-action@v3
@@ -46,4 +48,4 @@ jobs:
         uses: crazy-max/ghaction-github-runtime@v3
 
       - name: Run deploy command
-        run: kamal deploy -d production
+        run: bundle exec kamal deploy -d production

--- a/.github/workflows/staging_deploy.yml
+++ b/.github/workflows/staging_deploy.yml
@@ -18,6 +18,9 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
 
+    env:
+      BUNDLE_ONLY: 'deploy'
+
     steps:
       - name: Check out repository code
         uses: actions/checkout@v4
@@ -38,9 +41,8 @@ jobs:
 
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
-
-      - name: Install kamal
-        run: gem install kamal -v 1.3.0
+        with:
+          bundler-cache: true
 
       - name: Set up Docker Buildx for cache
         uses: docker/setup-buildx-action@v3
@@ -49,4 +51,4 @@ jobs:
         uses: crazy-max/ghaction-github-runtime@v3
 
       - name: Run deploy command
-        run: kamal deploy -d staging
+        run: bundle exec kamal deploy -d staging

--- a/Gemfile
+++ b/Gemfile
@@ -19,13 +19,16 @@ gem 'serviceworker-rails', '~> 0.6'
 gem 'stimulus-rails', '~> 1.3'
 gem 'turbo-rails', '~> 2.0'
 
+group :development, :deploy do
+  gem 'kamal', '~> 1.5'
+end
+
 group :development, :test do
   gem 'byebug', '~> 11.0', platforms: [:mri, :mingw, :x64_mingw]
   gem 'rspec-rails', '~> 6.1'
 end
 
 group :development do
-  gem 'kamal', '~> 1.5'
   gem "letter_opener", "~> 1.10"
   gem 'rubocop', '~> 1.63'
   gem 'rubocop-performance', '~> 1.21', require: false


### PR DESCRIPTION
## Motivation

We were harcoding `kamal`'s version in the deploy gh workflows, which mean that we have to manually update the version from time to time – we were already behind as the latest `kamal` version at the moment of this writing is `1.5.2` and we were using `1.3.0`.

## Details

This PRs removes the hardcoding of `kamal`'s version and uses the version specified in the `Gemfile`, which is constantly updated by `dependabot`. It also declares a new `deploy` bundler group and uses the `BUNDLE_ONLY` environment flag to install only the gems listed on that group – which is just `kamal` – so that we don't have to unnecessarily update all the our dependencies.

