### PR TITLE
Añadir Github Actions para cargar los yaml a la base de datos

### DIFF
--- a/.github/workflows/production_load_yaml.yml
+++ b/.github/workflows/production_load_yaml.yml
@@ -20,4 +20,4 @@ jobs:
           bundler-cache: true
 
       - name: Run load_yaml task
-        run: bundle exec kamal app exec 'bin/rails load_yml' -d production --reuse
+        run: bundle exec kamal app exec 'bin/rails load_yml' -d production --reuse --primary

--- a/.github/workflows/production_load_yaml.yml
+++ b/.github/workflows/production_load_yaml.yml
@@ -1,0 +1,23 @@
+name: Production Load YAML
+
+on:
+  workflow_dispatch:
+
+jobs:
+  load_yaml:
+    runs-on: ubuntu-latest
+
+    env:
+      BUNDLE_ONLY: 'deploy'
+
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@v4
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: true
+
+      - name: Run load_yaml task
+        run: bundle exec kamal app exec 'bin/rails load_yml' -d production

--- a/.github/workflows/production_load_yaml.yml
+++ b/.github/workflows/production_load_yaml.yml
@@ -20,4 +20,4 @@ jobs:
           bundler-cache: true
 
       - name: Run load_yaml task
-        run: bundle exec kamal app exec 'bin/rails load_yml' -d production
+        run: bundle exec kamal app exec 'bin/rails load_yml' -d production --reuse

--- a/.github/workflows/staging_load_yaml.yml
+++ b/.github/workflows/staging_load_yaml.yml
@@ -1,0 +1,23 @@
+name: Staging Load YAML
+
+on:
+  workflow_dispatch:
+
+jobs:
+  load_yaml:
+    runs-on: ubuntu-latest
+
+    env:
+      BUNDLE_ONLY: 'deploy'
+
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@v4
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: true
+
+      - name: Run load_yaml task
+        run: bundle exec kamal app exec 'bin/rails load_yml' -d staging

--- a/.github/workflows/staging_load_yaml.yml
+++ b/.github/workflows/staging_load_yaml.yml
@@ -20,4 +20,4 @@ jobs:
           bundler-cache: true
 
       - name: Run load_yaml task
-        run: bundle exec kamal app exec 'bin/rails load_yml' -d staging
+        run: bundle exec kamal app exec 'bin/rails load_yml' -d staging --reuse

--- a/.github/workflows/staging_load_yaml.yml
+++ b/.github/workflows/staging_load_yaml.yml
@@ -20,4 +20,4 @@ jobs:
           bundler-cache: true
 
       - name: Run load_yaml task
-        run: bundle exec kamal app exec 'bin/rails load_yml' -d staging --reuse
+        run: bundle exec kamal app exec 'bin/rails load_yml' -d staging --reuse --primary


### PR DESCRIPTION
Hoy en día, la task para cargar los yaml a la base de datos se corre de forma manual. La idea es agregar estas Github actions para que sea más sencillo y accessible el cargar las materias.