### PR TITLE
Borrar usos de `OpenStruct`

### DIFF
--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -2,10 +2,13 @@ require 'test_helper'
 
 class UserTest < ActiveSupport::TestCase
   test 'User.from_omniauth of a user that doesn\'t exist, should create a new user' do
-    auth = OpenStruct.new(
+    auth_info_klass = Struct.new(:email)
+    auth_klass = Struct.new(:provider, :uid, :info)
+
+    auth = auth_klass.new(
       provider: 'google',
       uid: '123456789',
-      info: OpenStruct.new(
+      info: auth_info_klass.new(
         email: 'user1@gmail.com'
       )
     )
@@ -21,10 +24,13 @@ class UserTest < ActiveSupport::TestCase
   test 'User.from_omniauth of a user that exists, should update the user' do
     user = create :user
 
-    auth = OpenStruct.new(
+    auth_info_klass = Struct.new(:email)
+    auth_klass = Struct.new(:provider, :uid, :info)
+
+    auth = auth_klass.new(
       provider: 'google',
       uid: '123456789',
-      info: OpenStruct.new(
+      info: auth_info_klass.new(
         email: user.email
       )
     )

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -1,14 +1,17 @@
 require 'test_helper'
 
 class UserTest < ActiveSupport::TestCase
-  test 'User.from_omniauth of a user that doesn\'t exist, should create a new user' do
-    auth_info_klass = Struct.new(:email)
-    auth_klass = Struct.new(:provider, :uid, :info)
+  class Auth < Struct.new(:provider, :uid, :info)
+  end
 
-    auth = auth_klass.new(
+  class Auth::Info < Struct.new(:email)
+  end
+
+  test 'User.from_omniauth of a user that doesn\'t exist, should create a new user' do
+    auth = Auth.new(
       provider: 'google',
       uid: '123456789',
-      info: auth_info_klass.new(
+      info: Auth::Info.new(
         email: 'user1@gmail.com'
       )
     )
@@ -24,13 +27,10 @@ class UserTest < ActiveSupport::TestCase
   test 'User.from_omniauth of a user that exists, should update the user' do
     user = create :user
 
-    auth_info_klass = Struct.new(:email)
-    auth_klass = Struct.new(:provider, :uid, :info)
-
-    auth = auth_klass.new(
+    auth = Auth.new(
       provider: 'google',
       uid: '123456789',
-      info: auth_info_klass.new(
+      info: Auth::Info.new(
         email: user.email
       )
     )


### PR DESCRIPTION
Al intentar actualizar `rollbar` a la versión `v3.6.1` se rompen los tests con el siguiente error:

```ruby
NameError: uninitialized constant UserTest::OpenStruct
```

El problema es que nuestra aplicación [usa `OpenStruct`](https://github.com/cedarcode/mi_carrera/blob/fa3f8548595677c4b6c6f7aa3f0683783d7143dd/test/models/user_test.rb#L5-L11) pero nunca la requerimos directamente – de todas formas funcionaba dado que `rollbar` [la requería en su código](https://github.com/ilkecan/rollbar-gem/blob/9efecb9a8d10ca7e5df9355c0a7dfd3f269a452c/lib/rollbar/notifier.rb#L12).

Sin embargo, [la versión `v3.6.1` de `rollbar` deja de requerir `OpenStruct`](https://github.com/rollbar/rollbar-gem/pull/1170) por lo que al actualizar a esa versión empiezan a fallar los tests.

Para solucionarlo simplemente nos definimos dos clases `Auth` y `Auth::Info` usando `Struct` que nos proveen la misma funcionalidad que estaba ofreciendo el `OpenStruct`.