### PR TITLE
Mandar notificación en `Slack` cuando el scraper falla

### DIFF
--- a/.github/workflows/scraper.yml
+++ b/.github/workflows/scraper.yml
@@ -58,8 +58,6 @@ jobs:
         retention-days: 5
     - name: Send Slack notification
       if: failure()
-      env:
-        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
       run: |
         RUN_URL="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
 
@@ -81,4 +79,4 @@ jobs:
               }
             }
           ]
-        }" "$SLACK_WEBHOOK_URL"
+        }" "${{ secrets.SLACK_WEBHOOK_URL }}"

--- a/.github/workflows/scraper.yml
+++ b/.github/workflows/scraper.yml
@@ -61,22 +61,14 @@ jobs:
       env:
         RUN_URL: "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
       run: |
-        curl -X POST -H 'Content-type: application/json' --data "{
-          \"blocks\": [
+        curl -X POST -H 'Content-type: application/json' --data '{
+          "blocks": [
             {
-              \"type\": \"section\",
-              \"text\": {
-                \"type\": \"mrkdwn\",
-                \"text\": \"El *Scraper* de *MiCarrera* falló :blob-sad:\"
-              },
-              \"accessory\": {
-                \"type\": \"button\",
-                \"text\": {
-                  \"type\": \"plain_text\",
-                  \"text\": \"Ver logs\"
-                },
-                \"url\": \"${RUN_URL}\"
+              "type": "section",
+              "text": {
+                "type": "mrkdwn",
+                "text": "El Scraper de MiCarrera falló - <'"$RUN_URL"'|logs>"
               }
             }
           ]
-        }" "${{ secrets.SLACK_WEBHOOK_URL }}"
+        }' "${{ secrets.SLACK_WEBHOOK_URL }}"

--- a/.github/workflows/scraper.yml
+++ b/.github/workflows/scraper.yml
@@ -61,14 +61,7 @@ jobs:
       env:
         RUN_URL: "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
       run: |
-        curl -X POST -H 'Content-type: application/json' --data '{
-          "blocks": [
-            {
-              "type": "section",
-              "text": {
-                "type": "mrkdwn",
-                "text": "El Scraper de MiCarrera falló - <'"$RUN_URL"'|logs>"
-              }
-            }
-          ]
-        }' "${{ secrets.SLACK_WEBHOOK_URL }}"
+        curl -X POST -H 'Content-type: application/json' \
+          --data '{
+            "text": "El Scraper de MiCarrera falló - <'"$RUN_URL"'|logs>"
+          }' "${{ secrets.SLACK_WEBHOOK_URL }}"

--- a/.github/workflows/scraper.yml
+++ b/.github/workflows/scraper.yml
@@ -58,9 +58,9 @@ jobs:
         retention-days: 5
     - name: Send Slack notification
       if: failure()
+      env:
+        RUN_URL: "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
       run: |
-        RUN_URL="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
-
         curl -X POST -H 'Content-type: application/json' --data "{
           \"blocks\": [
             {

--- a/.github/workflows/scraper.yml
+++ b/.github/workflows/scraper.yml
@@ -56,3 +56,29 @@ jobs:
         name: scraper_screenshot
         path: ./tmp/capybara
         retention-days: 5
+    - name: Send Slack notification
+      if: failure()
+      env:
+        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+      run: |
+        RUN_URL="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+
+        curl -X POST -H 'Content-type: application/json' --data "{
+          \"blocks\": [
+            {
+              \"type\": \"section\",
+              \"text\": {
+                \"type\": \"mrkdwn\",
+                \"text\": \"El *Scraper* de *MiCarrera* falló :blob-sad:\"
+              },
+              \"accessory\": {
+                \"type\": \"button\",
+                \"text\": {
+                  \"type\": \"plain_text\",
+                  \"text\": \"Ver logs\"
+                },
+                \"url\": \"${RUN_URL}\"
+              }
+            }
+          ]
+        }" "$SLACK_WEBHOOK_URL"


### PR DESCRIPTION
## Summary

Cuando el scraper falla se notificara en `Slack` que el mismo ha fallado con un link para ver los logs.

Utilizando [Block Kit Builder](https://app.slack.com/block-kit-builder/T7YCB51UL#%7B%22blocks%22:%5B%7B%22type%22:%22section%22,%22text%22:%7B%22type%22:%22mrkdwn%22,%22text%22:%22El%20*Scraper*%20de%20*MiCarrera*%20fall%C3%B3%20:blob-sad:%22%7D,%22accessory%22:%7B%22type%22:%22button%22,%22text%22:%7B%22type%22:%22plain_text%22,%22text%22:%22Ver%20logs%22%7D,%22url%22:%22https://google.com%22%7D%7D%5D%7D) se puede ver como quedaría el mensaje, tambien adjunto imagen:

<img width="460" alt="image" src="https://github.com/user-attachments/assets/2746db1e-49e4-408f-bbe0-e9e8c45b5f08" />

Para que funcione es necesario crear una app de `Slack` siguiendo los primeros 3 pasos que se explican [aca](https://api.slack.com/messaging/webhooks).

Una vez hecho esto se deberá agregar un secret en `Github` con el URL del Webhook.
## Reference
- https://api.slack.com/messaging/webhooks
- https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/accessing-contextual-information-about-workflow-runs
