### PR TITLE
Añadir helpers para renderizar view components

### DIFF
--- a/app/helpers/view_component_helper.rb
+++ b/app/helpers/view_component_helper.rb
@@ -1,0 +1,6 @@
+module ViewComponentHelper
+  def component(name, *args, **kwargs, &block)
+    component = "#{name.to_s.camelize}Component".constantize
+    render(component.new(*args, **kwargs), &block)
+  end
+end

--- a/app/views/subjects/_approvables.html.erb
+++ b/app/views/subjects/_approvables.html.erb
@@ -8,7 +8,7 @@
     </span>
 
     <span class="mdc-deprecated-list-item__meta">
-      <%= render(ApprovableCheckboxComponent.new(approvable: @subject.course, subject_show: true, current_student: current_student)) %>
+      <%= component(:approvable_checkbox, approvable: @subject.course, subject_show: true, current_student: current_student) %>
     </span>
   </label>
 
@@ -20,7 +20,7 @@
       </span>
 
       <span class="mdc-deprecated-list-item__meta">
-        <%= render(ApprovableCheckboxComponent.new(approvable: @subject.exam, subject_show: true, current_student: current_student)) %>
+        <%= component(:approvable_checkbox, approvable: @subject.exam, subject_show: true, current_student: current_student) %>
       </span>
     </label>
   <% end %>

--- a/app/views/subjects/_subject.html.erb
+++ b/app/views/subjects/_subject.html.erb
@@ -4,10 +4,10 @@
     <%= display_name(subject) %>
   <% end %>
   <span class="mdc-deprecated-list-item__meta two-checkboxes">
-    <%= render(ApprovableCheckboxComponent.new(approvable: subject.course, subject_show: false, current_student: current_student)) %>
+    <%= component(:approvable_checkbox, approvable: subject.course, subject_show: false, current_student: current_student) %>
 
     <% if subject.exam %>
-      <%= render(ApprovableCheckboxComponent.new(approvable: subject.exam, subject_show: false, current_student: current_student)) %>
+      <%= component(:approvable_checkbox, approvable: subject.exam, subject_show: false, current_student: current_student) %>
     <% end %>
   </span>
 </div>


### PR DESCRIPTION
## Motivación

Reducir un poco el `boilerplate` al renderizar componentes.

## Detalles

Este PR crea un `ViewComponentHelper` con el método `component` que infiere dinámicamente la clase del componente en base a un identificador (que puede ser un símbolo o un string) y lo renderiza con los parámetros que se le pasan.