### PR TITLE
Remover deprecation warning acerca de definir `enums` con keyword arguments

### DIFF
--- a/app/models/subject.rb
+++ b/app/models/subject.rb
@@ -27,7 +27,7 @@ class Subject < ApplicationRecord
     revalid
   ]
 
-  enum :category, CATEGORIES.index_with { |category| category.to_s }
+  enum :category, CATEGORIES.index_with(&:to_s)
 
   scope :ordered_by_category, -> { in_order_of(:category, CATEGORIES) }
   scope :ordered_by_category_and_name, -> { ordered_by_category.order(:name) }

--- a/app/models/subject.rb
+++ b/app/models/subject.rb
@@ -27,7 +27,7 @@ class Subject < ApplicationRecord
     revalid
   ]
 
-  enum category: CATEGORIES.index_with { |category| category.to_s }
+  enum :category, CATEGORIES.index_with { |category| category.to_s }
 
   scope :ordered_by_category, -> { in_order_of(:category, CATEGORIES) }
   scope :ordered_by_category_and_name, -> { ordered_by_category.order(:name) }


### PR DESCRIPTION
La siguiente deprecation warning estaba saltando después de actualizar a Rails 7.2.0:

```
DEPRECATION WARNING: Defining enums with keyword arguments is deprecated and will be removed
in Rails 8.0. Positional arguments should be used instead:

enum :category, {:first_semester=>"first_semester", :second_semester=>"second_semester", :third_semester=>"third_semester", :fourth_semester=>"fourth_semester", :fifth_semester=>"fifth_semester", :sixth_semester=>"sixth_semester", :seventh_semester=>"seventh_semester", :eighth_semester=>"eighth_semester", :nineth_semester=>"nineth_semester", :optional=>"optional", :extension_module=>"extension_module", :outside_montevideo=>"outside_montevideo", :inactive=>"inactive", :revalid=>"revalid"}
 (called from <class:Subject> at /home/runner/work/mi_carrera/mi_carrera/app/models/subject.rb:30)
 ```
 
 Este PR la arregla siguiendo la recomendación: usar positional arguments.