### PR TITLE
Añadir soporte para previas  'Actividad de instancia aprobada/reprobada'

### DIFF
--- a/app/helpers/subjects_helper.rb
+++ b/app/helpers/subjects_helper.rb
@@ -30,4 +30,8 @@ module SubjectsHelper
   def display_enrollment_prerequisite(enrollment_prerequisite)
     "inscripto a #{display_name(enrollment_prerequisite.approvable_needed.subject)}"
   end
+
+  def display_activity_prerequisite(activity_prerequisite)
+    "aprobado/reprobado #{display_subject_prerequisite(activity_prerequisite)}"
+  end
 end

--- a/app/models/activity_prerequisite.rb
+++ b/app/models/activity_prerequisite.rb
@@ -2,10 +2,6 @@ class ActivityPrerequisite < Prerequisite
   belongs_to :approvable_needed, class_name: "Approvable"
 
   def met?(approved_approvable_ids)
-    if approvable_needed.is_exam?
-      approved_approvable_ids.include?(approvable_needed.subject.course.id)
-    else
-      true
-    end
+    approvable_needed.available?(approved_approvable_ids)
   end
 end

--- a/app/models/activity_prerequisite.rb
+++ b/app/models/activity_prerequisite.rb
@@ -1,0 +1,11 @@
+class ActivityPrerequisite < Prerequisite
+  belongs_to :approvable_needed, class_name: "Approvable"
+
+  def met?(approved_approvable_ids)
+    if approvable_needed.is_exam?
+      approved_approvable_ids.include?(approvable_needed.subject.course.id)
+    else
+      true
+    end
+  end
+end

--- a/app/services/tree_preloader.rb
+++ b/app/services/tree_preloader.rb
@@ -32,6 +32,8 @@ class TreePreloader
       prereq.association(:approvable_needed).target = approvable_by_id[prereq.approvable_needed_id]
     when EnrollmentPrerequisite
       prereq.association(:approvable_needed).target = approvable_by_id[prereq.approvable_needed_id]
+    when ActivityPrerequisite
+      prereq.association(:approvable_needed).target = approvable_by_id[prereq.approvable_needed_id]
     else
       raise "Unknown prerequisite type: #{prereq.class}"
     end

--- a/app/services/yml_loader.rb
+++ b/app/services/yml_loader.rb
@@ -100,6 +100,7 @@ module YmlLoader
       when 'all' then SubjectPrerequisite.new(approvable_needed: subject.exam || subject.course)
       when 'course_enrollment' then EnrollmentPrerequisite.new(approvable_needed: subject.course)
       when 'exam_enrollment' then EnrollmentPrerequisite.new(approvable_needed: subject.exam)
+      when 'exam_activity' then ActivityPrerequisite.new(approvable_needed: subject.exam)
       else raise "Unknown approvable needed: #{prerequisite["needs"]}"
       end
 

--- a/app/views/activity_prerequisites/_activity_prerequisite.html.erb
+++ b/app/views/activity_prerequisites/_activity_prerequisite.html.erb
@@ -1,0 +1,9 @@
+<%= link_to subject_path(activity_prerequisite.approvable_needed.subject), class: 'mdc-deprecated-list-item' do %>
+  <span class="mdc-deprecated-list-item__ripple"></span>
+  <span class="mdc-deprecated-list-item__text">
+    <%= negative ? "No haber" : "Haber" %>
+    <%= display_activity_prerequisite(activity_prerequisite) %>
+  </span>
+
+  <%= render 'prerequisites/met_checkmark', prerequisite: activity_prerequisite, negative: %>
+<% end %>

--- a/db/data/scraped_prerequisites.yml
+++ b/db/data/scraped_prerequisites.yml
@@ -458,20 +458,8 @@
     logical_operator: or
     operands:
     - type: subject
-      subject_needed_code: CP6
-      subject_needed_name: ANALISIS MATEMATICO II
-      needs: exam
-    - type: subject
-      subject_needed_code: CP25
-      subject_needed_name: ANALISIS MATEMATICO II (P. 74)
-      needs: exam
-    - type: subject
       subject_needed_code: 1025P
       subject_needed_name: CREDITOS NO ACUM PROB Y EST.
-      needs: exam
-    - type: subject
-      subject_needed_code: 1025T
-      subject_needed_name: CREDITOS NO ACUM PROBABILIDAD Y ESTADISTICA
       needs: exam
     - type: subject
       subject_needed_code: '1025'
@@ -480,6 +468,17 @@
     - type: subject
       subject_needed_code: '1075'
       subject_needed_name: PROBABILIDAD Y ESTADISTICA
+      needs: exam
+  - type: logical
+    logical_operator: or
+    operands:
+    - type: subject
+      subject_needed_code: '1443'
+      subject_needed_name: ARQUITECTURA DE COMPUTADORAS
+      needs: exam
+    - type: subject
+      subject_needed_code: 1443P
+      subject_needed_name: CREDITOS NO ACUM. CON ARQUITECTURA DE COMPUTADORAS
       needs: exam
   subject_code: '1438'
   is_exam: false
@@ -7781,6 +7780,31 @@
       needs: course
   subject_code: '1773'
   is_exam: false
+- type: logical
+  logical_operator: not
+  operands:
+  - type: logical
+    logical_operator: or
+    operands:
+    - type: subject
+      subject_needed_code: SRN22
+      subject_needed_name: COMPRENSIÓN LECTORA DE INGLÉS
+      needs: exam
+    - type: subject
+      subject_needed_code: 816EU
+      subject_needed_name: INGLES CIENTÍFICO
+      needs: exam
+  subject_code: INFU1
+  is_exam: false
+- type: logical
+  logical_operator: and
+  operands:
+  - type: subject
+    needs: course
+    subject_needed_code: INFU1
+    subject_needed_name: INGLES PARA FINES UNIVERSITARIOS I
+  subject_code: INFU1
+  is_exam: true
 - type: logical
   logical_operator: and
   operands:
@@ -17767,6 +17791,56 @@
       subject_needed_name: GEOMETRIA Y ALGEBRA LINEAL 1 (ANUAL)
       needs: all
   subject_code: '1233'
+  is_exam: false
+- type: logical
+  logical_operator: and
+  operands:
+  - type: logical
+    logical_operator: not
+    operands:
+    - type: subject
+      needs: all
+      subject_needed_code: '2217'
+      subject_needed_name: TUTORIAS ENTRE PARES 2
+  - type: logical
+    logical_operator: not
+    operands:
+    - type: subject
+      needs: all
+      subject_needed_code: '2216'
+      subject_needed_name: TUTORIAS ENTRE PARES 1
+  - type: logical
+    logical_operator: or
+    operands:
+    - type: subject
+      needs: exam_activity
+      subject_needed_code: '1151'
+      subject_needed_name: FISICA 1
+    - type: logical
+      logical_operator: and
+      operands:
+      - type: subject
+        subject_needed_code: '1061'
+        subject_needed_name: CALCULO DIF. E INTEGRAL EN UNA VARIABLE
+        needs: exam
+      - type: subject
+        subject_needed_code: '1062'
+        subject_needed_name: CALCULO DIF. E INTEGRAL EN VARIAS VARIABLES
+        needs: course
+    - type: logical
+      logical_operator: and
+      operands:
+      - type: subject
+        subject_needed_code: '1030'
+        subject_needed_name: GEOMETRIA Y ALGEBRA LINEAL 1
+        needs: exam
+      - type: subject
+        subject_needed_code: '1031'
+        subject_needed_name: GEOMETRIA Y ALGEBRA LINEAL 2
+        needs: course
+  - type: credits
+    credits: 55
+  subject_code: '5005'
   is_exam: false
 - type: logical
   logical_operator: and

--- a/db/data/scraped_subjects.yml
+++ b/db/data/scraped_subjects.yml
@@ -3305,6 +3305,18 @@ CH8:
   credits: 8
   has_exam: false
   subject_group: '5265'
+INFU1:
+  code: INFU1
+  name: INGLES PARA FINES UNIVERSITARIOS I
+  credits: 8
+  has_exam: true
+  subject_group: '3582'
+'5005':
+  code: '5005'
+  name: TUTORIAS ENTRE PARES ACADEMICAS PROGRESA/FING
+  credits: 8
+  has_exam: false
+  subject_group: '3582'
 '1236':
   code: '1236'
   name: SEMINARIO SOBRE ENCUENTROS ENTRE ARTE Y TECNOLOGIAS
@@ -3321,7 +3333,7 @@ SRN22:
   code: SRN22
   name: COMPRENSIÓN LECTORA DE INGLÉS
   credits: 8
-  has_exam: false
+  has_exam: true
   subject_group: '3582'
 SRN25:
   code: SRN25
@@ -3363,7 +3375,7 @@ AT021:
   code: 816EU
   name: INGLES CIENTÍFICO
   credits: 4
-  has_exam: false
+  has_exam: true
   subject_group: '3582'
 2107A:
   code: 2107A
@@ -3427,7 +3439,7 @@ GP4:
   subject_group: '3582'
 '1438':
   code: '1438'
-  name: APLICACION DE TEORIA DE LA INF.AL PROC.DE IMAG.
+  name: APLICACIONES DE TEORIA DE LA INFORMACION AL PROC. DE IMAG.
   credits: 6
   has_exam: false
   subject_group: '3582'
@@ -3551,6 +3563,12 @@ C402:
   credits: 0
   has_exam: true
   subject_group:
+1443P:
+  code: 1443P
+  name: CREDITOS NO ACUM. CON ARQUITECTURA DE COMPUTADORAS
+  credits: 0
+  has_exam: true
+  subject_group:
 107L:
   code: 107L
   name: CALCULO 1
@@ -3596,12 +3614,6 @@ MA09:
 R101:
   code: R101
   name: GEOMETRIA Y ALGEBRA LINEAL
-  credits: 0
-  has_exam: true
-  subject_group:
-1443P:
-  code: 1443P
-  name: CREDITOS NO ACUM. CON ARQUITECTURA DE COMPUTADORAS
   credits: 0
   has_exam: true
   subject_group:

--- a/lib/scraper/prerequisites_tree_page.rb
+++ b/lib/scraper/prerequisites_tree_page.rb
@@ -45,6 +45,8 @@ module Scraper
       when 'Inscripción a Examen de la U.C.B:' then subject_prerequisite(content, 'exam_enrollment')
       # U.C.B Aprobada: 1424 - ARQUITECTURA DE COMPUTADORES 1
       when 'U.C.B Aprobada:' then subject_prerequisite(content, 'all')
+      # Actividad Examen aprobada/reprobada en la U.C.B: 1151 - FISICA 1
+      when 'Actividad Examen aprobada/reprobada en la U.C.B:' then subject_prerequisite(content, 'exam_activity')
       else raise "Unknown node title: #{title}"
       end
     end

--- a/spec/models/activity_prerequisite_spec.rb
+++ b/spec/models/activity_prerequisite_spec.rb
@@ -2,32 +2,25 @@ require 'rails_helper'
 
 RSpec.describe ActivityPrerequisite, type: :model do
   describe '#met?' do
-    context 'when approvable needed is an exam' do
-      context "when the course of the approvable needed's subject is approved" do
-        it 'returns true' do
-          subject_needed = create :subject, :with_exam
-          prerequisite = create :activity_prerequisite, approvable_needed: subject_needed.exam
+    context 'when the approvable needed is available' do
+      it 'returns true' do
+        subject_needed = create :subject, :with_exam
+        create :credits_prerequisite, approvable: subject_needed.exam, credits_needed: 5
 
-          expect(prerequisite.met?([subject_needed.course.id])).to be_truthy
-        end
-      end
+        prerequisite = create :activity_prerequisite, approvable_needed: subject_needed.exam
 
-      context "when the the course of the approvable needed's subject is not approved" do
-        it 'returns false' do
-          subject_needed = create :subject, :with_exam
-          prerequisite = create :activity_prerequisite, approvable_needed: subject_needed.exam
-
-          expect(prerequisite.met?([])).to be_falsey
-        end
+        expect(prerequisite.met?([create(:subject, credits: 5).course])).to be_truthy
       end
     end
 
-    context 'when approvable needed is a course' do
-      it 'returns true' do
-        subject_needed = create :subject
-        prerequisite = create :activity_prerequisite, approvable_needed: subject_needed.course
+    context 'when the approvable needed is not available' do
+      it 'returns false' do
+        subject_needed = create :subject, :with_exam
+        create :credits_prerequisite, approvable: subject_needed.exam, credits_needed: 5
 
-        expect(prerequisite.met?([])).to be_truthy
+        prerequisite = create :activity_prerequisite, approvable_needed: subject_needed.exam
+
+        expect(prerequisite.met?([])).to be_falsey
       end
     end
   end

--- a/spec/models/activity_prerequisite_spec.rb
+++ b/spec/models/activity_prerequisite_spec.rb
@@ -1,0 +1,34 @@
+require 'rails_helper'
+
+RSpec.describe ActivityPrerequisite, type: :model do
+  describe '#met?' do
+    context 'when approvable needed is an exam' do
+      context "when the course of the approvable needed's subject is approved" do
+        it 'returns true' do
+          subject_needed = create :subject, :with_exam
+          prerequisite = create :activity_prerequisite, approvable_needed: subject_needed.exam
+
+          expect(prerequisite.met?([subject_needed.course.id])).to be_truthy
+        end
+      end
+
+      context "when the the course of the approvable needed's subject is not approved" do
+        it 'returns false' do
+          subject_needed = create :subject, :with_exam
+          prerequisite = create :activity_prerequisite, approvable_needed: subject_needed.exam
+
+          expect(prerequisite.met?([])).to be_falsey
+        end
+      end
+    end
+
+    context 'when approvable needed is a course' do
+      it 'returns true' do
+        subject_needed = create :subject
+        prerequisite = create :activity_prerequisite, approvable_needed: subject_needed.course
+
+        expect(prerequisite.met?([])).to be_truthy
+      end
+    end
+  end
+end

--- a/spec/models/activity_prerequisite_spec.rb
+++ b/spec/models/activity_prerequisite_spec.rb
@@ -5,19 +5,17 @@ RSpec.describe ActivityPrerequisite, type: :model do
     context 'when the approvable needed is available' do
       it 'returns true' do
         subject_needed = create :subject, :with_exam
-        create :credits_prerequisite, approvable: subject_needed.exam, credits_needed: 5
-
+        allow(subject_needed.exam).to receive(:available?).and_return(true)
         prerequisite = create :activity_prerequisite, approvable_needed: subject_needed.exam
 
-        expect(prerequisite.met?([create(:subject, credits: 5).course])).to be_truthy
+        expect(prerequisite.met?([])).to be_truthy
       end
     end
 
     context 'when the approvable needed is not available' do
       it 'returns false' do
         subject_needed = create :subject, :with_exam
-        create :credits_prerequisite, approvable: subject_needed.exam, credits_needed: 5
-
+        allow(subject_needed.exam).to receive(:available?).and_return(false)
         prerequisite = create :activity_prerequisite, approvable_needed: subject_needed.exam
 
         expect(prerequisite.met?([])).to be_falsey

--- a/test/factories/prerequisites.rb
+++ b/test/factories/prerequisites.rb
@@ -30,4 +30,8 @@ FactoryBot.define do
       logical_operator { "at_least" }
     end
   end
+
+  factory :activity_prerequisite do
+    approvable_needed factory: :exam
+  end
 end


### PR DESCRIPTION
## Motivación

Hace unos días agregaron a Bedelías la materia `5005 - TUTORIAS ENTRE PARES ACADEMICAS PROGRESA/FING` que tiene una previa particular:

> Actividad Examen aprobada/reprobada de la U.C.B: 1151 - FISICA 1

![image](https://github.com/cedarcode/mi_carrera/assets/46354312/84a83e14-28d4-4bdf-89c9-974156905af7)

Hasta ahora no teníamos ningún caso de este tipo de previas por lo que este PR tiene como objetivo soportarlas.

## Detalles

Para esto, agregamos un nuevo tipo de modelo de previas `ActivityPrerequisite` que se cumple en los siguientes casos:

- Si la instancia que estamos chequeando es un examen:
  - Entonces se cumple si el curso de ese examen fue aprobado
- Si la instancia que estamos chequeando es un curso:
  - Siempre se cumple
  
(Nótese que por ahora solo hay un caso de este tipo de previa el cual se evalúa sobre un examen)

Adjunto captura de pantalla de cómo se ve este tipo de previa en la app:

<img width="497" alt="image" src="https://github.com/cedarcode/mi_carrera/assets/46354312/0c43b317-5b50-413b-9f30-a9346030e820">
