### PR TITLE
Añadir job al CI para escanear vulnerabilidades en las dependencias de JS

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -3,6 +3,21 @@ name: Ruby
 on: push
 
 jobs:
+  scan_js:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@v4
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: true
+
+      - name: Scan for security vulnerabilities in JavaScript dependencies
+        run: bin/importmap audit
+
   test:
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
La idea es escanear las vulnerabilidades constantemente para estar al tanto de cualquier vulnerabilidad que pueda surgir en una dependencia.

Para esto simplemente necesitamos correr `bin/importmap audit` en el CI.