### PR TITLE
Don't run code coverage action for dependabot PRs

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -95,6 +95,7 @@ jobs:
         retention-days: 2
 
     - uses: joshmfrankel/simplecov-check-action@main
+      if: github.actor != 'dependabot[bot]'
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
         minimum_suite_coverage: 40


### PR DESCRIPTION
## Summary

By default, dependabot PRs have a read-only GITHUB_TOKEN so the simplecov action is throwing this error:

> /action/lib/coverage/utils/request.rb:48:in `run': Forbidden: {"message":"Resource not accessible by integration","documentation_url":"[https://docs.github.com/rest/checks/runs#create-a-check-run"}](https://docs.github.com/rest/checks/runs#create-a-check-run%22%7D) (RuntimeError)