### PR TITLE
Clean up password routes code

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,22 +6,15 @@ Rails.application.routes.draw do
     # Can be used by load balancers and uptime monitors to verify that the app is live.
     get "up" => "rails/health#show", as: :rails_health_check
 
-    devise_for :users, path: "usuarios", skip: :passwords, controllers: {
+    devise_for :users, path: "usuarios", controllers: {
       omniauth_callbacks: 'users/omniauth_callbacks',
       registrations: 'users/registrations'
     }, path_names: {
       sign_in: 'iniciar_sesion',
       sign_out: 'cerrar_sesion',
       sign_up: 'registrarse',
+      password: 'contraseña',
     }
-
-    as :user do
-      get 'usuarios/contraseña/nueva', to: 'devise/passwords#new', as: :new_user_password
-      get 'usuarios/contraseña/editar', to: 'devise/passwords#edit', as: :edit_user_password
-      patch 'usuarios/contraseña', to: 'devise/passwords#update', as: :user_password
-      put 'usuarios/contraseña', to: 'devise/passwords#update'
-      post 'usuarios/contraseña', to: 'devise/passwords#create'
-    end
 
     root to: "subjects#index"
 


### PR DESCRIPTION
Abordando este comment: https://github.com/cedarcode/mi_carrera/pull/711#discussion_r2079716900

Las rutas se mantienen:
```
➜  mi_carrera git:(jt--cleanup_routes_code) ✗ diff routes1 routes2
8a9,13
>                     new_user_password GET      /usuarios/contrase%C3%B1a/nueva(.:format)       devise/passwords#new
>                    edit_user_password GET      /usuarios/contrase%C3%B1a/editar(.:format)      devise/passwords#edit
>                         user_password PATCH    /usuarios/contrase%C3%B1a(.:format)             devise/passwords#update
>                                       PUT      /usuarios/contrase%C3%B1a(.:format)             devise/passwords#update
>                                       POST     /usuarios/contrase%C3%B1a(.:format)             devise/passwords#create
19,23d23
<                     new_user_password GET      /usuarios/contrase%C3%B1a/nueva(.:format)       devise/passwords#new
<                    edit_user_password GET      /usuarios/contrase%C3%B1a/editar(.:format)      devise/passwords#edit
<                         user_password PATCH    /usuarios/contrase%C3%B1a(.:format)             devise/passwords#update
<                                       PUT      /usuarios/contrase%C3%B1a(.:format)             devise/passwords#update
<                                       POST     /usuarios/contrase%C3%B1a(.:format)             devise/passwords#create
```