### PR TITLE
Extract order form TreePreloader

### DIFF
--- a/app/controllers/approvals_controller.rb
+++ b/app/controllers/approvals_controller.rb
@@ -22,7 +22,7 @@ class ApprovalsController < ApplicationController
     if params[:subject_show] == "true"
       @subject = @approvable.subject
     else
-      @subjects = TreePreloader.new.preload.select do |subject|
+      @subjects = TreePreloader.new(Subject.ordered_by_category_and_name).preload.select do |subject|
         current_student.approved?(subject.course) ||
           (!subject.hidden_by_default? && current_student.available?(subject.course))
       end

--- a/app/controllers/subject_plans_controller.rb
+++ b/app/controllers/subject_plans_controller.rb
@@ -26,7 +26,8 @@ class SubjectPlansController < ApplicationController
   end
 
   def set_planned_and_not_planned_subjects
-    @planned_subjects, @not_planned_subjects = TreePreloader.new.preload.partition do |subject|
+    @planned_subjects, @not_planned_subjects =
+      TreePreloader.new(Subject.ordered_by_category_and_name).preload.partition do |subject|
       current_student.approved?(subject) || current_user.planned?(subject)
     end
   end

--- a/app/controllers/subjects_controller.rb
+++ b/app/controllers/subjects_controller.rb
@@ -21,10 +21,11 @@ class SubjectsController < ApplicationController
           .where("lower(unaccent(name)) LIKE lower(unaccent(?))", "%#{params[:search].strip}%")
           .or(Subject.where("lower(unaccent(short_name)) LIKE lower(unaccent(?))", "%#{params[:search].strip}%"))
           .or(Subject.where("lower(code) LIKE lower(?)", "%#{params[:search].strip}%"))
-          .ordered_by_category_and_name
-      end
+      else
+        Subject
+      end.ordered_by_category_and_name
 
-    @subjects = TreePreloader.new(subjects || Subject.ordered_by_category_and_name).preload
+    @subjects = TreePreloader.new(subjects).preload
   end
 
   private

--- a/app/controllers/subjects_controller.rb
+++ b/app/controllers/subjects_controller.rb
@@ -1,6 +1,6 @@
 class SubjectsController < ApplicationController
   def index
-    @subjects = TreePreloader.new.preload.select do |subject|
+    @subjects = TreePreloader.new(Subject.ordered_by_category_and_name).preload.select do |subject|
       current_student.approved?(subject.course) ||
         (!subject.hidden_by_default? && current_student.available?(subject.course))
     end
@@ -21,9 +21,10 @@ class SubjectsController < ApplicationController
           .where("lower(unaccent(name)) LIKE lower(unaccent(?))", "%#{params[:search].strip}%")
           .or(Subject.where("lower(unaccent(short_name)) LIKE lower(unaccent(?))", "%#{params[:search].strip}%"))
           .or(Subject.where("lower(code) LIKE lower(?)", "%#{params[:search].strip}%"))
+          .ordered_by_category_and_name
       end
 
-    @subjects = TreePreloader.new(subjects).preload
+    @subjects = TreePreloader.new(subjects || Subject.ordered_by_category_and_name).preload
   end
 
   private

--- a/app/services/tree_preloader.rb
+++ b/app/services/tree_preloader.rb
@@ -6,7 +6,6 @@ class TreePreloader
   def preload
     # rubocop:disable Rails/FindEach
     subjects
-      .ordered_by_category_and_name
       .includes(
         course: :prerequisite_tree,
         exam: :prerequisite_tree

--- a/app/services/tree_preloader.rb
+++ b/app/services/tree_preloader.rb
@@ -1,6 +1,6 @@
 class TreePreloader
-  def initialize(subjects = nil)
-    @subjects = subjects || Subject.all
+  def initialize(subjects)
+    @subjects = subjects
   end
 
   def preload

--- a/test/services/tree_preloader_test.rb
+++ b/test/services/tree_preloader_test.rb
@@ -6,7 +6,7 @@ class TreePreloaderTest < ActiveSupport::TestCase
     s2 = create :subject, :with_exam, name: "s2"
     create :subject_prerequisite, approvable: s2.course, approvable_needed: s1.course
 
-    subjects = TreePreloader.new.preload.sort_by(&:name)
+    subjects = TreePreloader.new(Subject).preload.sort_by(&:name)
 
     Subject.destroy_all
     Approvable.destroy_all
@@ -48,7 +48,7 @@ class TreePreloaderTest < ActiveSupport::TestCase
 
     assert_equal 0, subjects.count
 
-    subjects = TreePreloader.new(nil).preload
+    subjects = TreePreloader.new(Subject).preload
 
     assert_equal 2, subjects.count
     assert_equal "s1", subjects.first.name


### PR DESCRIPTION
El `TreePreloader` no tiene porque ordenar las materias. En su lugar, podemos inicializar el `TreePreloader` con las materias ordenadas como nos convenga. Esto nos va a ayudar para otros casos de uso donde no queremos que las materias se ordenen por category and name