### PR TITLE
Use Github App token to update scraped data

### DIFF
--- a/.github/workflows/scraper.yml
+++ b/.github/workflows/scraper.yml
@@ -1,19 +1,32 @@
 name: Scraper
+
 on:
   schedule:
     - cron:  '0 5 * * MON'
   workflow_dispatch:
+
 jobs:
   scrape:
     runs-on: ubuntu-latest
     steps:
+    - name: Generate a token
+      id: generate-token
+      uses: actions/create-github-app-token@v1
+      with:
+        app-id: ${{ secrets.SCRAPER_APP_ID }}
+        private-key: ${{ secrets.SCRAPER_APP_PRIVATE_KEY }}
+
     - uses: actions/checkout@v4
+      with:
+        token: ${{ steps.generate-token.outputs.token }}
+
     - uses: ruby/setup-ruby@v1
       with:
         bundler-cache: true
+
     - name: Run scraper
       env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        GH_TOKEN: ${{ steps.generate-token.outputs.token }}
       run: |
         bundle exec rake scraper
         sed -i -e 's/ $//' db/data/*.yml


### PR DESCRIPTION
El `GITHUB_TOKEN` que viene por default hace que no se ejecuten otros workflows a partir de eventos que se crean por ese token (https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/triggering-a-workflow#triggering-a-workflow-from-a-workflow). Por ej. el PR que crea esta acción, no ejecuta los tests que deberían pasar en cada push

La solución sugerida es usar un token de una Github App