### PR TITLE
Actualizar `kamal` a `v2.1.0`

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -138,7 +138,7 @@ GEM
     json (2.7.2)
     jwt (2.9.0)
       base64
-    kamal (2.0.0)
+    kamal (2.1.0)
       activesupport (>= 7.0)
       base64 (~> 0.2)
       bcrypt_pbkdf (~> 1.0)

--- a/config/deploy.production.yml
+++ b/config/deploy.production.yml
@@ -1,5 +1,8 @@
 proxy:
-  host: micarrera.uy,fing.micarrera.uy,www.micarrera.uy
+  hosts:
+    - micarrera.uy
+    - fing.micarrera.uy
+    - www.micarrera.uy
   app_port: 3000
   ssl: true
 

--- a/config/deploy.production.yml
+++ b/config/deploy.production.yml
@@ -1,6 +1,7 @@
 proxy:
   host: micarrera.uy,fing.micarrera.uy,www.micarrera.uy
   app_port: 3000
+  ssl: true
 
 servers:
   web:

--- a/config/deploy.staging.yml
+++ b/config/deploy.staging.yml
@@ -1,6 +1,7 @@
 proxy:
   host: staging.micarrera.uy
   app_port: 3000
+  ssl: true
 
 servers:
   web:


### PR DESCRIPTION
## Motivación

`kamal` `v2.0` no soporta [ACME http-01 challenges](https://letsencrypt.org/docs/challenge-types/#http-01-challenge) para validar los certificados de SSL. Este tipo de challenge es necesario para  para poder activar el modo Full encryption de Cloudflare.

`kamal` `v2.1` [añade soporte para este tipo de challenge](https://github.com/basecamp/kamal/pull/1010), por lo que ahora podemos configurar `kamal-proxy` para que use `ssl`. 