### PR TITLE
Guardar screenshots de todos los threads que fallan al correr scraper

### DIFF
--- a/lib/scraper/bedelias.rb
+++ b/lib/scraper/bedelias.rb
@@ -153,6 +153,9 @@ module Scraper
           prereq.merge(subject_code:, is_exam:)
         end
       end
+    rescue
+      Rails.logger.info save_screenshot
+      raise
     end
 
     def go_to_page(page)


### PR DESCRIPTION
- Agregar `rescue` en `process_requisites_slice`, que es el método que se llama en nuevos threads.
- Guardar screenshot en ese rescue
- De esta manera se evita que la screenshot se saque solamente en el thread principal que es quien tenia el único rescue