### PR TITLE
Añadir restricción sobre las mínimas versiones de navegadores soportadas

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,4 +1,7 @@
 class ApplicationController < ActionController::Base
+  # Only allow modern browsers supporting webp images, web push, badges, import maps, CSS nesting, and CSS :has.
+  allow_browser versions: :modern
+
   helper_method :current_student
 
   private


### PR DESCRIPTION
Este PR añade una llamada a `allow_browser` en nuestro `ApplicationController` para permitir que únicamente se pueda usar la app con navegadores modernos.