### PR TITLE
[PoC] Migrate subjects list's checkboxes to TailwindCSS

### DIFF
--- a/app/views/shared/_tailwind_checkbox_component.html.erb
+++ b/app/views/shared/_tailwind_checkbox_component.html.erb
@@ -1,0 +1,28 @@
+<%= form_with(
+  model: approvable,
+  url: approvable_approval_path(approvable, subject_show: subject_show),
+  data: { controller: "autosave-check" },
+  method: current_student.approved?(approvable) ? :delete : :post,
+  local: false,
+) do |form| %>
+  <div class="flex h-6 shrink-0 items-center w-[40px] justify-center mx-[5px]">
+    <div class="group grid size-4 grid-cols-1">
+      <%= form.check_box(
+        :approved,
+        {
+          id: dom_id(approvable),
+          class: "col-start-1 row-start-1 appearance-none rounded-sm border border-gray-300 bg-white checked:border-indigo-600 checked:bg-indigo-600 indeterminate:border-indigo-600 indeterminate:bg-indigo-600 focus-visible:outline-2 focus-visible:outline-offset-0 focus-visible:outline-indigo-600 disabled:border-gray-300 disabled:bg-gray-100 disabled:checked:bg-gray-100 forced-colors:appearance-auto",
+          checked: current_student.approved?(approvable),
+          disabled: !current_student.available?(approvable) && !current_student.approved?(approvable),
+          data: { action: "click->autosave-check#update click->loading#start", "loading-target": "checkbox" },
+        },
+      ) %>
+      <svg fill="none" viewBox="0 0 14 14" class="pointer-events-none col-start-1 row-start-1 size-3.5 self-center justify-self-center stroke-white group-has-disabled:stroke-white/25">
+        <path d="M3 8L6 11L11 3.5" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="opacity-0 group-has-checked:opacity-100">
+        </path>
+        <path d="M3 7H11" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="opacity-0 group-has-indeterminate:opacity-100">
+        </path>
+      </svg>
+    </div>
+  </div>
+<% end %>

--- a/app/views/subjects/_subject_with_tailwind.html.erb
+++ b/app/views/subjects/_subject_with_tailwind.html.erb
@@ -2,11 +2,10 @@
   <div class="min-w-0">
     <p class="text-sm/6 text-gray-900"><%= display_name(subject) %></p>
   </div>
-  <span class='flex two-checkboxes min-w-[100px] ms-[15px]'>
-    <%= render 'shared/checkbox_component', approvable: subject.course, subject_show: false %>
-
+  <span class='flex min-w-[90px] ms-[15px]'>
+    <%= render 'shared/tailwind_checkbox_component', approvable: subject.course, subject_show: false %>
     <% if subject.exam %>
-      <%= render 'shared/checkbox_component', approvable: subject.exam, subject_show: false %>
+      <%= render 'shared/tailwind_checkbox_component', approvable: subject.exam, subject_show: false %>
     <% end %>
   </span>
 </li>


### PR DESCRIPTION
## Motivation

Follow up for #682. This PR updates to the checkboxes of the subject list to use Tailwind CSS.

## Screenshots

### Before

<img width="376" alt="image" src="https://github.com/user-attachments/assets/bb101d1d-ba14-4e01-bbed-c078cf6f3998" />

### After

<img width="376" alt="image" src="https://github.com/user-attachments/assets/cb091e1e-78aa-479e-b9a1-1d8c2070a808" />