### PR TITLE
Borrar clases innecesarias de `ApprovableCheckboxComponent`

### DIFF
--- a/app/components/approvable_checkbox_component.rb
+++ b/app/components/approvable_checkbox_component.rb
@@ -14,9 +14,6 @@ class ApprovableCheckboxComponent < ViewComponent::Base
       checked:border-primary
       checked:bg-primary
 
-      indeterminate:border-primary
-      indeterminate:bg-primary
-
       focus-visible:outline-2
       focus-visible:outline-offset-0
       focus-visible:outline-primary


### PR DESCRIPTION
Estos checkboxes nunca se renderizan con el estado `indeterminate`, así que podemos simplemente borrar las clases asociadas a este.