### PR TITLE
Migrar `Sign In` a `Tailwind`

### DIFF
--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -10,7 +10,7 @@
         </div>
       </div>
 
-      <div data-controller="textfield show-password">
+      <div data-controller="show-password">
         <div class="flex items-center justify-between">
           <%= f.label :password, "Contraseña", class: "text-sm/6 font-medium text-indigo-700" %>
 

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -1,50 +1,51 @@
-<div class="mdc-deprecated-list-group">
-  <h3 class="mdc-deprecated-list-group__subheader mdc-typography--headline5 sign-in">Ingreso</h3>
-  <ul class="mdc-deprecated-list growing-text-list">
+<div class="flex flex-col justify-center px-6 py-12 space-y-10">
+  <h2 class="text-center text-3xl/9 text-indigo-800 font-bold">Iniciar sesión</h2>
 
-    <li class="form-input-container google-button-container">
-
-      <%- resource_class.omniauth_providers.each do |provider| %>
-        <%= form_with url: omniauth_authorize_path(resource_name, provider), method: :post, local: true do |f| %>
-          <%= f.button class: 'google-sign-in-button' do %>
-            <%= image_tag asset_path('google-icon.png'), class: 'google-icon' %>
-            <span class='google-sign-in-text'>Continuar con Google</span>
-          <% end %>
-        <% end %>
-      <% end %>
-    </li>
-
-    <li role="separator" class="mdc-deprecated-list-divider"></li>
-
-    <%= form_with(model: resource, url: session_path(resource_name), local: true) do |f| %>
-      <li class="form-input-container sign-in">
-        Ingresar con tu correo electrónico
-      </li>
-      <li class="form-input-container">
-        <div class="mdc-text-field mdc-text-field--filled <%='mdc-text-field--invalid mdc-text-field--with-trailing-icon' if resource.errors[:email].any? %>" data-controller="textfield">
-          <span class="mdc-text-field__ripple"></span>
-          <%= f.label :email, "Correo electrónico", class: "mdc-floating-label" %>
-          <%= f.email_field :email, class: "mdc-text-field__input", required: true, autofocus: true %>
-          <%= render 'shared/invalid_icon', resource: resource, field: :email %>
-          <div class="mdc-line-ripple"></div>
+  <div class="sm:mx-auto sm:w-full sm:max-w-sm space-y-6">
+    <%= form_with(model: resource, url: session_path(resource_name), class: "space-y-6", local: true) do |f| %>
+      <div>
+        <%= f.label :email, "Correo electrónico", class: "text-sm/6 font-medium text-indigo-700" %>
+        <div class="relative w-full">
+          <%= f.email_field :email, class: "w-full pr-16 rounded-md bg-white px-3 py-1.5 outline-1 focus:outline-2 outline-indigo-600 focus:outline-indigo-700", required: true, autofocus: true %>
         </div>
-        <%= render 'shared/info_and_errors', resource: resource, field: :email, text: '' %>
-      </li>
-      <li class="form-input-container">
-        <%= render 'shared/password_field', f:, resource:, field: :password, label_text: "Contraseña", autocomplete: "current-password", required: true %>
-        <%= render 'shared/info_and_errors', resource:, field: :password, text: '' %>
-      </li>
-      <li class="form-input-container sign-in">
-        <%= f.button class: "mdc-button mdc-button--raised" do %>
-          <span class="mdc-button__ripple"></span>
-          <span class='mdc-button__label'>
-            Ingresar
-          </span>
-        <% end %>
-      </li>
+      </div>
+
+      <div data-controller="textfield show-password">
+        <div class="flex items-center justify-between">
+          <%= f.label :password, "Contraseña", class: "text-sm/6 font-medium text-indigo-700" %>
+
+          <%= link_to '¿Has olvidado tu contraseña?', new_password_path(resource), class: "font-semibold text-indigo-700 hover:text-indigo-600 text-sm/6" %>
+        </div>
+
+        <div class="relative w-full">
+          <%= f.password_field :password, class: "w-full pr-16 rounded-md bg-white px-3 py-1.5 outline-1 focus:outline-2 outline-indigo-600 focus:outline-indigo-700", required: true, autofocus: true, autocomplete: false, data: { show_password_target: "password" } %>
+
+          <button type="button" class="absolute inset-y-0 right-0 flex items-center pr-3 cursor-pointer text-indigo-700 hover:text-indigo-600" data-action="show-password#toggle">
+            <span class="material-icons" data-show-password-target="icon">visibility</span>
+          </button>
+        </div>
+      </div>
+
+      <%= f.button "Ingresar", class: "w-full rounded-md bg-indigo-700 py-1.5 text-sm/6 font-semibold text-white shadow-sm hover:bg-indigo-600 cursor-pointer" %>
     <% end %>
 
-    <li role="separator" class="mdc-deprecated-list-divider"></li>
-    <%= render "devise/shared/links" %>
-  </ul>
+    <p class="text-center text-sm/6 text-indigo-500">
+      ¿No estás registrado?
+
+      <%= link_to 'Registrarte',new_registration_path(resource), class: "font-semibold text-indigo-700 hover:text-indigo-600" %>
+    </p>
+  </div>
+
+  <div class="my-4 py-3 flex items-center text-sm text-indigo-600 before:flex-1 before:border-t before:border-indigo-200 before:me-6 after:flex-1 after:border-t after:border-indigo-200 after:ms-6">Continua con</div>
+
+  <div class="google-button-container">
+    <%- resource_class.omniauth_providers.each do |provider| %>
+      <%= form_with url: omniauth_authorize_path(resource_name, provider), method: :post, local: true do |f| %>
+        <%= f.button class: 'google-sign-in-button' do %>
+          <%= image_tag asset_path('google-icon.png'), class: 'google-icon' %>
+          <span class='google-sign-in-text'>Continuar con Google</span>
+        <% end %>
+      <% end %>
+    <% end %>
+  </div>
 </div>

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -1,38 +1,38 @@
 <div class="flex flex-col justify-center px-6 py-12 space-y-10">
-  <h2 class="text-center text-3xl/9 text-indigo-800 font-bold">Iniciar sesión</h2>
+  <h2 class="text-center text-3xl/9 text-neutral-800 font-bold">Iniciar sesión</h2>
 
   <div class="sm:mx-auto sm:w-full sm:max-w-sm space-y-6">
     <%= form_with(model: resource, url: session_path(resource_name), class: "space-y-6", local: true) do |f| %>
       <div>
-        <%= f.label :email, "Correo electrónico", class: "text-sm/6 font-medium text-indigo-700" %>
+        <%= f.label :email, "Correo electrónico", class: "text-sm/6 font-medium text-neutral-800" %>
         <div class="relative w-full">
-          <%= f.email_field :email, class: "w-full pr-16 rounded-md bg-white px-3 py-1.5 outline-1 focus:outline-2 outline-indigo-600 focus:outline-indigo-700", required: true, autofocus: true %>
+          <%= f.email_field :email, class: "w-full pr-16 rounded-md bg-white px-3 py-1.5 outline-1 focus:outline-2 outline-neutral-600 focus:outline-indigo-700", required: true, autofocus: true %>
         </div>
       </div>
 
       <div data-controller="show-password">
         <div class="flex items-center justify-between">
-          <%= f.label :password, "Contraseña", class: "text-sm/6 font-medium text-indigo-700" %>
+          <%= f.label :password, "Contraseña", class: "text-sm/6 font-medium text-neutral-700" %>
 
-          <%= link_to '¿Has olvidado tu contraseña?', new_password_path(resource), class: "font-semibold text-indigo-700 hover:text-indigo-600 text-sm/6" %>
+          <%= link_to '¿Has olvidado tu contraseña?', new_password_path(resource), class: "font-semibold text-neutral-700 hover:text-indigo-700 text-sm/6" %>
         </div>
 
         <div class="relative w-full">
-          <%= f.password_field :password, class: "w-full pr-16 rounded-md bg-white px-3 py-1.5 outline-1 focus:outline-2 outline-indigo-600 focus:outline-indigo-700", required: true, autofocus: true, autocomplete: false, data: { show_password_target: "password" } %>
+          <%= f.password_field :password, class: "w-full pr-16 rounded-md bg-white px-3 py-1.5 outline-1 focus:outline-2 outline-neutral-600 focus:outline-indigo-700", required: true, autofocus: true, autocomplete: false, data: { show_password_target: "password" } %>
 
-          <button type="button" class="absolute inset-y-0 right-0 flex items-center pr-3 cursor-pointer text-indigo-700 hover:text-indigo-600" data-action="show-password#toggle">
+          <button type="button" class="absolute inset-y-0 right-0 flex items-center pr-3 cursor-pointer text-neutral-700 hover:text-indigo-700" data-action="show-password#toggle">
             <span class="material-icons" data-show-password-target="icon">visibility</span>
           </button>
         </div>
       </div>
 
-      <%= f.button "Ingresar", class: "w-full rounded-md bg-indigo-700 py-1.5 text-sm/6 font-semibold text-white shadow-sm hover:bg-indigo-600 cursor-pointer" %>
+      <%= f.button "Ingresar", class: "w-full rounded-md bg-indigo-700 py-1.5 text-sm/6 font-semibold text-white shadow-sm hover:bg-indigo-700 cursor-pointer" %>
     <% end %>
 
-    <p class="text-center text-sm/6 text-indigo-500">
+    <p class="text-center text-sm/6 text-neutral-500">
       ¿No estás registrado?
 
-      <%= link_to 'Registrarte',new_registration_path(resource), class: "font-semibold text-indigo-700 hover:text-indigo-600" %>
+      <%= link_to 'Registrarte',new_registration_path(resource), class: "font-semibold text-neutral-700 hover:text-indigo-700" %>
     </p>
   </div>
 

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -36,16 +36,5 @@
     </p>
   </div>
 
-  <div class="my-4 py-3 flex items-center text-sm text-indigo-600 before:flex-1 before:border-t before:border-indigo-200 before:me-6 after:flex-1 after:border-t after:border-indigo-200 after:ms-6">Continua con</div>
-
-  <div class="google-button-container">
-    <%- resource_class.omniauth_providers.each do |provider| %>
-      <%= form_with url: omniauth_authorize_path(resource_name, provider), method: :post, local: true do |f| %>
-        <%= f.button class: 'google-sign-in-button' do %>
-          <%= image_tag asset_path('google-icon.png'), class: 'google-icon' %>
-          <span class='google-sign-in-text'>Continuar con Google</span>
-        <% end %>
-      <% end %>
-    <% end %>
-  </div>
+  <%= render "devise/shared/sso_buttons" %>
 </div>

--- a/app/views/devise/shared/_sso_buttons.html.erb
+++ b/app/views/devise/shared/_sso_buttons.html.erb
@@ -1,6 +1,6 @@
 <%- resource_class.omniauth_providers.each do |provider| %>
   <%= form_with url: omniauth_authorize_path(resource_name, provider), method: :post, local: true, class: 'flex justify-center' do |f| %>
-    <%= f.button class: 'text-indigo-600 bg-white-700 hover:bg-white-600 font-medium rounded-lg text-sm px-5 py-2 inline-flex items-center cursor-pointer outline-1 outline-indigo-600 gap-2' do %>
+    <%= f.button class: 'text-neutral-600 bg-white-700 font-medium rounded-lg text-sm px-5 py-2 inline-flex items-center cursor-pointer outline-1 outline-neutral-600 hover:outline-indigo-700 hover:text-indigo-700 gap-2' do %>
       <%= image_tag asset_path('google-icon.png'), class: 'w-6 h-6' %>
       Continuar con Google
     <% end %>

--- a/app/views/devise/shared/_sso_buttons.html.erb
+++ b/app/views/devise/shared/_sso_buttons.html.erb
@@ -1,0 +1,8 @@
+<%- resource_class.omniauth_providers.each do |provider| %>
+  <%= form_with url: omniauth_authorize_path(resource_name, provider), method: :post, local: true, class: 'flex justify-center' do |f| %>
+    <%= f.button class: 'text-indigo-600 bg-white-700 hover:bg-white-600 font-medium rounded-lg text-sm px-5 py-2 inline-flex items-center cursor-pointer outline-1 outline-indigo-600 gap-2' do %>
+      <%= image_tag asset_path('google-icon.png'), class: 'w-6 h-6' %>
+      Continuar con Google
+    <% end %>
+  <% end %>
+<% end %>

--- a/test/support/password_helpers.rb
+++ b/test/support/password_helpers.rb
@@ -9,4 +9,15 @@ module PasswordHelpers
       assert_selector "input[type='password']"
     end
   end
+
+  def password_visibility_toggle_test_tailwind(label_text)
+    container = find(:xpath, "//div[@data-controller='textfield show-password'][.//label[text()='#{label_text}']]")
+
+    within(container) do
+      find("button[data-action='show-password#toggle']").click
+      assert_selector "input[type='text']"
+      find("button[data-action='show-password#toggle']").click
+      assert_selector "input[type='password']"
+    end
+  end
 end

--- a/test/support/password_helpers.rb
+++ b/test/support/password_helpers.rb
@@ -11,7 +11,7 @@ module PasswordHelpers
   end
 
   def password_visibility_toggle_test_tailwind(label_text)
-    container = find(:xpath, "//div[@data-controller='textfield show-password'][.//label[text()='#{label_text}']]")
+    container = find(:xpath, "//div[@data-controller='show-password'][.//label[text()='#{label_text}']]")
 
     within(container) do
       find("button[data-action='show-password#toggle']").click

--- a/test/system/user_test.rb
+++ b/test/system/user_test.rb
@@ -109,7 +109,7 @@ class UserTest < ApplicationSystemTestCase
 
     fill_in "Correo electrónico", with: user.email
     fill_in "Contraseña", with: user.password
-    password_visibility_toggle_test("Contraseña")
+    password_visibility_toggle_test_tailwind("Contraseña")
     click_on "Ingresar"
 
     assert_current_path(root_path)

--- a/test/system/user_test.rb
+++ b/test/system/user_test.rb
@@ -52,7 +52,7 @@ class UserTest < ApplicationSystemTestCase
 
     visit new_user_session_path
 
-    click_on "Restablecer contraseña"
+    click_on "¿Has olvidado tu contraseña?"
     fill_in "Correo electrónico", with: "non-existent@test.com"
 
     assert_no_emails do
@@ -98,7 +98,7 @@ class UserTest < ApplicationSystemTestCase
 
     visit new_user_session_path
 
-    assert_text "Ingreso"
+    assert_text "Iniciar sesión"
     assert_text "Continuar con Google"
 
     fill_in "Correo electrónico", with: user.email


### PR DESCRIPTION
## Summary

Este PR migra el sign in para que use `Tailwind` en lugar de `Material-UI` basado en [Tailwind components](https://tailwindui.com/components/application-ui/forms/sign-in-forms).

<img width="1552" alt="image" src="https://github.com/user-attachments/assets/ba7c6310-971c-49a2-a70d-f68cd3182944" />
<img width="1840" alt="image" src="https://github.com/user-attachments/assets/b0ad55ce-d90c-4044-af9f-2d949b24c04a" />