### PR TITLE
Allow removing approved planned subjects

### DIFF
--- a/app/views/subjects/_planned_subjects_list.html.erb
+++ b/app/views/subjects/_planned_subjects_list.html.erb
@@ -14,8 +14,10 @@
         </span>
         <% if current_student.approved?(subject) %>
           <span class="mdc-deprecated-list-item__meta material-icons">done</span>
-        <% else %>
-          <%= form_with(
+        <% elsif !current_student.available?(subject) %>
+          <span class="mdc-deprecated-list-item__meta material-icons">lock</span>
+        <% end %>
+        <%= form_with(
             url: subject_plan_path(subject_id: subject.id),
             method: :delete,
             data: { controller: "autosave-check" },
@@ -23,10 +25,6 @@
           ) do |form| %>
             <span class="mdc-deprecated-list-item__meta material-icons" data-action="click->autosave-check#update">remove_circle_outline</span>
           <% end %>
-          <% if !current_student.available?(subject) %>
-            <span class="mdc-deprecated-list-item__meta material-icons">lock</span>
-          <% end %>
-        <% end %>
       <% end %>
     <% end %>
   <% end %>

--- a/spec/support/planned_subjects_test_helper.rb
+++ b/spec/support/planned_subjects_test_helper.rb
@@ -21,6 +21,21 @@ module PlannedSubjectsTestHelper
     end
   end
 
+  def assert_planned_subject(subject_name)
+    expect(page).to have_text subject_name
+    within_subject_row(subject_name) do
+      expect(page).to have_selector("span", text: "remove_circle_outline")
+    end
+  end
+
+  def assert_not_planned_subject(subject_name)
+    expect(page).to have_text subject_name
+    within_subject_row(subject_name) do
+      expect(page).to have_selector("span", text: "add_circle_outline")
+      expect(page).to have_selector("select", text: 'Sem. 1')
+    end
+  end
+
   def within_planned_subjects(&block)
     within(:xpath, "//div[h3[contains(text(), 'Materias planeadas')]]/following-sibling::*[1]", &block)
   end

--- a/spec/system/planned_subjects_spec.rb
+++ b/spec/system/planned_subjects_spec.rb
@@ -37,14 +37,14 @@ RSpec.describe "PlannedSubjects", type: :system do
     within_not_planned_approved_subjects do
       expect(page).to have_no_text "GAL 1"
       expect(page).to have_no_text "GAL 2"
-      expect(page).to have_text "T1"
+      assert_not_planned_subject "T1"
     end
 
     expect(page).to have_text "Créditos planeados: 0"
 
     within_not_planned_subjects do
-      expect(page).to have_text "GAL 1"
-      expect(page).to have_text "GAL 2"
+      assert_not_planned_subject "GAL 1"
+      assert_not_planned_subject "GAL 2"
       expect(page).to have_no_text "T1"
     end
 
@@ -58,13 +58,14 @@ RSpec.describe "PlannedSubjects", type: :system do
       expect(page).to have_text "Primer semestre"
       expect(page).to have_text "Créditos planeados: 11"
       assert_approved_subject "T1"
+      assert_planned_subject "T1"
     end
 
     expect(page).to have_no_text "Materias aprobadas sin semestre asignado"
 
     within_not_planned_subjects do
-      expect(page).to have_text "GAL 1"
-      expect(page).to have_text "GAL 2"
+      assert_not_planned_subject "GAL 1"
+      assert_not_planned_subject "GAL 2"
       expect(page).to have_no_text "T1"
     end
 
@@ -81,10 +82,13 @@ RSpec.describe "PlannedSubjects", type: :system do
 
     within_planned_subjects do
       assert_available_subject "GAL 1"
+      assert_planned_subject "GAL 1"
       assert_approved_subject "T1"
+      assert_planned_subject "T1"
       expect(page).to have_text "Primer semestre"
       expect(page).to have_text "Créditos planeados: 20"
       assert_blocked_subject "GAL 2"
+      assert_planned_subject "GAL 2"
       expect(page).to have_text "Segundo semestre"
       expect(page).to have_text "Créditos planeados: 10"
     end
@@ -97,7 +101,9 @@ RSpec.describe "PlannedSubjects", type: :system do
 
     within_planned_subjects do
       assert_available_subject "GAL 1"
+      assert_planned_subject "GAL 1"
       assert_approved_subject "T1"
+      assert_planned_subject "T1"
       expect(page).to have_text "Primer semestre"
       expect(page).to have_text "Créditos planeados: 20"
       expect(page).to have_no_text "GAL 2"
@@ -107,7 +113,7 @@ RSpec.describe "PlannedSubjects", type: :system do
 
     within_not_planned_subjects do
       expect(page).to have_no_text "GAL 1"
-      expect(page).to have_text "GAL 2"
+      assert_not_planned_subject "GAL 2"
       expect(page).to have_no_text "T1"
     end
 


### PR DESCRIPTION
Permitir quitar del planificador materias que ya aprobaste. No estoy seguro si introdujimos esto como un bug o nunca estuvo pero remover materias planeadas es algo que tenemos que permitir sin importar si la materia fue aprobada o no.

Modifiqué los tests también para mejorar un poquito los expects de cuando una materia está planeada o no

[Ticket](https://github.com/orgs/cedarcode/projects/3/views/1?pane=issue&itemId=98616576)