### PR TITLE
Send logs to AppSignal

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -30,9 +30,10 @@ Rails.application.configure do
   # Skip http-to-https redirect for the default health check endpoint.
   # config.ssl_options = { redirect: { exclude: ->(request) { request.path == "/up" } } }
 
-  # Log to STDOUT with the current request id as a default log tag.
+  # Log to AppSignal with the current request id as a default log tag.
   config.log_tags = [ :request_id ]
-  config.logger   = ActiveSupport::TaggedLogging.logger(STDOUT)
+  appsignal_logger = Appsignal::Logger.new("rails")
+  config.logger = ActiveSupport::TaggedLogging.new(appsignal_logger)
 
   # Change to "debug" to log everything (including potentially personally-identifiable information!)
   config.log_level = ENV.fetch("RAILS_LOG_LEVEL", "info")


### PR DESCRIPTION
- Empezar a usar el `logger`  de `Appsignal` en producción y staging.

Documentación:
https://docs.appsignal.com/logging/integrations/ruby.html