### PR TITLE
Extraer las clases de los elementos de `ApprovableCheckboxComponent` a constantes de Ruby

### DIFF
--- a/app/components/approvable_checkbox_component.html.erb
+++ b/app/components/approvable_checkbox_component.html.erb
@@ -12,7 +12,7 @@
         id: dom_id(approvable),
         checked: checked?,
         disabled: disabled?,
-        class: "col-start-1 row-start-1 appearance-none rounded-sm border border-gray-300 bg-white checked:border-indigo-600 checked:bg-indigo-600 indeterminate:border-indigo-600 indeterminate:bg-indigo-600 focus-visible:outline-2 focus-visible:outline-offset-0 focus-visible:outline-indigo-600 disabled:border-gray-300 disabled:bg-gray-100 disabled:checked:bg-gray-100 forced-colors:appearance-auto",
+        class: STYLES[:checkbox].join(' '),
         data: { action: "click->autosave-check#update click->loading#start", "loading-target": "checkbox" },
       ) %>
 

--- a/app/components/approvable_checkbox_component.html.erb
+++ b/app/components/approvable_checkbox_component.html.erb
@@ -12,11 +12,11 @@
         id: dom_id(approvable),
         checked: checked?,
         disabled: disabled?,
-        class: STYLES[:checkbox].join(' '),
+        class: class_names(STYLES[:checkbox]),
         data: { action: "click->autosave-check#update click->loading#start", "loading-target": "checkbox" },
       ) %>
 
-    <svg fill="none" viewBox="0 0 14 14" class="<%= STYLES[:svg].join(' ') %>">
+    <svg fill="none" viewBox="0 0 14 14" class="<%= class_names(STYLES[:svg]) %>">
         <path d="M3 8L6 11L11 3.5" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="opacity-0 group-has-checked:opacity-100">
         </path>
         <path d="M3 7H11" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="opacity-0 group-has-indeterminate:opacity-100">

--- a/app/components/approvable_checkbox_component.html.erb
+++ b/app/components/approvable_checkbox_component.html.erb
@@ -12,7 +12,7 @@
         id: dom_id(approvable),
         checked: checked?,
         disabled: disabled?,
-        class: class_names(STYLES[:checkbox]),
+        class: STYLES[:checkbox],
         data: { action: "click->autosave-check#update click->loading#start", "loading-target": "checkbox" },
       ) %>
 

--- a/app/components/approvable_checkbox_component.html.erb
+++ b/app/components/approvable_checkbox_component.html.erb
@@ -16,7 +16,7 @@
         data: { action: "click->autosave-check#update click->loading#start", "loading-target": "checkbox" },
       ) %>
 
-      <svg fill="none" viewBox="0 0 14 14" class="pointer-events-none col-start-1 row-start-1 size-3.5 self-center justify-self-center stroke-white group-has-disabled:stroke-white/25">
+    <svg fill="none" viewBox="0 0 14 14" class="<%= STYLES[:svg].join(' ') %>">
         <path d="M3 8L6 11L11 3.5" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="opacity-0 group-has-checked:opacity-100">
         </path>
         <path d="M3 7H11" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="opacity-0 group-has-indeterminate:opacity-100">

--- a/app/components/approvable_checkbox_component.html.erb
+++ b/app/components/approvable_checkbox_component.html.erb
@@ -16,7 +16,7 @@
         data: { action: "click->autosave-check#update click->loading#start", "loading-target": "checkbox" },
       ) %>
 
-    <svg fill="none" viewBox="0 0 14 14" class="<%= class_names(STYLES[:svg]) %>">
+      <svg fill="none" viewBox="0 0 14 14" class="<%= class_names(STYLES[:svg]) %>">
         <path d="M3 8L6 11L11 3.5" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="opacity-0 group-has-checked:opacity-100">
         </path>
         <path d="M3 7H11" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="opacity-0 group-has-indeterminate:opacity-100">

--- a/app/components/approvable_checkbox_component.rb
+++ b/app/components/approvable_checkbox_component.rb
@@ -27,6 +27,16 @@ class ApprovableCheckboxComponent < ViewComponent::Base
 
       forced-colors:appearance-auto
     ],
+    svg: %w[
+      pointer-events-none
+      col-start-1
+      row-start-1
+      size-3.5
+      self-center
+      justify-self-center
+      stroke-white
+      group-has-disabled:stroke-white/25
+    ],
   }
 
   attr_reader :approvable, :subject_show, :current_student

--- a/app/components/approvable_checkbox_component.rb
+++ b/app/components/approvable_checkbox_component.rb
@@ -1,6 +1,34 @@
 # frozen_string_literal: true
 
 class ApprovableCheckboxComponent < ViewComponent::Base
+  STYLES = {
+    checkbox: %w[
+      col-start-1
+      row-start-1
+      appearance-none
+      rounded-sm
+      border
+      border-gray-300
+      bg-white
+
+      checked:border-indigo-600
+      checked:bg-indigo-600
+
+      indeterminate:border-indigo-600
+      indeterminate:bg-indigo-600
+
+      focus-visible:outline-2
+      focus-visible:outline-offset-0
+      focus-visible:outline-indigo-600
+
+      disabled:border-gray-300
+      disabled:bg-gray-100
+      disabled:checked:bg-gray-100
+
+      forced-colors:appearance-auto
+    ],
+  }
+
   attr_reader :approvable, :subject_show, :current_student
 
   def initialize(approvable:, subject_show:, current_student:)


### PR DESCRIPTION
Sugerido por https://github.com/cedarcode/mi_carrera/pull/709#discussion_r2069562539 y https://github.com/cedarcode/mi_carrera/pull/709#discussion_r2070912950.