### PR TITLE
Arreglar helpers de Devise

### DIFF
--- a/test/application_controller_test_case.rb
+++ b/test/application_controller_test_case.rb
@@ -2,4 +2,9 @@ require "test_helper"
 
 class ApplicationControllerTestCase < ActionDispatch::IntegrationTest
   include Devise::Test::IntegrationHelpers
+
+  # TODO: remove when Devise fixes https://github.com/heartcombo/devise/issues/5705
+  setup do
+    Rails.application.reload_routes_unless_loaded
+  end
 end


### PR DESCRIPTION
## Motivación

Los tests se nos están rompiendo localmente con el siguiente error cuando se llama al helper de `sign_in` de `Devise`:

```
Error:
UserOnboardingsControllerTest#test_patch_update_should_return_ok_when_signed_in:
RuntimeError: Could not find a valid mapping for #<User id: 6, uid: nil, provider: nil, email: [FILTERED], created_at: "2024-11-20 21:33:37.638546000 +0000", updated_at: "2024-11-20 21:33:37.638546000 +0000", approvals: [], welcome_banner_viewed: false>
    test/controllers/user_onboardings_controller_test.rb:9:in `block in <class:UserOnboardingsControllerTest>'
```

El error parece estar relacionado con https://github.com/heartcombo/devise/issues/5705.

# Detalles

Al parecer, una forma sugerida de solucionarlo es llamar a `Rails.application.reload_routes_unless_loaded` antes de cada test.