### PR TITLE
Increase Kamal's number of `max_attempts`

### DIFF
--- a/config/deploy.yml
+++ b/config/deploy.yml
@@ -17,7 +17,7 @@ ssh:
 
 healthcheck:
   interval: 30s
-  max_attempts: 8
+  max_attempts: 14
 
 builder:
   multiarch: false


### PR DESCRIPTION
## Motivación

Estamos teniendo un problema para deployar donde cada deploy, después de iniciar el nuevo container con la nueva versión de la aplicación, no lograba eliminar el container viejo ya que Kamal alcanzaba el número máximo de intentos antes de que el container fuese marcado como `unhealthy` por Docker, lo que hace que el deploy falle.

Después de investigar un poco, nos dimos cuenta de que el problema es que cuando aumentamos el `interval` de los healthchecks, no le estábamos dando a Docker suficiente tiempo para marcar el container como `unhealthy` antes de que Kamal alcanzara el número maximo de intentos.

Resulta que Docker marca el container como `unhealthy` después de tres healthchecks fallidas consecutivas. En nuestro caso, donde realizamos un healthcheck cada 30s, significa que tienen que pasar al menos 90s para que Docker marque el container como `unhealthy`.

Por otro lado, al deployar, Kamal verifica si el servicio está `healthy` por, cómo máximo, `max_attempts` veces, donde cada healthcheck está separado por un intervalo creciente que comienza con 1 segundo. En nuestro caso, establecimos `max_attempts` a `8`, por lo que le lleva a Kamal `1+2+3+...+7=28s` alcanzar su límite de intentos.

Por lo tanto, el problema es que Kamal alcanza su límite de intentos antes de que Docker siquiera intente una tercer healthcheck, por lo tanto, el container viejo no es marcado como `unhealthy` lo cual hace que el deploy falle.

## Detalles

Este PR soluciona este problema aumentando el `max_attempts` a `14`, lo que significa que le va a llevar `1+2+...+12+13=91s` a Kamal hasta alcanzar su límite, lo que debería ser suficiente tiempo para que ocurran tres healthchecks fallidas de Docker y por lo tanto se marque el container como `unhealthy` correctamente.