### PR TITLE
Fix deploy

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,7 @@ FROM base AS build
 
 # Install packages needed to build gems
 RUN apt-get update -qq && \
-    apt-get install --no-install-recommends -y build-essential git libpq-dev pkg-config && \
+    apt-get install --no-install-recommends -y build-essential git libpq-dev libyaml-dev pkg-config && \
     rm -rf /var/lib/apt/lists /var/cache/apt/archives
 
 # Install application gems


### PR DESCRIPTION
## Summary
This PR attempts to fix the deployment by installing the `libyaml-dev` package.

## Why?
In the latest `Ruby` images, the `libyaml-dev` package [was removed](https://github.com/docker-library/ruby/pull/493/files#diff-8d7a21b017921bb88eaf71656b7b5767203db16e8126fc1e5ad2a9ba0bc542f5L37)

This package is needed to install `psych` gem

Also it [was added](https://github.com/rails/rails/pull/54237) to the Rails Dockerfile as one of the default packages to install.