### PR TITLE
Use more secure password to avoid Chrome leaked password detection

### DIFF
--- a/test/controllers/registrations_controller_test.rb
+++ b/test/controllers/registrations_controller_test.rb
@@ -2,8 +2,8 @@ require "application_controller_test_case"
 
 class RegistrationsControllerTest < ApplicationControllerTestCase
   setup do
-    @oauth_user = create :user, provider: 'google_oauth2', uid: '123456'
-    @regular_user = create :user
+    @oauth_user = create :user, provider: 'google_oauth2', uid: '123456', password: 'secret'
+    @regular_user = create :user, password: 'secret'
   end
 
   test 'update email of regular user should maintain provider and uid as nil' do

--- a/test/factories/users.rb
+++ b/test/factories/users.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :user do
     sequence(:email) { |n| "user#{n}@example.com" }
-    password { "secret" }
+    password { "S3cr3tP@ssw0rd!" }
   end
 end

--- a/test/system/subjects_test.rb
+++ b/test/system/subjects_test.rb
@@ -83,7 +83,7 @@ class SubjectsTest < ApplicationSystemTestCase
 
     # Logged
     fill_in "Correo electrónico", with: user.email
-    fill_in "Contraseña", with: "secret"
+    fill_in "Contraseña", with: user.password
     click_button "Ingresar"
 
     assert_text "Iniciaste sesión correctamente"


### PR DESCRIPTION
System tests are intermittently failing because Chrome opens an alert asking to change the password

![image](https://github.com/user-attachments/assets/32185a4c-6f6f-4c43-9bbe-08340260b2b3)
