### PR TITLE
Migrate from `sprockets` to `propshaft`

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,6 +12,7 @@ gem "omniauth", "~> 2.1"
 gem "omniauth-google-oauth2", '~> 1.2'
 gem "omniauth-rails_csrf_protection", '~> 1.0'
 gem 'pg', '~> 1.5'
+gem 'propshaft', '~> 1.1'
 gem 'puma', '~> 6.6'
 gem 'rollbar', '~> 3.6'
 gem 'stimulus-rails', '~> 1.3'

--- a/Gemfile
+++ b/Gemfile
@@ -14,7 +14,6 @@ gem "omniauth-rails_csrf_protection", '~> 1.0'
 gem 'pg', '~> 1.5'
 gem 'puma', '~> 6.6'
 gem 'rollbar', '~> 3.6'
-gem 'sprockets-rails', '~> 3.5', require: 'sprockets/railtie'
 gem 'stimulus-rails', '~> 1.3'
 gem 'turbo-rails', '~> 2.0'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -344,13 +344,6 @@ GEM
     snaky_hash (2.0.1)
       hashie
       version_gem (~> 1.1, >= 1.1.1)
-    sprockets (4.2.1)
-      concurrent-ruby (~> 1.0)
-      rack (>= 2.2.4, < 4)
-    sprockets-rails (3.5.2)
-      actionpack (>= 6.1)
-      activesupport (>= 6.1)
-      sprockets (>= 3.0.0)
     sshkit (1.24.0)
       base64
       logger
@@ -416,7 +409,6 @@ DEPENDENCIES
   selenium-webdriver (~> 4.28)
   shoulda-matchers (~> 6.0)
   simplecov
-  sprockets-rails (~> 3.5)
   stimulus-rails (~> 1.3)
   turbo-rails (~> 2.0)
   web-console (~> 4.2)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -227,6 +227,11 @@ GEM
     pp (0.6.2)
       prettyprint
     prettyprint (0.2.0)
+    propshaft (1.1.0)
+      actionpack (>= 7.0.0)
+      activesupport (>= 7.0.0)
+      rack
+      railties (>= 7.0.0)
     psych (5.2.3)
       date
       stringio
@@ -399,6 +404,7 @@ DEPENDENCIES
   omniauth-google-oauth2 (~> 1.2)
   omniauth-rails_csrf_protection (~> 1.0)
   pg (~> 1.5)
+  propshaft (~> 1.1)
   puma (~> 6.6)
   rails (~> 8.0.0)
   rollbar (~> 3.6)

--- a/app/assets/config/manifest.js
+++ b/app/assets/config/manifest.js
@@ -1,5 +1,0 @@
-//= link_tree ../images
-//= link_directory ../javascripts .js
-//= link_directory ../stylesheets .css
-//= link_tree ../../javascript .js
-//= link_tree ../../../vendor/javascript .js

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -1,21 +1,3 @@
-/*
- * This is a manifest file that'll be compiled into application.css, which will include all the files
- * listed below.
- *
- * Any CSS and SCSS file within this directory, lib/assets/stylesheets, or any plugin's
- * vendor/assets/stylesheets directory can be referenced here using a relative path.
- *
- * You're free to add application-wide styles to this file and they'll appear at the bottom of the
- * compiled file so the styles you add here take precedence over styles defined in any other CSS/SCSS
- * files in this directory. Styles in this file should be added after the last require_* statement.
- * It is generally better to create a new file per style scope.
- *
- *= require reset
- *= require_tree .
- *= require_self
- */
-
-
 body {
   display: flex;
   justify-content: start;

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -10,7 +10,8 @@
     <link rel="icon" type="image/png" href="/icon-128.png" sizes="128x128">
 
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <%= stylesheet_link_tag    'application', media: 'all' %>
+    <%= stylesheet_link_tag :app, "data-turbo-track": "reload" %>
+    <%= stylesheet_link_tag :reset, "data-turbo-track": "reload" %>
     <%= stylesheet_link_tag    'https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@48,500,0,0' %>
     <%= stylesheet_link_tag    'https://fonts.googleapis.com/css?family=Roboto:300,400,500,600,700' %>
     <%= stylesheet_link_tag    'https://fonts.googleapis.com/icon?family=Material+Icons' %>

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -5,4 +5,3 @@ Rails.application.config.assets.version = '1.0'
 
 # Add additional assets to the asset load path.
 # Rails.application.config.assets.paths << Emoji.images_path
-Rails.application.config.assets.paths << Rails.root.join('app/assets/fonts')


### PR DESCRIPTION
## Summary

This PR migrates from `sprockets-rails` to `propshaft` following the official [migration guide](https://github.com/rails/propshaft/blob/689e756689baa141291c7422f6a2df41b5ceead8/UPGRADING.md)