### PR TITLE
Fix scraper not filling input when looking for `INGENIERIA EN COMPUTACION`

### DIFF
--- a/lib/scraper/bedelias.rb
+++ b/lib/scraper/bedelias.rb
@@ -65,6 +65,12 @@ module Scraper
       find('.ui-accordion-header', text: 'TECNOLOGÍA Y CIENCIAS DE LA NATURALEZA').click
       find('td', text: 'FING - FACULTAD DE INGENIERÍA', visible: false).click
 
+      find('span', text: 'Planes de estudio - FING')
+
+      if has_css?('.ui-widget-overlay')
+        assert_no_selector('.ui-widget-overlay')
+      end
+
       find('.ui-column-filter').set('INGENIERIA EN COMPUTACION')
 
       within('tr', text: 'INGENIERIA EN COMPUTACION', match: :prefer_exact) do


### PR DESCRIPTION
El scraper esta teniendo un comportamiento flaky, en el que el input de buscar la carrera muchas veces no se llena.

El motivo es la aparición de este widget de que la pagina esta cargando:
![image](https://github.com/user-attachments/assets/c0a585d6-1728-4462-9bca-ba0270a2f274)

1. Esperar a saber que estamos en la pagina de buscar carreras haciendo find('span', text: 'Planes de estudio - FING').
Esto lo hacemos para no matchear con el widget de la pagina anterior.

2. Esperar a ver si aparece el widget `.ui-widget-overlay` , y hasta que no se vaya no usar el input.