### PR TITLE
Configurar el color primario en tailwind

### DIFF
--- a/app/assets/tailwind/application.css
+++ b/app/assets/tailwind/application.css
@@ -1,1 +1,5 @@
 @import "tailwindcss";
+
+@theme {
+  --color-primary: #6200ee;
+}

--- a/app/components/approvable_checkbox_component.html.erb
+++ b/app/components/approvable_checkbox_component.html.erb
@@ -12,10 +12,9 @@
         id: dom_id(approvable),
         checked: checked?,
         disabled: disabled?,
-        class: "col-start-1 row-start-1 appearance-none rounded-sm border border-gray-300 bg-white checked:border-indigo-600 checked:bg-indigo-600 indeterminate:border-indigo-600 indeterminate:bg-indigo-600 focus-visible:outline-2 focus-visible:outline-offset-0 focus-visible:outline-indigo-600 disabled:border-gray-300 disabled:bg-gray-100 disabled:checked:bg-gray-100 forced-colors:appearance-auto",
+        class: "col-start-1 row-start-1 appearance-none rounded-sm border border-gray-300 bg-white checked:border-primary checked:bg-primary indeterminate:border-primary indeterminate:bg-primary focus-visible:outline-2 focus-visible:outline-offset-0 focus-visible:outline-primary disabled:border-gray-300 disabled:bg-gray-100 disabled:checked:bg-gray-100 forced-colors:appearance-auto",
         data: { action: "click->autosave-check#update click->loading#start", "loading-target": "checkbox" },
       ) %>
-
       <svg fill="none" viewBox="0 0 14 14" class="pointer-events-none col-start-1 row-start-1 size-3.5 self-center justify-self-center stroke-white group-has-disabled:stroke-white/25">
         <path d="M3 8L6 11L11 3.5" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="opacity-0 group-has-checked:opacity-100">
         </path>


### PR DESCRIPTION
Usando la [documentacion](https://tailwindcss.com/docs/functions-and-directives#theme-directive) de tailwindcss para la version 4.1

Ticket: https://github.com/orgs/cedarcode/projects/3/views/1?pane=issue&itemId=107986376
