### PR TITLE
Correr `brakeman` en el CI

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -3,6 +3,21 @@ name: Ruby
 on: push
 
 jobs:
+  scan_ruby:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@v4
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: true
+
+      - name: Scan for common Rails security vulnerabilities using static analysis
+        run: bin/brakeman --no-pager
+
   test:
     runs-on: ubuntu-latest
 

--- a/Gemfile
+++ b/Gemfile
@@ -23,6 +23,7 @@ group :development, :deploy do
 end
 
 group :development, :test do
+  gem "brakeman", "~> 6.1"
   gem 'byebug', '~> 11.0', platforms: [:mri, :mingw, :x64_mingw]
   gem 'rspec-rails', '~> 6.1'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -81,6 +81,8 @@ GEM
     bindex (0.8.1)
     bootsnap (1.18.4)
       msgpack (~> 1.2)
+    brakeman (6.1.2)
+      racc
     builder (3.3.0)
     byebug (11.1.3)
     capybara (3.40.0)
@@ -382,6 +384,7 @@ PLATFORMS
 
 DEPENDENCIES
   bootsnap (~> 1.18)
+  brakeman (~> 6.1)
   byebug (~> 11.0)
   capybara (~> 3.40)
   devise (~> 4.9)

--- a/bin/brakeman
+++ b/bin/brakeman
@@ -1,0 +1,7 @@
+#!/usr/bin/env ruby
+require "rubygems"
+require "bundler/setup"
+
+ARGV.unshift("--ensure-latest")
+
+load Gem.bin_path("brakeman", "brakeman")


### PR DESCRIPTION
Brakeman es una buena forma de prevenir vulnerabilidades. Corriéndolo en el CI nos aseguramos de prevenir vulnerabilidades antes de mandar el código a producción.