### PR TITLE
[infra] Configure `Puma` to start 3 threads

### DIFF
--- a/config/puma.rb
+++ b/config/puma.rb
@@ -20,7 +20,7 @@
 # Any libraries that use a connection pool or another resource pool should
 # be configured to provide at least as many connections as the number of
 # threads. This includes Active Record's `pool` parameter in `database.yml`.
-threads_count = ENV.fetch("RAILS_MAX_THREADS", 5)
+threads_count = ENV.fetch("RAILS_MAX_THREADS", 3)
 threads threads_count, threads_count
 
 # Specifies the `port` that Puma will listen on to receive requests; default is 3000.


### PR DESCRIPTION
## Summary
[Rails 7.2](https://github.com/rails/rails/blob/v7.2.0/railties/lib/rails/generators/rails/app/templates/config/puma.rb.tt#L23) sets the default max threads to 3.