### PR TITLE
Prevenir que el CI falle si brakeman no está en su última versión

### DIFF
--- a/bin/brakeman
+++ b/bin/brakeman
@@ -2,6 +2,4 @@
 require "rubygems"
 require "bundler/setup"
 
-ARGV.unshift("--ensure-latest")
-
 load Gem.bin_path("brakeman", "brakeman")


### PR DESCRIPTION
El CI está fallando porque brakeman está desactualizado:

```
Run bin/brakeman --no-pager
Brakeman 6.1.2 is not the latest version 6.2.1
```

Evitemos bloquear a las personas para que no puedan hacer merge simplemente porque brakeman está desactualizado. Actualizamos nuestras dependencias cada semana, así que tendemos a estar actualizados, por lo tanto, incluso si no tenemos la última versión, sabemos que vamos a estar corriendo una release que tiene, como máximo, una semana de antigüedad, lo cual debería ser suficiente para detectar la mayoría de las vulnerabilidades.

Si no, nos vamos a dar cuenta bastante rápido ya que brakeman se va a actualizar en poco tiempo y el CI va a fallar si detecta una vulnerabilidad.