### PR TITLE
Add rate limiting to incoming requests

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,5 +1,6 @@
 class ApplicationController < ActionController::Base
   helper_method :current_student
+  rate_limit to: 20, within: 10.seconds
 
   private
 


### PR DESCRIPTION
## What
- [x] Limitar requests a 20 cada 10 segundos en `ApplicationController`, utilizando el metodo `rate_limit` de rails.

## Observaciones
- Por defecto el metodo `rate_limit` asocia el limite a la IP de la que se hace la request.
- De excederse el limite el error es un `429`.

## Links 
- [Ticket](https://github.com/orgs/cedarcode/projects/3?pane=issue&itemId=90448662)
- [Rails 7.2 Adds Rate Limiting to Action Controller](https://blog.saeloun.com/2024/04/01/rails-7-2-adds-rate-limiting-to-action-controller/)
