### PR TITLE
Remover el estilo por defecto de los browsers al autocompletar un `input`

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -207,3 +207,11 @@ body {
 .show-password-button {
   margin-right: -20px;
 }
+
+input {
+  &:-webkit-autofill {
+    transition: background-color 0s 0s, color 0s 0s;
+    transition-delay: calc(infinity * 1s);
+  }
+}
+


### PR DESCRIPTION
## Que se hizo
Se remueve el estilo por default que setean los browsers al hacer autocomplete.
Estuve investigando, y al parecer es un dolor de cabeza para mucha gente:
- https://stackoverflow.com/questions/2781549/removing-input-background-colour-for-chrome-autocomplete/65964956
- https://stackoverflow.com/questions/61083813/how-to-avoid-internal-autofill-selected-style-to-be-applied

No pude hacer funcionar algo distinto. La transition con posposición indefinida fue lo único q lo "fixea" de la forma más rapida. Se aceptan alternativas

## Video

https://github.com/user-attachments/assets/570985b5-d27f-4902-9e17-8e15f1e91627

