### PR TITLE
Limitar intentos de login fallidos

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -50,6 +50,7 @@ Security:
 Rails/BulkChangeTable:
   Exclude:
     - 'db/migrate/20190321140119_add_validations.rb'
+    - 'db/migrate/20250121233816_add_lockable_to_devise.rb'
 
 Rails/LexicallyScopedActionFilter:
   Enabled: false

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -50,7 +50,6 @@ Security:
 Rails/BulkChangeTable:
   Exclude:
     - 'db/migrate/20190321140119_add_validations.rb'
-    - 'db/migrate/20250121233816_add_lockable_to_devise.rb'
 
 Rails/LexicallyScopedActionFilter:
   Enabled: false

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,6 +1,6 @@
 class User < ApplicationRecord
   devise :database_authenticatable, :registerable,
-         :recoverable, :rememberable, :validatable,
+         :recoverable, :rememberable, :validatable, :lockable,
          :omniauthable, omniauth_providers: [:google_oauth2]
 
   serialize :approvals, type: Array, coder: YAML

--- a/app/views/devise/mailer/reset_password_instructions.html.erb
+++ b/app/views/devise/mailer/reset_password_instructions.html.erb
@@ -1,59 +1,12 @@
-<style>
-  .content {
-    display: flex;
-    justify-content: center;
-    flex-direction: column;
-    align-items: center;
-  }
-
-  .email-text {
-    display: flex;
-    justify-content: center;
-    flex-direction: column;
-    align-items: start;
-  }
-
-  .center {
-    text-align: center;
-    width: 100%;
-  }
-
-  .button-container {
-    margin: 10px 0;
-    display: flex;
-    justify-content: center;
-    flex-direction: column;
-    align-items: center;
-    width: 100%;
-  }
-
-  .button {
-    background-color: #3869D4;
-    border: solid #3869D4;
-    border-width: 10px 18px;
-    display: inline-block;
-    color: #FFF;
-    text-decoration: none;
-    border-radius: 3px;
-    box-shadow: 0 2px 3px rgba(0, 0, 0, 0.16);
-    -webkit-text-size-adjust: none;
-    box-sizing: border-box;
-  }
-
-  p {
-    margin: 10px 0;
-  }
-</style>
-
-<div class='content'>
+<div class='mailer-content'>
   <div class='email-text'>
 
-    <h4 class='center'>MiCarrera</h4>
+    <h4 class='mailer-center'>MiCarrera</h4>
     <h2>Hola <%= @resource.email %>!</h2>
     <p>Alguien ha solicitado un enlace para cambiar su contraseña. Puede hacerlo a través del enlace de abajo.</p>
 
-    <div class='button-container'>
-      <%= link_to 'Restablecer Contraseña', edit_password_url(@resource, reset_password_token: @token), class: 'button' %>
+    <div class='mailer-button-container'>
+      <%= link_to 'Restablecer Contraseña', edit_password_url(@resource, reset_password_token: @token), class: 'mailer-button' %>
     </div>
 
     <p>Si no solicitó esto, ignore este correo electrónico.</p>

--- a/app/views/devise/mailer/unlock_instructions.html.erb
+++ b/app/views/devise/mailer/unlock_instructions.html.erb
@@ -1,0 +1,62 @@
+<style>
+  .content {
+    display: flex;
+    justify-content: center;
+    flex-direction: column;
+    align-items: center;
+  }
+
+  .email-text {
+    display: flex;
+    justify-content: center;
+    flex-direction: column;
+    align-items: start;
+  }
+
+  .center {
+    text-align: center;
+    width: 100%;
+  }
+
+  .button-container {
+    margin: 10px 0;
+    display: flex;
+    justify-content: center;
+    flex-direction: column;
+    align-items: center;
+    width: 100%;
+  }
+
+  .button {
+    background-color: #3869D4;
+    border: solid #3869D4;
+    border-width: 10px 18px;
+    display: inline-block;
+    color: #FFF;
+    text-decoration: none;
+    border-radius: 3px;
+    box-shadow: 0 2px 3px rgba(0, 0, 0, 0.16);
+    -webkit-text-size-adjust: none;
+    box-sizing: border-box;
+  }
+
+  p {
+    margin: 10px 0;
+  }
+</style>
+
+<div class='content'>
+  <div class='email-text'>
+    <h4 class='center'>MiCarrera</h4>
+    <h2>Hola <%= @resource.email %>!</h2>
+
+
+    <p>Tu cuenta fue bloqueada por una cantidad excesiva de intentos acceso fallidos.</p>
+
+    <p>Clickeá en el link de abajo para desbloquear tu cuenta, o espera una hora.</p>
+
+    <div class='button-container'>
+      <p><%= link_to 'Desbloquear mi cuenta', unlock_url(@resource, unlock_token: @token), class: 'button' %></p>
+    </div>
+  </div>
+</div>

--- a/app/views/devise/mailer/unlock_instructions.html.erb
+++ b/app/views/devise/mailer/unlock_instructions.html.erb
@@ -1,53 +1,6 @@
-<style>
-  .content {
-    display: flex;
-    justify-content: center;
-    flex-direction: column;
-    align-items: center;
-  }
-
-  .email-text {
-    display: flex;
-    justify-content: center;
-    flex-direction: column;
-    align-items: start;
-  }
-
-  .center {
-    text-align: center;
-    width: 100%;
-  }
-
-  .button-container {
-    margin: 10px 0;
-    display: flex;
-    justify-content: center;
-    flex-direction: column;
-    align-items: center;
-    width: 100%;
-  }
-
-  .button {
-    background-color: #3869D4;
-    border: solid #3869D4;
-    border-width: 10px 18px;
-    display: inline-block;
-    color: #FFF;
-    text-decoration: none;
-    border-radius: 3px;
-    box-shadow: 0 2px 3px rgba(0, 0, 0, 0.16);
-    -webkit-text-size-adjust: none;
-    box-sizing: border-box;
-  }
-
-  p {
-    margin: 10px 0;
-  }
-</style>
-
-<div class='content'>
+<div class='mailer-content'>
   <div class='email-text'>
-    <h4 class='center'>MiCarrera</h4>
+    <h4 class='mailer-center'>MiCarrera</h4>
     <h2>Hola <%= @resource.email %>!</h2>
 
 
@@ -55,8 +8,8 @@
 
     <p>Clickeá en el link de abajo para desbloquear tu cuenta, o espera una hora.</p>
 
-    <div class='button-container'>
-      <p><%= link_to 'Desbloquear mi cuenta', unlock_url(@resource, unlock_token: @token), class: 'button' %></p>
+    <div class='mailer-button-container'>
+      <p><%= link_to 'Desbloquear mi cuenta', unlock_url(@resource, unlock_token: @token), class: 'mailer-button' %></p>
     </div>
   </div>
 </div>

--- a/app/views/devise/mailer/unlock_instructions.html.erb
+++ b/app/views/devise/mailer/unlock_instructions.html.erb
@@ -3,8 +3,7 @@
     <h4 class='mailer-center'>MiCarrera</h4>
     <h2>Hola <%= @resource.email %>!</h2>
 
-
-    <p>Tu cuenta fue bloqueada por una cantidad excesiva de intentos acceso fallidos.</p>
+    <p>Tu cuenta fue bloqueada por una cantidad excesiva de intentos de acceso fallidos.</p>
 
     <p>Clickeá en el link de abajo para desbloquear tu cuenta, o espera una hora.</p>
 

--- a/app/views/layouts/mailer.html.erb
+++ b/app/views/layouts/mailer.html.erb
@@ -3,7 +3,50 @@
   <head>
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <style>
-      /* Email styles need to be inline */
+      .mailer-content {
+        display: flex;
+        justify-content: center;
+        flex-direction: column;
+        align-items: center;
+      }
+
+      .email-text {
+        display: flex;
+        justify-content: center;
+        flex-direction: column;
+        align-items: start;
+      }
+
+      .mailer-center {
+        text-align: center;
+        width: 100%;
+      }
+
+      .mailer-button-container {
+        margin: 10px 0;
+        display: flex;
+        justify-content: center;
+        flex-direction: column;
+        align-items: center;
+        width: 100%;
+      }
+
+      .mailer-button {
+        background-color: #3869D4;
+        border: solid #3869D4;
+        border-width: 10px 18px;
+        display: inline-block;
+        color: #FFF;
+        text-decoration: none;
+        border-radius: 3px;
+        box-shadow: 0 2px 3px rgba(0, 0, 0, 0.16);
+        -webkit-text-size-adjust: none;
+        box-sizing: border-box;
+      }
+
+      p {
+        margin: 10px 0;
+      }
     </style>
   </head>
 

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -206,7 +206,7 @@ Devise.setup do |config|
   # :time  = Re-enables login after a certain amount of time (see :unlock_in below)
   # :both  = Enables both strategies
   # :none  = No unlock strategy. You should handle unlocking by yourself.
-  config.unlock_strategy = :time
+  config.unlock_strategy = :both
 
   # Number of authentication tries before locking an account if lock_strategy
   # is failed attempts.

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -196,27 +196,27 @@ Devise.setup do |config|
   # Defines which strategy will be used to lock an account.
   # :failed_attempts = Locks an account after a number of failed attempts to sign in.
   # :none            = No lock strategy. You should handle locking by yourself.
-  # config.lock_strategy = :failed_attempts
+  config.lock_strategy = :failed_attempts
 
   # Defines which key will be used when locking and unlocking an account
-  # config.unlock_keys = [:email]
+  config.unlock_keys = [:email]
 
   # Defines which strategy will be used to unlock an account.
   # :email = Sends an unlock link to the user email
   # :time  = Re-enables login after a certain amount of time (see :unlock_in below)
   # :both  = Enables both strategies
   # :none  = No unlock strategy. You should handle unlocking by yourself.
-  # config.unlock_strategy = :both
+  config.unlock_strategy = :time
 
   # Number of authentication tries before locking an account if lock_strategy
   # is failed attempts.
-  # config.maximum_attempts = 20
+  config.maximum_attempts = 8
 
   # Time interval to unlock the account if :time is enabled as unlock_strategy.
-  # config.unlock_in = 1.hour
+  config.unlock_in = 1.hour
 
   # Warn on the last attempt before the account is locked.
-  # config.last_attempt_warning = true
+  config.last_attempt_warning = true
 
   # ==> Configuration for :recoverable
   #

--- a/config/locales/devise.es.yml
+++ b/config/locales/devise.es.yml
@@ -16,6 +16,8 @@ es:
         subject: "Email modificado"
       password_change:
         subject: "Contraseña modificada"
+      unlock_instructions:
+        subject: "Instrucciones para desbloquear"
     omniauth_callbacks:
       failure: 'No pudimos autentificar tu cuenta de %{kind} por la siguiente razón: "%{reason}".'
       success: "Te autentificaste correctamente con tu cuenta de %{kind}."

--- a/config/locales/devise.es.yml
+++ b/config/locales/devise.es.yml
@@ -7,6 +7,8 @@ es:
       timeout: "Tu sesión ha expirado. Inicia sesión nuevamente."
       unauthenticated: "Tienes que registrarte o iniciar sesión antes de continuar."
       unconfirmed: "Tienes que confirmar tu cuenta antes de continuar."
+      locked: "Tu cuenta está bloqueada por repetidos intentos de acceso fallidos. Luego de 1 hora podrás intentar nuevamente."
+      last_attempt: "Este es tu último intento de acceso antes de que tu cuenta sea bloqueada."
     mailer:
       reset_password_instructions:
         subject: "Instrucciones de cambio de contraseña"

--- a/config/locales/devise.es.yml
+++ b/config/locales/devise.es.yml
@@ -7,7 +7,7 @@ es:
       timeout: "Tu sesión ha expirado. Inicia sesión nuevamente."
       unauthenticated: "Tienes que registrarte o iniciar sesión antes de continuar."
       unconfirmed: "Tienes que confirmar tu cuenta antes de continuar."
-      locked: "Tu cuenta está bloqueada por repetidos intentos de acceso fallidos. Luego de 1 hora podrás intentar nuevamente."
+      locked: "Tu cuenta está bloqueada por repetidos intentos de acceso fallidos. Sigue las instrucciones en el email que te enviamos, o espera 1 hora."
       last_attempt: "Este es tu último intento de acceso antes de que tu cuenta sea bloqueada."
     mailer:
       reset_password_instructions:
@@ -38,6 +38,8 @@ es:
       signed_in: "Iniciaste sesión correctamente."
       signed_out: "Cerraste sesión correctamente."
       already_signed_out: "Se cerró sesión correctamente."
+    unlocks:
+      unlocked: "Tu cuenta ha sido desbloqueada. Por favor inicia sesión para continuar."
   errors:
     messages:
       already_confirmed: "ya fue confirmada. Intenta ingresar."

--- a/config/locales/devise.es.yml
+++ b/config/locales/devise.es.yml
@@ -7,8 +7,8 @@ es:
       timeout: "Tu sesión ha expirado. Inicia sesión nuevamente."
       unauthenticated: "Tienes que registrarte o iniciar sesión antes de continuar."
       unconfirmed: "Tienes que confirmar tu cuenta antes de continuar."
-      locked: "Tu cuenta está bloqueada por repetidos intentos de acceso fallidos. Sigue las instrucciones en el email que te enviamos, o espera 1 hora."
-      last_attempt: "Este es tu último intento de acceso antes de que tu cuenta sea bloqueada."
+      locked: "Tu cuenta fue bloqueada por demasiados intentos de acceso fallidos. Sigue las instrucciones en el email que te enviamos, o espera 1 hora."
+      last_attempt: "Tienes un intento más antes de que tu cuenta sea bloqueada."
     mailer:
       reset_password_instructions:
         subject: "Instrucciones de cambio de contraseña"
@@ -39,7 +39,7 @@ es:
       signed_out: "Cerraste sesión correctamente."
       already_signed_out: "Se cerró sesión correctamente."
     unlocks:
-      unlocked: "Tu cuenta ha sido desbloqueada. Por favor inicia sesión para continuar."
+      unlocked: "Tu cuenta ha sido desbloqueada. Ya puedes iniciar sesión."
   errors:
     messages:
       already_confirmed: "ya fue confirmada. Intenta ingresar."

--- a/db/migrate/20250121233816_add_lockable_to_devise.rb
+++ b/db/migrate/20250121233816_add_lockable_to_devise.rb
@@ -1,0 +1,8 @@
+class AddLockableToDevise < ActiveRecord::Migration[8.0]
+  def change
+    # Only if lock strategy is :failed_attempts
+    add_column :users, :failed_attempts, :integer, default: 0, null: false
+
+    add_column :users, :locked_at, :datetime
+  end
+end

--- a/db/migrate/20250121233816_add_lockable_to_devise.rb
+++ b/db/migrate/20250121233816_add_lockable_to_devise.rb
@@ -4,6 +4,12 @@ class AddLockableToDevise < ActiveRecord::Migration[8.0]
       # Only if lock strategy is :failed_attempts
       t.integer :failed_attempts, default: 0, null: false
       t.datetime :locked_at
+
+      # Only if unlock strategy is :email or :both
+      t.string :unlock_token
+
+      # Add index to unlock_token
+      t.index :unlock_token, unique: true
     end
   end
 end

--- a/db/migrate/20250121233816_add_lockable_to_devise.rb
+++ b/db/migrate/20250121233816_add_lockable_to_devise.rb
@@ -1,8 +1,9 @@
 class AddLockableToDevise < ActiveRecord::Migration[8.0]
   def change
-    # Only if lock strategy is :failed_attempts
-    add_column :users, :failed_attempts, :integer, default: 0, null: false
-
-    add_column :users, :locked_at, :datetime
+    change_table :users, bulk: true do |t|
+      # Only if lock strategy is :failed_attempts
+      t.integer :failed_attempts, default: 0, null: false
+      t.datetime :locked_at
+    end
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -89,8 +89,10 @@ ActiveRecord::Schema[8.0].define(version: 2025_01_23_031734) do
     t.boolean "welcome_banner_viewed", default: false
     t.integer "failed_attempts", default: 0, null: false
     t.datetime "locked_at"
+    t.string "unlock_token"
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
+    t.index ["unlock_token"], name: "index_users_on_unlock_token", unique: true
   end
 
   add_foreign_key "reviews", "subjects"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -87,6 +87,8 @@ ActiveRecord::Schema[8.0].define(version: 2025_01_23_031734) do
     t.datetime "updated_at", null: false
     t.text "approvals"
     t.boolean "welcome_banner_viewed", default: false
+    t.integer "failed_attempts", default: 0, null: false
+    t.datetime "locked_at"
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end


### PR DESCRIPTION
## Que se hizo
Se agrega una restricción en el limite de Login fallidos consecutivos a través de la extensión `lockable` provista por la gema `devise`

### Documentación de devise
Repo: https://github.com/heartcombo/devise
Extensión:
- https://www.rubydoc.info/github/heartcombo/devise/main/Devise/Models/Lockable
- https://github.com/heartcombo/devise/wiki/How-To:-Add-:lockable-to-Users

Se seteó un maximo de 8 intentos consecutivos erroneos, y el blockeo se realiza durante una hora. Se notifica en el intento número 7 que con un intento fallido más se bloqueará la cuenta.
Se puede desbloquear la cuenta antes del periodo default de 1 hora, a través del mail que se envía al usuario una vez se bloquea el acceso.

## Screenshots
### Ultimo intento fallido
<img width="1789" alt="Screenshot 2025-01-21 at 8 44 39 PM" src="https://github.com/user-attachments/assets/0a78a6ad-20a8-4e56-a8e9-e7bb7585df6f" />

### Cuenta bloqueada
<img width="1784" alt="image" src="https://github.com/user-attachments/assets/3d5501ea-06ee-4199-bbec-120f52cc2732" />

### Email para desbloquear
![image](https://github.com/user-attachments/assets/cd630a57-1028-47c3-b319-2adf0fb741f0)

### Cuenta desbloqueada
<img width="1783" alt="image" src="https://github.com/user-attachments/assets/55b2820c-5463-4bc9-b3dc-893984552ae1" />


