### PR TITLE
Use `plugins` instead of `require` to load `rubocop` extensions

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,4 +1,4 @@
-require:
+plugins:
   - rubocop-performance
   - rubocop-rails
 


### PR DESCRIPTION
## Summary
In `Rubocop 1.72` was introduced a new API for `Rubocop` extensions.

See the migration guide here:
https://docs.rubocop.org/rubocop/plugin_migration_guide.html

This fixes the following `rubocop` suggestion that is being raised each time we execute `rubocop:`

```
rubocop-performance extension supports plugin, specify `plugins: rubocop-performance` instead of `require: rubocop-performance` in /mi_carrera/.rubocop.yml.
For more information, see https://docs.rubocop.org/rubocop/plugin_migration_guide.html.

rubocop-rails extension supports plugin, specify `plugins: rubocop-rails` instead of `require: rubocop-rails` in /mi_carrera/.rubocop.yml.
For more information, see https://docs.rubocop.org/rubocop/plugin_migration_guide.html.
```