### PR TITLE
Agregar `Ingeniería Eléctrica`

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,7 @@ ruby file: ".ruby-version"
 
 gem 'rails', '~> 8.0.2'
 
+gem 'acts_as_tenant', '~> 1.0'
 gem 'appsignal', '~> 4.5'
 gem 'bootsnap', '~> 1.18', require: false
 gem 'devise', '~> 4.9'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -73,6 +73,8 @@ GEM
       securerandom (>= 0.3)
       tzinfo (~> 2.0, >= 2.0.5)
       uri (>= 0.13.1)
+    acts_as_tenant (1.0.1)
+      rails (>= 6.0)
     addressable (2.8.6)
       public_suffix (>= 2.0.2, < 6.0)
     afm (0.2.2)
@@ -441,6 +443,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  acts_as_tenant (~> 1.0)
   appsignal (~> 4.5)
   bootsnap (~> 1.18)
   brakeman (~> 7.0)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,8 +1,14 @@
 class ApplicationController < ActionController::Base
   helper_method :current_student
   rate_limit to: 20, within: 10.seconds
+  set_current_tenant_through_filter
+  before_action :switch_tenant
 
   private
+
+  def switch_tenant
+    set_current_tenant(current_student.degree)
+  end
 
   def current_student
     @current_student ||= current_user ? UserStudent.new(current_user) : CookieStudent.new(cookies)

--- a/app/controllers/student_degrees_controller.rb
+++ b/app/controllers/student_degrees_controller.rb
@@ -1,0 +1,7 @@
+class StudentDegreesController < ApplicationController
+  def update
+    degree_id = params[:degree]
+    current_student.change_degree(degree_id)
+    redirect_to root_path
+  end
+end

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -24,7 +24,7 @@ class Users::RegistrationsController < Devise::RegistrationsController
   end
 
   def configure_permitted_parameters_sign_up
-    devise_parameter_sanitizer.permit(:sign_up, keys: [:email, :password, :password_confirmation])
+    devise_parameter_sanitizer.permit(:sign_up, keys: [:email, :degree_id, :password, :password_confirmation])
   end
 
   def configure_permitted_parameters_account_update

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -40,4 +40,8 @@ module ApplicationHelper
       raise "Unexpected logical operator: #{prerequisite.logical_operator}"
     end
   end
+
+  def prompt_for_degree_selection?
+    current_student.degree.blank? && ['subjects', 'profiles'].include?(controller_path)
+  end
 end

--- a/app/models/approvable.rb
+++ b/app/models/approvable.rb
@@ -1,4 +1,6 @@
 class Approvable < ApplicationRecord
+  acts_as_tenant :degree
+
   belongs_to :subject
   has_one :prerequisite_tree, class_name: "Prerequisite", dependent: :destroy
 

--- a/app/models/base_student.rb
+++ b/app/models/base_student.rb
@@ -35,6 +35,8 @@ class BaseStudent
   def group_credits_met?(group) = group_credits(group) >= group.credits_needed
   def groups_credits_met? = SubjectGroup.all.all? { |group| group_credits_met?(group) }
   def graduated? = total_credits >= 450 && groups_credits_met?
+  def change_degree(degree) = raise NotImplementedError
+  def degree = raise NotImplementedError
 
   private
 

--- a/app/models/cookie_student.rb
+++ b/app/models/cookie_student.rb
@@ -15,6 +15,19 @@ class CookieStudent < BaseStudent
     }
   end
 
+  def change_degree(degree_id)
+    cookie[:degree] = {
+      value: degree_id,
+      domain: :all
+    }
+  end
+
+  def degree
+    return unless cookie[:degree]
+
+    Degree.find(cookie[:degree])
+  end
+
   private
 
   attr_reader :cookie

--- a/app/models/degree.rb
+++ b/app/models/degree.rb
@@ -1,3 +1,5 @@
 class Degree < ApplicationRecord
+  has_many :users, dependent: :nullify
+
   validates :key, presence: true, uniqueness: true
 end

--- a/app/models/degree.rb
+++ b/app/models/degree.rb
@@ -1,0 +1,3 @@
+class Degree < ApplicationRecord
+  validates :key, presence: true, uniqueness: true
+end

--- a/app/models/prerequisite.rb
+++ b/app/models/prerequisite.rb
@@ -1,4 +1,6 @@
 class Prerequisite < ApplicationRecord
+  acts_as_tenant :degree
+
   belongs_to :parent_prerequisite, class_name: 'Prerequisite', optional: true
   belongs_to :approvable, optional: true
 

--- a/app/models/review.rb
+++ b/app/models/review.rb
@@ -1,4 +1,6 @@
 class Review < ApplicationRecord
+  acts_as_tenant :degree
+
   belongs_to :user
   belongs_to :subject
 

--- a/app/models/subject.rb
+++ b/app/models/subject.rb
@@ -1,4 +1,6 @@
 class Subject < ApplicationRecord
+  acts_as_tenant :degree
+
   has_one :course, -> { where is_exam: false }, class_name: 'Approvable', dependent: :destroy, inverse_of: :subject
   has_one :exam, -> { where is_exam: true }, class_name: 'Approvable', dependent: :destroy, inverse_of: :subject
   belongs_to :group, class_name: 'SubjectGroup', optional: true
@@ -6,7 +8,7 @@ class Subject < ApplicationRecord
 
   validates :name, presence: true
   validates :credits, presence: true
-  validates :code, uniqueness: true
+  validates_uniqueness_to_tenant :code
 
   scope :with_exam, -> { includes(:exam, :course).where.not(exam: { id: nil }) }
   scope :without_exam, -> { includes(:exam, :course).where(exam: { id: nil }) }

--- a/app/models/subject_group.rb
+++ b/app/models/subject_group.rb
@@ -1,6 +1,8 @@
 class SubjectGroup < ApplicationRecord
+  acts_as_tenant :degree
+
   has_many :subjects, foreign_key: :group_id, inverse_of: :group, dependent: :restrict_with_exception
 
   validates :name, presence: true
-  validates :code, uniqueness: true
+  validates_uniqueness_to_tenant :code
 end

--- a/app/models/subject_plan.rb
+++ b/app/models/subject_plan.rb
@@ -1,4 +1,6 @@
 class SubjectPlan < ApplicationRecord
+  acts_as_tenant :degree
+
   belongs_to :user
   belongs_to :subject
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -8,6 +8,7 @@ class User < ApplicationRecord
   has_many :reviews, dependent: :destroy
   has_many :subject_plans, dependent: :destroy
   has_many :planned_subjects, through: :subject_plans, source: :subject
+  belongs_to :degree, optional: true
 
   def self.from_omniauth(auth, cookie)
     # check that user with same email exists

--- a/app/models/user_student.rb
+++ b/app/models/user_student.rb
@@ -12,6 +12,8 @@ class UserStudent < BaseStudent
     user.update!(welcome_banner_viewed: true)
   end
 
+  delegate :degree, to: :user
+
   private
 
   attr_reader :user

--- a/app/models/user_student.rb
+++ b/app/models/user_student.rb
@@ -12,6 +12,10 @@ class UserStudent < BaseStudent
     user.update!(welcome_banner_viewed: true)
   end
 
+  def change_degree(degree_id)
+    user.update!(degree_id:)
+  end
+
   delegate :degree, to: :user
 
   private

--- a/app/services/yml_loader.rb
+++ b/app/services/yml_loader.rb
@@ -8,11 +8,13 @@ class YmlLoader
 
   def initialize(degree_hash)
     @degree_hash = degree_hash
-    @degree_dir = Rails.root.join("db/data/#{degree_hash[:key]}/")
+    @degree_key = degree_hash[:key]
+    @degree_dir = Rails.root.join("db/data/#{@degree_key}/")
   end
 
   def load
     load_degree
+    switch_tenant
     load_subject_groups
     load_subjects
     load_prerequisites
@@ -22,14 +24,19 @@ class YmlLoader
   private
 
   attr_reader :degree_hash
+  attr_reader :degree_key
   attr_reader :degree_dir
 
   def load_degree
-    degree = Degree.find_or_initialize_by(key: degree_hash[:key])
-    degree.name = degree_hash[:name]
-    degree.current_plan = degree_hash[:current_plan]
-    degree.include_inco_subjects = degree_hash[:include_inco_subjects]
-    degree.save!
+    @degree = Degree.find_or_initialize_by(key: degree_key)
+    @degree.name = degree_hash[:name]
+    @degree.current_plan = degree_hash[:current_plan]
+    @degree.include_inco_subjects = degree_hash[:include_inco_subjects]
+    @degree.save!
+  end
+
+  def switch_tenant
+    ActsAsTenant.current_tenant = @degree
   end
 
   def load_subject_groups

--- a/app/services/yml_loader.rb
+++ b/app/services/yml_loader.rb
@@ -18,7 +18,7 @@ class YmlLoader
     load_subject_groups
     load_subjects
     load_prerequisites
-    load_current_optional_subjects
+    load_current_optional_subjects if degree_hash[:include_inco_subjects]
   end
 
   private

--- a/app/services/yml_loader.rb
+++ b/app/services/yml_loader.rb
@@ -1,16 +1,18 @@
 class YmlLoader
   def self.load
     degrees = Rails.configuration.degrees
-    degrees.each do |degree|
-      new(degree[:key]).load
+    degrees.each do |degree_hash|
+      new(degree_hash).load
     end
   end
 
-  def initialize(degree_key)
-    @degree_dir = Rails.root.join("db/data/#{degree_key}/")
+  def initialize(degree_hash)
+    @degree_hash = degree_hash
+    @degree_dir = Rails.root.join("db/data/#{degree_hash[:key]}/")
   end
 
   def load
+    load_degree
     load_subject_groups
     load_subjects
     load_prerequisites
@@ -19,7 +21,16 @@ class YmlLoader
 
   private
 
+  attr_reader :degree_hash
   attr_reader :degree_dir
+
+  def load_degree
+    degree = Degree.find_or_initialize_by(key: degree_hash[:key])
+    degree.name = degree_hash[:name]
+    degree.current_plan = degree_hash[:current_plan]
+    degree.include_inco_subjects = degree_hash[:include_inco_subjects]
+    degree.save!
+  end
 
   def load_subject_groups
     subject_groups = YAML.load_file(degree_dir.join("scraped_subject_groups.yml"))

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -11,6 +11,13 @@
 
       <%= render PasswordFieldComponent.new(form: f, attribute: :password_confirmation, label: "Confirma tu contraseña", input_options: { required: true, autocomplete: "new-password" }) %>
 
+      <p class="text-sm text-gray-500">Para continuar, por favor seleccioná una carrera:</p>
+      <%= render partial: 'shared/select_field', locals: {
+        f: f,
+        field_name: :degree_id,
+        collection: Degree.all.pluck(:name, :id),
+      } %>
+
       <%= f.button "Registrarte", class: "mdc-button mdc-button--raised self-center" %>
     <% end %>
 

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -94,6 +94,7 @@
         <% end %>
         <%= yield :welcome_banner %>
         <div class='content'>
+          <%= render 'shared/degree_select_modal' %>
           <%= yield %>
         </div>
       </main>

--- a/app/views/shared/_degree_select_modal.html.erb
+++ b/app/views/shared/_degree_select_modal.html.erb
@@ -1,0 +1,37 @@
+<% if prompt_for_degree_selection? %>
+  <div class="relative z-10">
+    <div class="fixed inset-0 bg-gray-500/75 transition-opacity" aria-hidden="true"></div>
+    <div class="fixed inset-0 z-10 w-screen overflow-y-auto">
+      <div class="flex min-h-full items-center justify-center p-4 text-center sm:items-center sm:p-0">
+        <%= form_with url: student_degrees_path, method: :patch do |f| %>
+          <div class="relative transform overflow-hidden rounded-lg bg-white text-left shadow-xl transition-all sm:my-8 sm:w-full sm:max-w-lg">
+            <div class="bg-white px-4 pt-5 pb-4 sm:p-6 sm:pb-4">
+              <div class="sm:flex sm:items-center">
+                <div class="mt-3 text-center sm:mt-0 sm:mx-4 sm:text-center">
+                  <h1 class="text-xl font-semibold text-gray-900">Seleccionar carrera</h3>
+                  <div class="mt-3">
+                    <p class="text-sm text-gray-500 mb-4">Para continuar, por favor seleccioná una carrera:</p>
+                    <%= render partial: 'shared/select_field', locals: {
+                      f: f,
+                      field_name: :degree,
+                      collection: Degree.all.pluck(:name, :id),
+                    } %>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div class="flex flex-col p-5">
+              <%= f.button class: 'mdc-button mdc-button--raised' do %>
+                <div class="mdc-button__label">Seleccionar</div>
+              <% end %>
+            </div>
+            <div class="py-2 flex items-center text-sm text-gray-500 before:flex-1 before:border-t before:border-gray-200 before:me-6 after:flex-1 after:border-t after:border-gray-200 after:ms-6"> o ingresá con tu cuenta </div>
+            <li class="flex flex-col p-5">
+              <%= link_to 'Ingresar', new_user_session_path, class: 'mdc-button mdc-button--raised'%>
+            </li>
+          </div>
+        <% end %>
+      </div>
+    </div>
+  </div>
+<% end %>

--- a/app/views/shared/_select_field.html.erb
+++ b/app/views/shared/_select_field.html.erb
@@ -1,0 +1,7 @@
+<div>
+  <button type="button" class="grid w-full cursor-default grid-cols-1 rounded-md bg-white py-1.5 pr-2 pl-3 text-left text-gray-900 outline-1 -outline-offset-1 outline-gray-300 focus:outline-2 focus:-outline-offset-2 focus:outline-indigo-600 sm:text-sm/6">
+    <%= f.select field_name,
+                 collection,
+                 { class: "mt-1 block w-full rounded-md border-gray-300 shadow-sm" } %>
+  </button>
+</div>

--- a/config/degrees.yml
+++ b/config/degrees.yml
@@ -4,3 +4,7 @@ shared:
   key: "computacion"
   current_plan: "1997"
   include_inco_subjects: true
+- name: "INGENIERIA ELECTRICA"
+  key: "electrica"
+  current_plan: "2023"
+  include_inco_subjects: false

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -34,6 +34,8 @@ Rails.application.routes.draw do
 
     resource :user_onboardings, only: :update
 
+    resource :student_degrees, only: :update
+
     resources :current_optional_subjects, path: "materias_inco_semestre_actual", only: :index
 
     resources :transcripts, path: "escolaridades", only: [:new, :create]

--- a/db/data/electrica/scraped_prerequisites.yml
+++ b/db/data/electrica/scraped_prerequisites.yml
@@ -1,0 +1,12401 @@
+---
+- type: logical
+  logical_operator: and
+  operands:
+  - type: logical
+    logical_operator: not
+    operands:
+    - type: logical
+      logical_operator: or
+      operands:
+      - type: subject
+        subject_needed_code: CP23
+        subject_needed_name: CRÉDITOS POR LABORATORIO GENERAL
+        needs: exam
+      - type: subject
+        subject_needed_code: CP03
+        subject_needed_name: CRÉDITOS POR QCA. ANAL. CUALITATIVA
+        needs: exam
+      - type: subject
+        subject_needed_code: CP22
+        subject_needed_name: CRÉDITOS POR QCA. GENERAL E INORGÁNICA
+        needs: exam
+      - type: subject
+        subject_needed_code: CP02
+        subject_needed_name: CRÉDITOS POR QUÍMICA GENERAL
+        needs: exam
+      - type: subject
+        subject_needed_code: '601'
+        subject_needed_name: LABORATORIO GENERAL (PLAN 1992)
+        needs: course
+      - type: subject
+        subject_needed_code: '189'
+        subject_needed_name: QCA. ANALÍTICA CUALITATIVA (ANUAL 1986)
+        needs: course
+      - type: subject
+        subject_needed_code: 189R
+        subject_needed_name: QCA. ANALÍTICA CUALITATIVA (ANUAL 1986)
+        needs: exam
+      - type: subject
+        subject_needed_code: '183'
+        subject_needed_name: QCA. ANALÍTICA CUALITATIVA I (SEM. 1980)
+        needs: course
+      - type: subject
+        subject_needed_code: '284'
+        subject_needed_name: QCA. ANALÍTICA CUALITATIVA II (SEM.1980)
+        needs: course
+      - type: subject
+        subject_needed_code: '188'
+        subject_needed_name: QCA. GENERAL (ANUAL 1986)
+        needs: course
+      - type: subject
+        subject_needed_code: 188R
+        subject_needed_name: QCA. GENERAL (ANUAL 1986)
+        needs: exam
+      - type: subject
+        subject_needed_code: '600'
+        subject_needed_name: QCA. GENERAL E INORGÁNICA (PLAN 1992)
+        needs: course
+      - type: subject
+        subject_needed_code: 102R
+        subject_needed_name: QCA. GENERAL I (PLAN 2000)
+        needs: exam
+      - type: subject
+        subject_needed_code: '181'
+        subject_needed_name: QCA. GENERAL I (SEMESTRAL 1980)
+        needs: course
+      - type: subject
+        subject_needed_code: '186'
+        subject_needed_name: QCA. GENERAL II (SEMESTRAL 1980)
+        needs: course
+  subject_code: '102'
+  is_exam: false
+- type: logical
+  logical_operator: and
+  operands:
+  - type: subject
+    needs: course
+    subject_needed_code: '102'
+    subject_needed_name: QUÍMICA GENERAL I
+  subject_code: '102'
+  is_exam: true
+- type: logical
+  logical_operator: and
+  operands:
+  - type: logical
+    logical_operator: not
+    operands:
+    - type: logical
+      logical_operator: and
+      operands:
+      - type: subject
+        subject_needed_code: CP1
+        subject_needed_name: ANALISIS MATEMATICO I
+        needs: all
+      - type: subject
+        subject_needed_code: CP6
+        subject_needed_name: ANALISIS MATEMATICO II
+        needs: all
+      - type: subject
+        subject_needed_code: CP2
+        subject_needed_name: GEOMETRIA Y ALGEBRA LINEAL
+        needs: all
+  - type: logical
+    logical_operator: not
+    operands:
+    - type: logical
+      logical_operator: and
+      operands:
+      - type: subject
+        subject_needed_code: CP1
+        subject_needed_name: ANALISIS MATEMATICO I
+        needs: all
+      - type: subject
+        subject_needed_code: CP2
+        subject_needed_name: GEOMETRIA Y ALGEBRA LINEAL
+        needs: all
+      - type: subject
+        subject_needed_code: CP4
+        subject_needed_name: LOGICA
+        needs: all
+  - type: logical
+    logical_operator: not
+    operands:
+    - type: logical
+      logical_operator: or
+      operands:
+      - type: subject
+        subject_needed_code: MA15
+        subject_needed_name: CREDITOS ASIGNADOS POR REVALIDA
+        needs: all
+      - type: subject
+        subject_needed_code: MA29
+        subject_needed_name: CREDITOS ASIGNADOS POR REVALIDA
+        needs: all
+      - type: subject
+        subject_needed_code: M24
+        subject_needed_name: CREDITOS ASIGNADOS POR REVALIDA
+        needs: all
+  subject_code: '1023'
+  is_exam: false
+- type: logical
+  logical_operator: and
+  operands:
+  - type: logical
+    logical_operator: not
+    operands:
+    - type: logical
+      logical_operator: and
+      operands:
+      - type: subject
+        subject_needed_code: CP1
+        subject_needed_name: ANALISIS MATEMATICO I
+        needs: all
+      - type: subject
+        subject_needed_code: CP6
+        subject_needed_name: ANALISIS MATEMATICO II
+        needs: all
+      - type: subject
+        subject_needed_code: CP2
+        subject_needed_name: GEOMETRIA Y ALGEBRA LINEAL
+        needs: all
+  - type: logical
+    logical_operator: not
+    operands:
+    - type: logical
+      logical_operator: and
+      operands:
+      - type: subject
+        subject_needed_code: CP1
+        subject_needed_name: ANALISIS MATEMATICO I
+        needs: all
+      - type: subject
+        subject_needed_code: CP2
+        subject_needed_name: GEOMETRIA Y ALGEBRA LINEAL
+        needs: all
+      - type: subject
+        subject_needed_code: CP4
+        subject_needed_name: LOGICA
+        needs: all
+  - type: logical
+    logical_operator: not
+    operands:
+    - type: logical
+      logical_operator: or
+      operands:
+      - type: subject
+        subject_needed_code: MA15
+        subject_needed_name: CREDITOS ASIGNADOS POR REVALIDA
+        needs: all
+      - type: subject
+        subject_needed_code: MA29
+        subject_needed_name: CREDITOS ASIGNADOS POR REVALIDA
+        needs: all
+      - type: subject
+        subject_needed_code: M24
+        subject_needed_name: CREDITOS ASIGNADOS POR REVALIDA
+        needs: all
+  subject_code: '1023'
+  is_exam: true
+- type: logical
+  logical_operator: and
+  operands:
+  - type: logical
+    logical_operator: not
+    operands:
+    - type: logical
+      logical_operator: or
+      operands:
+      - type: subject
+        subject_needed_code: CP6
+        subject_needed_name: ANALISIS MATEMATICO II
+        needs: exam
+      - type: subject
+        subject_needed_code: CP25
+        subject_needed_name: ANALISIS MATEMATICO II (P. 74)
+        needs: exam
+      - type: subject
+        subject_needed_code: CP49
+        subject_needed_name: ANALISIS MATEMATICO II (2DO.SEM.)
+        needs: exam
+      - type: subject
+        subject_needed_code: 1025P
+        subject_needed_name: CREDITOS NO ACUM PROB Y EST.
+        needs: exam
+  - type: logical
+    logical_operator: or
+    operands:
+    - type: subject
+      subject_needed_code: CP1
+      subject_needed_name: ANALISIS MATEMATICO I
+      needs: exam
+    - type: subject
+      subject_needed_code: CP22
+      subject_needed_name: ANALISIS MATEMATICO I (P. 74)
+      needs: exam
+    - type: subject
+      subject_needed_code: '1062'
+      subject_needed_name: CALCULO DIF. E INTEGRAL EN VARIAS VARIABLES
+      needs: course
+    - type: subject
+      subject_needed_code: '1022'
+      subject_needed_name: CALCULO 2
+      needs: exam
+    - type: subject
+      subject_needed_code: '1072'
+      subject_needed_name: CALCULO 2
+      needs: exam
+    - type: subject
+      subject_needed_code: 172Q
+      subject_needed_name: CALCULO 2
+      needs: exam
+    - type: subject
+      subject_needed_code: MAT33
+      subject_needed_name: CREDITOS ASIGNADOS POR REVALIDA
+      needs: exam
+    - type: subject
+      subject_needed_code: MA47
+      subject_needed_name: CREDITOS ASIGNADOS POR REVALIDA
+      needs: exam
+    - type: subject
+      subject_needed_code: 1062P
+      subject_needed_name: CREDITOS NO ACUM CDIVV
+      needs: exam
+  - type: logical
+    logical_operator: or
+    operands:
+    - type: subject
+      subject_needed_code: '1021'
+      subject_needed_name: ALGEBRA LINEAL
+      needs: course
+    - type: subject
+      subject_needed_code: CM14
+      subject_needed_name: CREDITOS ASIGNADOS POR REVALIDA
+      needs: exam
+    - type: subject
+      subject_needed_code: MAT33
+      subject_needed_name: CREDITOS ASIGNADOS POR REVALIDA
+      needs: exam
+    - type: subject
+      subject_needed_code: M9
+      subject_needed_name: CREDITOS ASIGNADOS POR REVALIDA
+      needs: exam
+    - type: subject
+      subject_needed_code: 1030P
+      subject_needed_name: CREDITOS NO ACUM GAL1
+      needs: exam
+    - type: subject
+      subject_needed_code: CP2
+      subject_needed_name: GEOMETRIA Y ALGEBRA LINEAL
+      needs: exam
+    - type: subject
+      subject_needed_code: CP23
+      subject_needed_name: GEOMETRIA Y ALGEBRA LINEAL (P. 74)
+      needs: exam
+    - type: subject
+      subject_needed_code: '1030'
+      subject_needed_name: GEOMETRIA Y ALGEBRA LINEAL 1
+      needs: exam
+    - type: subject
+      subject_needed_code: '1071'
+      subject_needed_name: GEOMETRIA Y ALGEBRA LINEAL 1
+      needs: exam
+    - type: subject
+      subject_needed_code: 171L
+      subject_needed_name: GEOMETRIA Y ALGEBRA LINEAL 1
+      needs: exam
+    - type: subject
+      subject_needed_code: 171Q
+      subject_needed_name: GEOMETRIA Y ALGEBRA LINEAL 1
+      needs: exam
+    - type: subject
+      subject_needed_code: '1053'
+      subject_needed_name: GEOMETRIA Y ALGEBRA LINEAL 1 (ANUAL)
+      needs: exam
+    - type: subject
+      subject_needed_code: GAL1P
+      subject_needed_name: GEOMETRIA Y ALGEBRA LINEAL 1 INTERACTIVA
+      needs: exam
+  - type: logical
+    logical_operator: or
+    operands:
+    - type: subject
+      subject_needed_code: CP1
+      subject_needed_name: ANALISIS MATEMATICO I
+      needs: exam
+    - type: subject
+      subject_needed_code: CP22
+      subject_needed_name: ANALISIS MATEMATICO I (P. 74)
+      needs: exam
+    - type: subject
+      subject_needed_code: '1061'
+      subject_needed_name: CALCULO DIF. E INTEGRAL EN UNA VARIABLE
+      needs: exam
+    - type: subject
+      subject_needed_code: '1020'
+      subject_needed_name: CALCULO 1
+      needs: exam
+    - type: subject
+      subject_needed_code: 107L
+      subject_needed_name: CALCULO 1
+      needs: exam
+    - type: subject
+      subject_needed_code: '1070'
+      subject_needed_name: CALCULO 1
+      needs: exam
+    - type: subject
+      subject_needed_code: 170Q
+      subject_needed_name: CALCULO 1
+      needs: exam
+    - type: subject
+      subject_needed_code: '1052'
+      subject_needed_name: CALCULO 1 (ANUAL)
+      needs: exam
+    - type: subject
+      subject_needed_code: CAL10
+      subject_needed_name: CREDITOS ASIGNADOS POR REVALIDA
+      needs: exam
+    - type: subject
+      subject_needed_code: MAT33
+      subject_needed_name: CREDITOS ASIGNADOS POR REVALIDA
+      needs: exam
+    - type: subject
+      subject_needed_code: MA47
+      subject_needed_name: CREDITOS ASIGNADOS POR REVALIDA
+      needs: exam
+    - type: subject
+      subject_needed_code: M13
+      subject_needed_name: CREDITOS ASIGNADOS POR REVALIDA
+      needs: exam
+    - type: subject
+      subject_needed_code: 1020P
+      subject_needed_name: CREDITOS NO ACUM CALCULO 1
+      needs: exam
+    - type: subject
+      subject_needed_code: 1061P
+      subject_needed_name: CREDITOS NO ACUM CDIV
+      needs: exam
+  subject_code: '1025'
+  is_exam: false
+- type: logical
+  logical_operator: and
+  operands:
+  - type: logical
+    logical_operator: not
+    operands:
+    - type: logical
+      logical_operator: or
+      operands:
+      - type: subject
+        subject_needed_code: CP6
+        subject_needed_name: ANALISIS MATEMATICO II
+        needs: exam
+      - type: subject
+        subject_needed_code: CP25
+        subject_needed_name: ANALISIS MATEMATICO II (P. 74)
+        needs: exam
+      - type: subject
+        subject_needed_code: CP49
+        subject_needed_name: ANALISIS MATEMATICO II (2DO.SEM.)
+        needs: exam
+      - type: subject
+        subject_needed_code: 1025P
+        subject_needed_name: CREDITOS NO ACUM PROB Y EST.
+        needs: exam
+  - type: logical
+    logical_operator: or
+    operands:
+    - type: logical
+      logical_operator: and
+      operands:
+      - type: logical
+        logical_operator: or
+        operands:
+        - type: subject
+          subject_needed_code: CP1
+          subject_needed_name: ANALISIS MATEMATICO I
+          needs: exam
+        - type: subject
+          subject_needed_code: CP22
+          subject_needed_name: ANALISIS MATEMATICO I (P. 74)
+          needs: exam
+        - type: subject
+          subject_needed_code: '1061'
+          subject_needed_name: CALCULO DIF. E INTEGRAL EN UNA VARIABLE
+          needs: exam
+        - type: subject
+          subject_needed_code: '1020'
+          subject_needed_name: CALCULO 1
+          needs: exam
+        - type: subject
+          subject_needed_code: 107L
+          subject_needed_name: CALCULO 1
+          needs: exam
+        - type: subject
+          subject_needed_code: '1070'
+          subject_needed_name: CALCULO 1
+          needs: exam
+        - type: subject
+          subject_needed_code: 170Q
+          subject_needed_name: CALCULO 1
+          needs: exam
+        - type: subject
+          subject_needed_code: '1052'
+          subject_needed_name: CALCULO 1 (ANUAL)
+          needs: exam
+        - type: subject
+          subject_needed_code: CAL10
+          subject_needed_name: CREDITOS ASIGNADOS POR REVALIDA
+          needs: exam
+        - type: subject
+          subject_needed_code: MAT33
+          subject_needed_name: CREDITOS ASIGNADOS POR REVALIDA
+          needs: exam
+        - type: subject
+          subject_needed_code: MA47
+          subject_needed_name: CREDITOS ASIGNADOS POR REVALIDA
+          needs: exam
+        - type: subject
+          subject_needed_code: M13
+          subject_needed_name: CREDITOS ASIGNADOS POR REVALIDA
+          needs: exam
+        - type: subject
+          subject_needed_code: 1020P
+          subject_needed_name: CREDITOS NO ACUM CALCULO 1
+          needs: exam
+        - type: subject
+          subject_needed_code: 1061P
+          subject_needed_name: CREDITOS NO ACUM CDIV
+          needs: exam
+      - type: logical
+        logical_operator: or
+        operands:
+        - type: subject
+          subject_needed_code: CP1
+          subject_needed_name: ANALISIS MATEMATICO I
+          needs: exam
+        - type: subject
+          subject_needed_code: CP22
+          subject_needed_name: ANALISIS MATEMATICO I (P. 74)
+          needs: exam
+        - type: subject
+          subject_needed_code: '1062'
+          subject_needed_name: CALCULO DIF. E INTEGRAL EN VARIAS VARIABLES
+          needs: course
+        - type: subject
+          subject_needed_code: '1022'
+          subject_needed_name: CALCULO 2
+          needs: exam
+        - type: subject
+          subject_needed_code: '1072'
+          subject_needed_name: CALCULO 2
+          needs: exam
+        - type: subject
+          subject_needed_code: 172Q
+          subject_needed_name: CALCULO 2
+          needs: exam
+        - type: subject
+          subject_needed_code: MAT33
+          subject_needed_name: CREDITOS ASIGNADOS POR REVALIDA
+          needs: exam
+        - type: subject
+          subject_needed_code: MA47
+          subject_needed_name: CREDITOS ASIGNADOS POR REVALIDA
+          needs: exam
+        - type: subject
+          subject_needed_code: 1062P
+          subject_needed_name: CREDITOS NO ACUM CDIVV
+          needs: exam
+      - type: logical
+        logical_operator: or
+        operands:
+        - type: subject
+          subject_needed_code: '1021'
+          subject_needed_name: ALGEBRA LINEAL
+          needs: course
+        - type: subject
+          subject_needed_code: CM14
+          subject_needed_name: CREDITOS ASIGNADOS POR REVALIDA
+          needs: exam
+        - type: subject
+          subject_needed_code: MAT33
+          subject_needed_name: CREDITOS ASIGNADOS POR REVALIDA
+          needs: exam
+        - type: subject
+          subject_needed_code: M9
+          subject_needed_name: CREDITOS ASIGNADOS POR REVALIDA
+          needs: exam
+        - type: subject
+          subject_needed_code: 1030P
+          subject_needed_name: CREDITOS NO ACUM GAL1
+          needs: exam
+        - type: subject
+          subject_needed_code: CP2
+          subject_needed_name: GEOMETRIA Y ALGEBRA LINEAL
+          needs: exam
+        - type: subject
+          subject_needed_code: CP23
+          subject_needed_name: GEOMETRIA Y ALGEBRA LINEAL (P. 74)
+          needs: exam
+        - type: subject
+          subject_needed_code: '1030'
+          subject_needed_name: GEOMETRIA Y ALGEBRA LINEAL 1
+          needs: exam
+        - type: subject
+          subject_needed_code: '1071'
+          subject_needed_name: GEOMETRIA Y ALGEBRA LINEAL 1
+          needs: exam
+        - type: subject
+          subject_needed_code: 171L
+          subject_needed_name: GEOMETRIA Y ALGEBRA LINEAL 1
+          needs: exam
+        - type: subject
+          subject_needed_code: 171Q
+          subject_needed_name: GEOMETRIA Y ALGEBRA LINEAL 1
+          needs: exam
+        - type: subject
+          subject_needed_code: '1053'
+          subject_needed_name: GEOMETRIA Y ALGEBRA LINEAL 1 (ANUAL)
+          needs: exam
+        - type: subject
+          subject_needed_code: GAL1P
+          subject_needed_name: GEOMETRIA Y ALGEBRA LINEAL 1 INTERACTIVA
+          needs: exam
+    - type: subject
+      needs: course
+      subject_needed_code: '1025'
+      subject_needed_name: PROBABILIDAD Y ESTADISTICA
+  subject_code: '1025'
+  is_exam: true
+- type: logical
+  logical_operator: and
+  operands:
+  - type: subject
+    needs: course
+    subject_needed_code: '1023'
+    subject_needed_name: MATEMATICA DISCRETA 1
+  subject_code: '1027'
+  is_exam: false
+- type: logical
+  logical_operator: and
+  operands:
+  - type: subject
+    needs: course
+    subject_needed_code: '1027'
+    subject_needed_name: LOGICA
+  subject_code: '1027'
+  is_exam: true
+- type: logical
+  logical_operator: and
+  operands:
+  - type: logical
+    logical_operator: not
+    operands:
+    - type: subject
+      needs: course_enrollment
+      subject_needed_code: GAL1P
+      subject_needed_name: GEOMETRIA Y ALGEBRA LINEAL 1 INTERACTIVA
+  - type: logical
+    logical_operator: not
+    operands:
+    - type: logical
+      logical_operator: or
+      operands:
+      - type: subject
+        subject_needed_code: CM14
+        subject_needed_name: CREDITOS ASIGNADOS POR REVALIDA
+        needs: exam
+      - type: subject
+        subject_needed_code: GAL7
+        subject_needed_name: CREDITOS ASIGNADOS POR REVALIDA
+        needs: exam
+      - type: subject
+        subject_needed_code: MAT33
+        subject_needed_name: CREDITOS ASIGNADOS POR REVALIDA
+        needs: exam
+      - type: subject
+        subject_needed_code: MA51
+        subject_needed_name: CREDITOS ASIGNADOS POR REVALIDA
+        needs: exam
+      - type: subject
+        subject_needed_code: MA7
+        subject_needed_name: CREDITOS ASIGNADOS POR REVALIDA
+        needs: exam
+      - type: subject
+        subject_needed_code: MC3
+        subject_needed_name: CREDITOS ASIGNADOS POR REVALIDA
+        needs: exam
+      - type: subject
+        subject_needed_code: M24
+        subject_needed_name: CREDITOS ASIGNADOS POR REVALIDA
+        needs: exam
+      - type: subject
+        subject_needed_code: M9
+        subject_needed_name: CREDITOS ASIGNADOS POR REVALIDA
+        needs: exam
+      - type: subject
+        subject_needed_code: 1030P
+        subject_needed_name: CREDITOS NO ACUM GAL1
+        needs: exam
+      - type: subject
+        subject_needed_code: CP2
+        subject_needed_name: GEOMETRIA Y ALGEBRA LINEAL
+        needs: exam
+      - type: subject
+        subject_needed_code: CP23
+        subject_needed_name: GEOMETRIA Y ALGEBRA LINEAL (P. 74)
+        needs: exam
+      - type: subject
+        subject_needed_code: CP46
+        subject_needed_name: GEOMETRIA Y ALGEBRA LINEAL (1ER.SEM.)
+        needs: exam
+      - type: subject
+        subject_needed_code: '1071'
+        subject_needed_name: GEOMETRIA Y ALGEBRA LINEAL 1
+        needs: exam
+      - type: subject
+        subject_needed_code: 171L
+        subject_needed_name: GEOMETRIA Y ALGEBRA LINEAL 1
+        needs: exam
+      - type: subject
+        subject_needed_code: 171Q
+        subject_needed_name: GEOMETRIA Y ALGEBRA LINEAL 1
+        needs: exam
+      - type: subject
+        subject_needed_code: '1053'
+        subject_needed_name: GEOMETRIA Y ALGEBRA LINEAL 1 (ANUAL)
+        needs: exam
+      - type: subject
+        subject_needed_code: GAL1P
+        subject_needed_name: GEOMETRIA Y ALGEBRA LINEAL 1 INTERACTIVA
+        needs: exam
+  subject_code: '1030'
+  is_exam: false
+- type: logical
+  logical_operator: and
+  operands:
+  - type: logical
+    logical_operator: not
+    operands:
+    - type: logical
+      logical_operator: or
+      operands:
+      - type: subject
+        subject_needed_code: CM14
+        subject_needed_name: CREDITOS ASIGNADOS POR REVALIDA
+        needs: exam
+      - type: subject
+        subject_needed_code: GAL7
+        subject_needed_name: CREDITOS ASIGNADOS POR REVALIDA
+        needs: exam
+      - type: subject
+        subject_needed_code: MAT33
+        subject_needed_name: CREDITOS ASIGNADOS POR REVALIDA
+        needs: exam
+      - type: subject
+        subject_needed_code: MA51
+        subject_needed_name: CREDITOS ASIGNADOS POR REVALIDA
+        needs: exam
+      - type: subject
+        subject_needed_code: MA7
+        subject_needed_name: CREDITOS ASIGNADOS POR REVALIDA
+        needs: exam
+      - type: subject
+        subject_needed_code: MC3
+        subject_needed_name: CREDITOS ASIGNADOS POR REVALIDA
+        needs: exam
+      - type: subject
+        subject_needed_code: M24
+        subject_needed_name: CREDITOS ASIGNADOS POR REVALIDA
+        needs: exam
+      - type: subject
+        subject_needed_code: M9
+        subject_needed_name: CREDITOS ASIGNADOS POR REVALIDA
+        needs: exam
+      - type: subject
+        subject_needed_code: 1030P
+        subject_needed_name: CREDITOS NO ACUM GAL1
+        needs: exam
+      - type: subject
+        subject_needed_code: CP2
+        subject_needed_name: GEOMETRIA Y ALGEBRA LINEAL
+        needs: exam
+      - type: subject
+        subject_needed_code: CP23
+        subject_needed_name: GEOMETRIA Y ALGEBRA LINEAL (P. 74)
+        needs: exam
+      - type: subject
+        subject_needed_code: CP46
+        subject_needed_name: GEOMETRIA Y ALGEBRA LINEAL (1ER.SEM.)
+        needs: exam
+      - type: subject
+        subject_needed_code: '1071'
+        subject_needed_name: GEOMETRIA Y ALGEBRA LINEAL 1
+        needs: exam
+      - type: subject
+        subject_needed_code: 171L
+        subject_needed_name: GEOMETRIA Y ALGEBRA LINEAL 1
+        needs: exam
+      - type: subject
+        subject_needed_code: 171Q
+        subject_needed_name: GEOMETRIA Y ALGEBRA LINEAL 1
+        needs: exam
+      - type: subject
+        subject_needed_code: '1053'
+        subject_needed_name: GEOMETRIA Y ALGEBRA LINEAL 1 (ANUAL)
+        needs: exam
+      - type: subject
+        subject_needed_code: GAL1P
+        subject_needed_name: GEOMETRIA Y ALGEBRA LINEAL 1 INTERACTIVA
+        needs: exam
+  - type: logical
+    logical_operator: not
+    operands:
+    - type: subject
+      needs: exam_enrollment
+      subject_needed_code: GAL1P
+      subject_needed_name: GEOMETRIA Y ALGEBRA LINEAL 1 INTERACTIVA
+  subject_code: '1030'
+  is_exam: true
+- type: logical
+  logical_operator: and
+  operands:
+  - type: logical
+    logical_operator: not
+    operands:
+    - type: logical
+      logical_operator: or
+      operands:
+      - type: subject
+        subject_needed_code: MA09
+        subject_needed_name: CREDITOS ASIGNADOS POR REVALIDA
+        needs: exam
+      - type: subject
+        subject_needed_code: MA10
+        subject_needed_name: CREDITOS ASIGNADOS POR REVALIDA
+        needs: exam
+      - type: subject
+        subject_needed_code: MA5
+        subject_needed_name: CREDITOS ASIGNADOS POR REVALIDA
+        needs: exam
+      - type: subject
+        subject_needed_code: M9
+        subject_needed_name: CREDITOS ASIGNADOS POR REVALIDA
+        needs: exam
+      - type: subject
+        subject_needed_code: 1031P
+        subject_needed_name: CREDITOS NO ACUM GAL2
+        needs: exam
+      - type: subject
+        subject_needed_code: CP2
+        subject_needed_name: GEOMETRIA Y ALGEBRA LINEAL
+        needs: exam
+      - type: subject
+        subject_needed_code: CP23
+        subject_needed_name: GEOMETRIA Y ALGEBRA LINEAL (P. 74)
+        needs: exam
+      - type: subject
+        subject_needed_code: CP47
+        subject_needed_name: GEOMETRIA Y ALGEBRA LINEAL (2DO.SEM.)
+        needs: exam
+      - type: subject
+        subject_needed_code: '1058'
+        subject_needed_name: GEOMETRIA Y ALGEBRA LINEAL 2
+        needs: exam
+      - type: subject
+        subject_needed_code: 158Q
+        subject_needed_name: GEOMETRIA Y ALGEBRA LINEAL 2
+        needs: exam
+  - type: logical
+    logical_operator: or
+    operands:
+    - type: subject
+      subject_needed_code: CM14
+      subject_needed_name: CREDITOS ASIGNADOS POR REVALIDA
+      needs: exam
+    - type: subject
+      subject_needed_code: MAT33
+      subject_needed_name: CREDITOS ASIGNADOS POR REVALIDA
+      needs: exam
+    - type: subject
+      subject_needed_code: 1030P
+      subject_needed_name: CREDITOS NO ACUM GAL1
+      needs: exam
+    - type: subject
+      subject_needed_code: '1030'
+      subject_needed_name: GEOMETRIA Y ALGEBRA LINEAL 1
+      needs: course
+    - type: subject
+      subject_needed_code: '1071'
+      subject_needed_name: GEOMETRIA Y ALGEBRA LINEAL 1
+      needs: exam
+    - type: subject
+      subject_needed_code: 171L
+      subject_needed_name: GEOMETRIA Y ALGEBRA LINEAL 1
+      needs: exam
+    - type: subject
+      subject_needed_code: 171Q
+      subject_needed_name: GEOMETRIA Y ALGEBRA LINEAL 1
+      needs: exam
+    - type: subject
+      subject_needed_code: '1053'
+      subject_needed_name: GEOMETRIA Y ALGEBRA LINEAL 1 (ANUAL)
+      needs: course
+    - type: subject
+      subject_needed_code: GAL1P
+      subject_needed_name: GEOMETRIA Y ALGEBRA LINEAL 1 INTERACTIVA
+      needs: course
+  subject_code: '1031'
+  is_exam: false
+- type: logical
+  logical_operator: and
+  operands:
+  - type: logical
+    logical_operator: not
+    operands:
+    - type: logical
+      logical_operator: or
+      operands:
+      - type: subject
+        subject_needed_code: MA09
+        subject_needed_name: CREDITOS ASIGNADOS POR REVALIDA
+        needs: exam
+      - type: subject
+        subject_needed_code: MA10
+        subject_needed_name: CREDITOS ASIGNADOS POR REVALIDA
+        needs: exam
+      - type: subject
+        subject_needed_code: MA5
+        subject_needed_name: CREDITOS ASIGNADOS POR REVALIDA
+        needs: exam
+      - type: subject
+        subject_needed_code: M9
+        subject_needed_name: CREDITOS ASIGNADOS POR REVALIDA
+        needs: exam
+      - type: subject
+        subject_needed_code: 1031P
+        subject_needed_name: CREDITOS NO ACUM GAL2
+        needs: exam
+      - type: subject
+        subject_needed_code: CP2
+        subject_needed_name: GEOMETRIA Y ALGEBRA LINEAL
+        needs: exam
+      - type: subject
+        subject_needed_code: CP23
+        subject_needed_name: GEOMETRIA Y ALGEBRA LINEAL (P. 74)
+        needs: exam
+      - type: subject
+        subject_needed_code: CP47
+        subject_needed_name: GEOMETRIA Y ALGEBRA LINEAL (2DO.SEM.)
+        needs: exam
+      - type: subject
+        subject_needed_code: '1058'
+        subject_needed_name: GEOMETRIA Y ALGEBRA LINEAL 2
+        needs: exam
+      - type: subject
+        subject_needed_code: 158Q
+        subject_needed_name: GEOMETRIA Y ALGEBRA LINEAL 2
+        needs: exam
+  - type: logical
+    logical_operator: or
+    operands:
+    - type: subject
+      subject_needed_code: '1021'
+      subject_needed_name: ALGEBRA LINEAL
+      needs: exam
+    - type: subject
+      subject_needed_code: CM14
+      subject_needed_name: CREDITOS ASIGNADOS POR REVALIDA
+      needs: exam
+    - type: subject
+      subject_needed_code: MAT33
+      subject_needed_name: CREDITOS ASIGNADOS POR REVALIDA
+      needs: exam
+    - type: subject
+      subject_needed_code: 1030P
+      subject_needed_name: CREDITOS NO ACUM GAL1
+      needs: exam
+    - type: subject
+      subject_needed_code: CP2
+      subject_needed_name: GEOMETRIA Y ALGEBRA LINEAL
+      needs: exam
+    - type: subject
+      subject_needed_code: '1030'
+      subject_needed_name: GEOMETRIA Y ALGEBRA LINEAL 1
+      needs: exam
+    - type: subject
+      subject_needed_code: '1071'
+      subject_needed_name: GEOMETRIA Y ALGEBRA LINEAL 1
+      needs: exam
+    - type: subject
+      subject_needed_code: 171L
+      subject_needed_name: GEOMETRIA Y ALGEBRA LINEAL 1
+      needs: exam
+    - type: subject
+      subject_needed_code: 171Q
+      subject_needed_name: GEOMETRIA Y ALGEBRA LINEAL 1
+      needs: exam
+    - type: subject
+      subject_needed_code: '1053'
+      subject_needed_name: GEOMETRIA Y ALGEBRA LINEAL 1 (ANUAL)
+      needs: exam
+    - type: subject
+      subject_needed_code: GAL1P
+      subject_needed_name: GEOMETRIA Y ALGEBRA LINEAL 1 INTERACTIVA
+      needs: exam
+  subject_code: '1031'
+  is_exam: true
+- type: logical
+  logical_operator: and
+  operands:
+  - type: logical
+    logical_operator: not
+    operands:
+    - type: logical
+      logical_operator: or
+      operands:
+      - type: subject
+        subject_needed_code: CP16
+        subject_needed_name: CALCULO NUMERICO
+        needs: all
+      - type: subject
+        subject_needed_code: '1079'
+        subject_needed_name: METODOS NUMERICOS
+        needs: all
+  - type: logical
+    logical_operator: or
+    operands:
+    - type: subject
+      subject_needed_code: CP52
+      subject_needed_name: COMPUTACION
+      needs: all
+    - type: subject
+      subject_needed_code: 1322P
+      subject_needed_name: CREDITOS NO ACUM PROGRAMACION 1
+      needs: all
+    - type: subject
+      subject_needed_code: CP9
+      subject_needed_name: PROGRAMACION I
+      needs: all
+    - type: subject
+      subject_needed_code: '1320'
+      subject_needed_name: PROGRAMACION 1
+      needs: all
+    - type: subject
+      subject_needed_code: '1322'
+      subject_needed_name: PROGRAMACION 1
+      needs: all
+    - type: subject
+      subject_needed_code: '1373'
+      subject_needed_name: PROGRAMACION 1
+      needs: all
+  - type: logical
+    logical_operator: or
+    operands:
+    - type: subject
+      subject_needed_code: CP1
+      subject_needed_name: ANALISIS MATEMATICO I
+      needs: all
+    - type: subject
+      subject_needed_code: CP22
+      subject_needed_name: ANALISIS MATEMATICO I (P. 74)
+      needs: all
+    - type: subject
+      subject_needed_code: '1062'
+      subject_needed_name: CALCULO DIF. E INTEGRAL EN VARIAS VARIABLES
+      needs: all
+    - type: subject
+      subject_needed_code: '1022'
+      subject_needed_name: CALCULO 2
+      needs: all
+    - type: subject
+      subject_needed_code: '1072'
+      subject_needed_name: CALCULO 2
+      needs: all
+    - type: subject
+      subject_needed_code: MAT33
+      subject_needed_name: CREDITOS ASIGNADOS POR REVALIDA
+      needs: all
+    - type: subject
+      subject_needed_code: 1062P
+      subject_needed_name: CREDITOS NO ACUM CDIVV
+      needs: all
+  - type: logical
+    logical_operator: or
+    operands:
+    - type: subject
+      subject_needed_code: '1021'
+      subject_needed_name: ALGEBRA LINEAL
+      needs: all
+    - type: subject
+      subject_needed_code: CM14
+      subject_needed_name: CREDITOS ASIGNADOS POR REVALIDA
+      needs: all
+    - type: subject
+      subject_needed_code: MAT33
+      subject_needed_name: CREDITOS ASIGNADOS POR REVALIDA
+      needs: all
+    - type: subject
+      subject_needed_code: M9
+      subject_needed_name: CREDITOS ASIGNADOS POR REVALIDA
+      needs: all
+    - type: subject
+      subject_needed_code: 1030P
+      subject_needed_name: CREDITOS NO ACUM GAL1
+      needs: all
+    - type: subject
+      subject_needed_code: CP2
+      subject_needed_name: GEOMETRIA Y ALGEBRA LINEAL
+      needs: all
+    - type: subject
+      subject_needed_code: '1030'
+      subject_needed_name: GEOMETRIA Y ALGEBRA LINEAL 1
+      needs: all
+    - type: subject
+      subject_needed_code: '1071'
+      subject_needed_name: GEOMETRIA Y ALGEBRA LINEAL 1
+      needs: all
+    - type: subject
+      subject_needed_code: 171L
+      subject_needed_name: GEOMETRIA Y ALGEBRA LINEAL 1
+      needs: all
+    - type: subject
+      subject_needed_code: 171Q
+      subject_needed_name: GEOMETRIA Y ALGEBRA LINEAL 1
+      needs: all
+    - type: subject
+      subject_needed_code: '1053'
+      subject_needed_name: GEOMETRIA Y ALGEBRA LINEAL 1 (ANUAL)
+      needs: all
+    - type: subject
+      subject_needed_code: GAL1P
+      subject_needed_name: GEOMETRIA Y ALGEBRA LINEAL 1 INTERACTIVA
+      needs: all
+  - type: logical
+    logical_operator: or
+    operands:
+    - type: subject
+      subject_needed_code: '1021'
+      subject_needed_name: ALGEBRA LINEAL
+      needs: all
+    - type: subject
+      subject_needed_code: MAT33
+      subject_needed_name: CREDITOS ASIGNADOS POR REVALIDA
+      needs: all
+    - type: subject
+      subject_needed_code: MA09
+      subject_needed_name: CREDITOS ASIGNADOS POR REVALIDA
+      needs: all
+    - type: subject
+      subject_needed_code: M9
+      subject_needed_name: CREDITOS ASIGNADOS POR REVALIDA
+      needs: all
+    - type: subject
+      subject_needed_code: 1031P
+      subject_needed_name: CREDITOS NO ACUM GAL2
+      needs: all
+    - type: subject
+      subject_needed_code: CP2
+      subject_needed_name: GEOMETRIA Y ALGEBRA LINEAL
+      needs: all
+    - type: subject
+      subject_needed_code: R101
+      subject_needed_name: GEOMETRIA Y ALGEBRA LINEAL
+      needs: all
+    - type: subject
+      subject_needed_code: CP23
+      subject_needed_name: GEOMETRIA Y ALGEBRA LINEAL (P. 74)
+      needs: all
+    - type: subject
+      subject_needed_code: '1031'
+      subject_needed_name: GEOMETRIA Y ALGEBRA LINEAL 2
+      needs: all
+    - type: subject
+      subject_needed_code: '1058'
+      subject_needed_name: GEOMETRIA Y ALGEBRA LINEAL 2
+      needs: all
+  - type: logical
+    logical_operator: or
+    operands:
+    - type: subject
+      subject_needed_code: CP1
+      subject_needed_name: ANALISIS MATEMATICO I
+      needs: all
+    - type: subject
+      subject_needed_code: '1061'
+      subject_needed_name: CALCULO DIF. E INTEGRAL EN UNA VARIABLE
+      needs: all
+    - type: subject
+      subject_needed_code: '1020'
+      subject_needed_name: CALCULO 1
+      needs: all
+    - type: subject
+      subject_needed_code: 107L
+      subject_needed_name: CALCULO 1
+      needs: all
+    - type: subject
+      subject_needed_code: '1070'
+      subject_needed_name: CALCULO 1
+      needs: all
+    - type: subject
+      subject_needed_code: 170Q
+      subject_needed_name: CALCULO 1
+      needs: all
+    - type: subject
+      subject_needed_code: '1052'
+      subject_needed_name: CALCULO 1 (ANUAL)
+      needs: all
+    - type: subject
+      subject_needed_code: CAL10
+      subject_needed_name: CREDITOS ASIGNADOS POR REVALIDA
+      needs: all
+    - type: subject
+      subject_needed_code: MAT33
+      subject_needed_name: CREDITOS ASIGNADOS POR REVALIDA
+      needs: all
+    - type: subject
+      subject_needed_code: 1020P
+      subject_needed_name: CREDITOS NO ACUM CALCULO 1
+      needs: all
+    - type: subject
+      subject_needed_code: 1061P
+      subject_needed_name: CREDITOS NO ACUM CDIV
+      needs: all
+  subject_code: '1033'
+  is_exam: false
+- type: logical
+  logical_operator: and
+  operands:
+  - type: subject
+    needs: course
+    subject_needed_code: '1033'
+    subject_needed_name: METODOS NUMERICOS
+  subject_code: '1033'
+  is_exam: true
+- type: logical
+  logical_operator: and
+  operands:
+  - type: logical
+    logical_operator: not
+    operands:
+    - type: logical
+      logical_operator: or
+      operands:
+      - type: subject
+        subject_needed_code: CP1
+        subject_needed_name: ANALISIS MATEMATICO I
+        needs: all
+      - type: subject
+        subject_needed_code: CP22
+        subject_needed_name: ANALISIS MATEMATICO I (P. 74)
+        needs: all
+      - type: subject
+        subject_needed_code: CP44
+        subject_needed_name: ANALISIS MATEMATICO I (1ER.SEM.)
+        needs: all
+      - type: subject
+        subject_needed_code: 1061I
+        subject_needed_name: CALCULO DIF. E INTEGRAL EN UNA VARIABLE
+        needs: all
+      - type: subject
+        subject_needed_code: 1061R
+        subject_needed_name: CALCULO DIF. E INTEGRAL EN UNA VARIABLE
+        needs: all
+      - type: subject
+        subject_needed_code: '1020'
+        subject_needed_name: CALCULO 1
+        needs: all
+      - type: subject
+        subject_needed_code: 107L
+        subject_needed_name: CALCULO 1
+        needs: all
+      - type: subject
+        subject_needed_code: '1070'
+        subject_needed_name: CALCULO 1
+        needs: all
+      - type: subject
+        subject_needed_code: 170Q
+        subject_needed_name: CALCULO 1
+        needs: all
+      - type: subject
+        subject_needed_code: '1052'
+        subject_needed_name: CALCULO 1 (ANUAL)
+        needs: all
+      - type: subject
+        subject_needed_code: CAL10
+        subject_needed_name: CREDITOS ASIGNADOS POR REVALIDA
+        needs: all
+      - type: subject
+        subject_needed_code: CAL12
+        subject_needed_name: CREDITOS ASIGNADOS POR REVALIDA
+        needs: all
+      - type: subject
+        subject_needed_code: MAT14
+        subject_needed_name: CREDITOS ASIGNADOS POR REVALIDA
+        needs: all
+      - type: subject
+        subject_needed_code: MAT33
+        subject_needed_name: CREDITOS ASIGNADOS POR REVALIDA
+        needs: all
+      - type: subject
+        subject_needed_code: MA25
+        subject_needed_name: CREDITOS ASIGNADOS POR REVALIDA
+        needs: all
+      - type: subject
+        subject_needed_code: MA47
+        subject_needed_name: CREDITOS ASIGNADOS POR REVALIDA
+        needs: all
+      - type: subject
+        subject_needed_code: MA51
+        subject_needed_name: CREDITOS ASIGNADOS POR REVALIDA
+        needs: all
+      - type: subject
+        subject_needed_code: MC13
+        subject_needed_name: CREDITOS ASIGNADOS POR REVALIDA
+        needs: all
+      - type: subject
+        subject_needed_code: M12
+        subject_needed_name: CREDITOS ASIGNADOS POR REVALIDA
+        needs: all
+      - type: subject
+        subject_needed_code: M13
+        subject_needed_name: CREDITOS ASIGNADOS POR REVALIDA
+        needs: all
+      - type: subject
+        subject_needed_code: M14
+        subject_needed_name: CREDITOS ASIGNADOS POR REVALIDA
+        needs: all
+      - type: subject
+        subject_needed_code: 1020R
+        subject_needed_name: CREDITOS ASIGNADOS POR REVALIDA
+        needs: all
+  - type: logical
+    logical_operator: or
+    operands:
+    - type: logical
+      logical_operator: not
+      operands:
+      - type: subject
+        needs: course_enrollment
+        subject_needed_code: MI2
+        subject_needed_name: MATEMATICA INICIAL
+    - type: subject
+      needs: all
+      subject_needed_code: MI2
+      subject_needed_name: MATEMATICA INICIAL
+  subject_code: '1061'
+  is_exam: false
+- type: logical
+  logical_operator: and
+  operands:
+  - type: logical
+    logical_operator: not
+    operands:
+    - type: logical
+      logical_operator: or
+      operands:
+      - type: subject
+        subject_needed_code: CP1
+        subject_needed_name: ANALISIS MATEMATICO I
+        needs: all
+      - type: subject
+        subject_needed_code: CP22
+        subject_needed_name: ANALISIS MATEMATICO I (P. 74)
+        needs: all
+      - type: subject
+        subject_needed_code: CP44
+        subject_needed_name: ANALISIS MATEMATICO I (1ER.SEM.)
+        needs: all
+      - type: subject
+        subject_needed_code: 1061R
+        subject_needed_name: CALCULO DIF. E INTEGRAL EN UNA VARIABLE
+        needs: all
+      - type: subject
+        subject_needed_code: MA01
+        subject_needed_name: CALCULO DIFERENCIAL E INTEGRAL I
+        needs: all
+      - type: subject
+        subject_needed_code: '1020'
+        subject_needed_name: CALCULO 1
+        needs: all
+      - type: subject
+        subject_needed_code: 107L
+        subject_needed_name: CALCULO 1
+        needs: all
+      - type: subject
+        subject_needed_code: '1070'
+        subject_needed_name: CALCULO 1
+        needs: all
+      - type: subject
+        subject_needed_code: 170Q
+        subject_needed_name: CALCULO 1
+        needs: all
+      - type: subject
+        subject_needed_code: '1052'
+        subject_needed_name: CALCULO 1 (ANUAL)
+        needs: all
+      - type: subject
+        subject_needed_code: MA13
+        subject_needed_name: CÁLCULO DIFERENCIAL E INTEGRAL I (F)
+        needs: all
+      - type: subject
+        subject_needed_code: CAL10
+        subject_needed_name: CREDITOS ASIGNADOS POR REVALIDA
+        needs: all
+      - type: subject
+        subject_needed_code: CAL12
+        subject_needed_name: CREDITOS ASIGNADOS POR REVALIDA
+        needs: all
+      - type: subject
+        subject_needed_code: MAT14
+        subject_needed_name: CREDITOS ASIGNADOS POR REVALIDA
+        needs: all
+      - type: subject
+        subject_needed_code: MAT33
+        subject_needed_name: CREDITOS ASIGNADOS POR REVALIDA
+        needs: all
+      - type: subject
+        subject_needed_code: MA25
+        subject_needed_name: CREDITOS ASIGNADOS POR REVALIDA
+        needs: all
+      - type: subject
+        subject_needed_code: MA47
+        subject_needed_name: CREDITOS ASIGNADOS POR REVALIDA
+        needs: all
+      - type: subject
+        subject_needed_code: MA51
+        subject_needed_name: CREDITOS ASIGNADOS POR REVALIDA
+        needs: all
+      - type: subject
+        subject_needed_code: MC13
+        subject_needed_name: CREDITOS ASIGNADOS POR REVALIDA
+        needs: all
+      - type: subject
+        subject_needed_code: M12
+        subject_needed_name: CREDITOS ASIGNADOS POR REVALIDA
+        needs: all
+      - type: subject
+        subject_needed_code: M13
+        subject_needed_name: CREDITOS ASIGNADOS POR REVALIDA
+        needs: all
+      - type: subject
+        subject_needed_code: M14
+        subject_needed_name: CREDITOS ASIGNADOS POR REVALIDA
+        needs: all
+      - type: subject
+        subject_needed_code: 1020R
+        subject_needed_name: CREDITOS ASIGNADOS POR REVALIDA
+        needs: all
+      - type: subject
+        subject_needed_code: 1020P
+        subject_needed_name: CREDITOS NO ACUM CALCULO 1
+        needs: all
+      - type: subject
+        subject_needed_code: 1061P
+        subject_needed_name: CREDITOS NO ACUM CDIV
+        needs: all
+      - type: subject
+        subject_needed_code: '01'
+        subject_needed_name: MAT. 01 (ANÁLISIS I)
+        needs: all
+      - type: subject
+        subject_needed_code: '101'
+        subject_needed_name: MATEMÁTICA 101 (ANÁLISIS I)
+        needs: all
+  - type: logical
+    logical_operator: not
+    operands:
+    - type: subject
+      needs: course_enrollment
+      subject_needed_code: MI2
+      subject_needed_name: MATEMATICA INICIAL
+  - type: logical
+    logical_operator: not
+    operands:
+    - type: subject
+      needs: exam_enrollment
+      subject_needed_code: MI2
+      subject_needed_name: MATEMATICA INICIAL
+  subject_code: '1061'
+  is_exam: true
+- type: logical
+  logical_operator: and
+  operands:
+  - type: logical
+    logical_operator: not
+    operands:
+    - type: logical
+      logical_operator: or
+      operands:
+      - type: subject
+        subject_needed_code: CP1
+        subject_needed_name: ANALISIS MATEMATICO I
+        needs: all
+      - type: subject
+        subject_needed_code: CP22
+        subject_needed_name: ANALISIS MATEMATICO I (P. 74)
+        needs: all
+      - type: subject
+        subject_needed_code: CP45
+        subject_needed_name: ANALISIS MATEMATICO I (2DO.SEM.)
+        needs: all
+      - type: subject
+        subject_needed_code: '1022'
+        subject_needed_name: CALCULO 2
+        needs: all
+      - type: subject
+        subject_needed_code: MAT18
+        subject_needed_name: CREDITOS ASIGNADOS POR REVALIDA
+        needs: all
+      - type: subject
+        subject_needed_code: MAT33
+        subject_needed_name: CREDITOS ASIGNADOS POR REVALIDA
+        needs: all
+      - type: subject
+        subject_needed_code: 1062P
+        subject_needed_name: CREDITOS NO ACUM CDIVV
+        needs: all
+  - type: logical
+    logical_operator: or
+    operands:
+    - type: subject
+      subject_needed_code: '1061'
+      subject_needed_name: CALCULO DIF. E INTEGRAL EN UNA VARIABLE
+      needs: course
+    - type: subject
+      subject_needed_code: 1061I
+      subject_needed_name: CALCULO DIF. E INTEGRAL EN UNA VARIABLE
+      needs: exam
+    - type: subject
+      subject_needed_code: '1020'
+      subject_needed_name: CALCULO 1
+      needs: exam
+    - type: subject
+      subject_needed_code: 107L
+      subject_needed_name: CALCULO 1
+      needs: exam
+    - type: subject
+      subject_needed_code: '1070'
+      subject_needed_name: CALCULO 1
+      needs: exam
+    - type: subject
+      subject_needed_code: 170Q
+      subject_needed_name: CALCULO 1
+      needs: exam
+    - type: subject
+      subject_needed_code: '1052'
+      subject_needed_name: CALCULO 1 (ANUAL)
+      needs: exam
+    - type: subject
+      subject_needed_code: CAL10
+      subject_needed_name: CREDITOS ASIGNADOS POR REVALIDA
+      needs: exam
+    - type: subject
+      subject_needed_code: CAL12
+      subject_needed_name: CREDITOS ASIGNADOS POR REVALIDA
+      needs: exam
+    - type: subject
+      subject_needed_code: M13
+      subject_needed_name: CREDITOS ASIGNADOS POR REVALIDA
+      needs: exam
+    - type: subject
+      subject_needed_code: 1020P
+      subject_needed_name: CREDITOS NO ACUM CALCULO 1
+      needs: exam
+    - type: subject
+      subject_needed_code: 1061P
+      subject_needed_name: CREDITOS NO ACUM CDIV
+      needs: exam
+  subject_code: '1062'
+  is_exam: false
+- type: logical
+  logical_operator: and
+  operands:
+  - type: logical
+    logical_operator: not
+    operands:
+    - type: logical
+      logical_operator: or
+      operands:
+      - type: subject
+        subject_needed_code: CP1
+        subject_needed_name: ANALISIS MATEMATICO I
+        needs: all
+      - type: subject
+        subject_needed_code: CP22
+        subject_needed_name: ANALISIS MATEMATICO I (P. 74)
+        needs: all
+      - type: subject
+        subject_needed_code: CP45
+        subject_needed_name: ANALISIS MATEMATICO I (2DO.SEM.)
+        needs: all
+      - type: subject
+        subject_needed_code: '1022'
+        subject_needed_name: CALCULO 2
+        needs: all
+      - type: subject
+        subject_needed_code: MAT18
+        subject_needed_name: CREDITOS ASIGNADOS POR REVALIDA
+        needs: all
+      - type: subject
+        subject_needed_code: MAT33
+        subject_needed_name: CREDITOS ASIGNADOS POR REVALIDA
+        needs: all
+      - type: subject
+        subject_needed_code: 1062P
+        subject_needed_name: CREDITOS NO ACUM CDIVV
+        needs: all
+  - type: logical
+    logical_operator: or
+    operands:
+    - type: subject
+      subject_needed_code: '1061'
+      subject_needed_name: CALCULO DIF. E INTEGRAL EN UNA VARIABLE
+      needs: all
+    - type: subject
+      subject_needed_code: '1020'
+      subject_needed_name: CALCULO 1
+      needs: all
+    - type: subject
+      subject_needed_code: 107L
+      subject_needed_name: CALCULO 1
+      needs: all
+    - type: subject
+      subject_needed_code: '1070'
+      subject_needed_name: CALCULO 1
+      needs: all
+    - type: subject
+      subject_needed_code: 170Q
+      subject_needed_name: CALCULO 1
+      needs: all
+    - type: subject
+      subject_needed_code: '1052'
+      subject_needed_name: CALCULO 1 (ANUAL)
+      needs: all
+    - type: subject
+      subject_needed_code: CAL10
+      subject_needed_name: CREDITOS ASIGNADOS POR REVALIDA
+      needs: all
+    - type: subject
+      subject_needed_code: 1020P
+      subject_needed_name: CREDITOS NO ACUM CALCULO 1
+      needs: all
+    - type: subject
+      subject_needed_code: 1061P
+      subject_needed_name: CREDITOS NO ACUM CDIV
+      needs: all
+  subject_code: '1062'
+  is_exam: true
+- type: logical
+  logical_operator: and
+  operands:
+  - type: logical
+    logical_operator: not
+    operands:
+    - type: logical
+      logical_operator: or
+      operands:
+      - type: subject
+        subject_needed_code: CP6
+        subject_needed_name: ANALISIS MATEMATICO II
+        needs: all
+      - type: subject
+        subject_needed_code: CP25
+        subject_needed_name: ANALISIS MATEMATICO II (P. 74)
+        needs: all
+      - type: subject
+        subject_needed_code: '1024'
+        subject_needed_name: CALCULO 3
+        needs: all
+      - type: subject
+        subject_needed_code: MAT18
+        subject_needed_name: CREDITOS ASIGNADOS POR REVALIDA
+        needs: all
+      - type: subject
+        subject_needed_code: 1063P
+        subject_needed_name: CREDITOS NO ACUM CAL. VECTORIAL
+        needs: all
+      - type: subject
+        subject_needed_code: 1024P
+        subject_needed_name: CREDITOS NO ACUM CALCULO 3
+        needs: all
+  - type: logical
+    logical_operator: or
+    operands:
+    - type: subject
+      subject_needed_code: CP1
+      subject_needed_name: ANALISIS MATEMATICO I
+      needs: exam
+    - type: subject
+      subject_needed_code: CP22
+      subject_needed_name: ANALISIS MATEMATICO I (P. 74)
+      needs: exam
+    - type: subject
+      subject_needed_code: '1062'
+      subject_needed_name: CALCULO DIF. E INTEGRAL EN VARIAS VARIABLES
+      needs: course
+    - type: subject
+      subject_needed_code: '1022'
+      subject_needed_name: CALCULO 2
+      needs: exam
+    - type: subject
+      subject_needed_code: '1072'
+      subject_needed_name: CALCULO 2
+      needs: exam
+    - type: subject
+      subject_needed_code: 172Q
+      subject_needed_name: CALCULO 2
+      needs: exam
+    - type: subject
+      subject_needed_code: MAT33
+      subject_needed_name: CREDITOS ASIGNADOS POR REVALIDA
+      needs: exam
+    - type: subject
+      subject_needed_code: MA47
+      subject_needed_name: CREDITOS ASIGNADOS POR REVALIDA
+      needs: exam
+    - type: subject
+      subject_needed_code: 1062P
+      subject_needed_name: CREDITOS NO ACUM CDIVV
+      needs: exam
+  - type: logical
+    logical_operator: or
+    operands:
+    - type: subject
+      subject_needed_code: '1021'
+      subject_needed_name: ALGEBRA LINEAL
+      needs: exam
+    - type: subject
+      subject_needed_code: CM14
+      subject_needed_name: CREDITOS ASIGNADOS POR REVALIDA
+      needs: exam
+    - type: subject
+      subject_needed_code: MAT33
+      subject_needed_name: CREDITOS ASIGNADOS POR REVALIDA
+      needs: exam
+    - type: subject
+      subject_needed_code: M9
+      subject_needed_name: CREDITOS ASIGNADOS POR REVALIDA
+      needs: exam
+    - type: subject
+      subject_needed_code: 1030P
+      subject_needed_name: CREDITOS NO ACUM GAL1
+      needs: exam
+    - type: subject
+      subject_needed_code: CP2
+      subject_needed_name: GEOMETRIA Y ALGEBRA LINEAL
+      needs: exam
+    - type: subject
+      subject_needed_code: CP23
+      subject_needed_name: GEOMETRIA Y ALGEBRA LINEAL (P. 74)
+      needs: exam
+    - type: subject
+      subject_needed_code: '1030'
+      subject_needed_name: GEOMETRIA Y ALGEBRA LINEAL 1
+      needs: exam
+    - type: subject
+      subject_needed_code: '1071'
+      subject_needed_name: GEOMETRIA Y ALGEBRA LINEAL 1
+      needs: exam
+    - type: subject
+      subject_needed_code: 171L
+      subject_needed_name: GEOMETRIA Y ALGEBRA LINEAL 1
+      needs: exam
+    - type: subject
+      subject_needed_code: 171Q
+      subject_needed_name: GEOMETRIA Y ALGEBRA LINEAL 1
+      needs: exam
+    - type: subject
+      subject_needed_code: '1053'
+      subject_needed_name: GEOMETRIA Y ALGEBRA LINEAL 1 (ANUAL)
+      needs: exam
+    - type: subject
+      subject_needed_code: GAL1P
+      subject_needed_name: GEOMETRIA Y ALGEBRA LINEAL 1 INTERACTIVA
+      needs: exam
+  - type: logical
+    logical_operator: or
+    operands:
+    - type: subject
+      subject_needed_code: CP1
+      subject_needed_name: ANALISIS MATEMATICO I
+      needs: exam
+    - type: subject
+      subject_needed_code: CP22
+      subject_needed_name: ANALISIS MATEMATICO I (P. 74)
+      needs: exam
+    - type: subject
+      subject_needed_code: '1061'
+      subject_needed_name: CALCULO DIF. E INTEGRAL EN UNA VARIABLE
+      needs: exam
+    - type: subject
+      subject_needed_code: '1020'
+      subject_needed_name: CALCULO 1
+      needs: exam
+    - type: subject
+      subject_needed_code: 107L
+      subject_needed_name: CALCULO 1
+      needs: exam
+    - type: subject
+      subject_needed_code: '1070'
+      subject_needed_name: CALCULO 1
+      needs: exam
+    - type: subject
+      subject_needed_code: 170Q
+      subject_needed_name: CALCULO 1
+      needs: exam
+    - type: subject
+      subject_needed_code: '1052'
+      subject_needed_name: CALCULO 1 (ANUAL)
+      needs: exam
+    - type: subject
+      subject_needed_code: CAL10
+      subject_needed_name: CREDITOS ASIGNADOS POR REVALIDA
+      needs: exam
+    - type: subject
+      subject_needed_code: MAT33
+      subject_needed_name: CREDITOS ASIGNADOS POR REVALIDA
+      needs: exam
+    - type: subject
+      subject_needed_code: MA47
+      subject_needed_name: CREDITOS ASIGNADOS POR REVALIDA
+      needs: exam
+    - type: subject
+      subject_needed_code: M13
+      subject_needed_name: CREDITOS ASIGNADOS POR REVALIDA
+      needs: exam
+    - type: subject
+      subject_needed_code: 1020P
+      subject_needed_name: CREDITOS NO ACUM CALCULO 1
+      needs: exam
+    - type: subject
+      subject_needed_code: 1061P
+      subject_needed_name: CREDITOS NO ACUM CDIV
+      needs: exam
+  subject_code: '1063'
+  is_exam: false
+- type: logical
+  logical_operator: and
+  operands:
+  - type: logical
+    logical_operator: not
+    operands:
+    - type: logical
+      logical_operator: or
+      operands:
+      - type: subject
+        subject_needed_code: CP6
+        subject_needed_name: ANALISIS MATEMATICO II
+        needs: exam
+      - type: subject
+        subject_needed_code: CP25
+        subject_needed_name: ANALISIS MATEMATICO II (P. 74)
+        needs: exam
+      - type: subject
+        subject_needed_code: '1024'
+        subject_needed_name: CALCULO 3
+        needs: exam
+      - type: subject
+        subject_needed_code: '1076'
+        subject_needed_name: CALCULO 3
+        needs: exam
+      - type: subject
+        subject_needed_code: 176Q
+        subject_needed_name: CALCULO 3
+        needs: exam
+      - type: subject
+        subject_needed_code: MAT18
+        subject_needed_name: CREDITOS ASIGNADOS POR REVALIDA
+        needs: exam
+      - type: subject
+        subject_needed_code: 1063P
+        subject_needed_name: CREDITOS NO ACUM CAL. VECTORIAL
+        needs: exam
+      - type: subject
+        subject_needed_code: 1024P
+        subject_needed_name: CREDITOS NO ACUM CALCULO 3
+        needs: exam
+  - type: logical
+    logical_operator: or
+    operands:
+    - type: logical
+      logical_operator: and
+      operands:
+      - type: logical
+        logical_operator: or
+        operands:
+        - type: subject
+          subject_needed_code: CP1
+          subject_needed_name: ANALISIS MATEMATICO I
+          needs: exam
+        - type: subject
+          subject_needed_code: CP22
+          subject_needed_name: ANALISIS MATEMATICO I (P. 74)
+          needs: exam
+        - type: subject
+          subject_needed_code: '1062'
+          subject_needed_name: CALCULO DIF. E INTEGRAL EN VARIAS VARIABLES
+          needs: course
+        - type: subject
+          subject_needed_code: '1022'
+          subject_needed_name: CALCULO 2
+          needs: exam
+        - type: subject
+          subject_needed_code: '1072'
+          subject_needed_name: CALCULO 2
+          needs: exam
+        - type: subject
+          subject_needed_code: 172Q
+          subject_needed_name: CALCULO 2
+          needs: exam
+        - type: subject
+          subject_needed_code: MAT33
+          subject_needed_name: CREDITOS ASIGNADOS POR REVALIDA
+          needs: exam
+        - type: subject
+          subject_needed_code: MA47
+          subject_needed_name: CREDITOS ASIGNADOS POR REVALIDA
+          needs: exam
+        - type: subject
+          subject_needed_code: 1062P
+          subject_needed_name: CREDITOS NO ACUM CDIVV
+          needs: exam
+      - type: logical
+        logical_operator: or
+        operands:
+        - type: subject
+          subject_needed_code: '1021'
+          subject_needed_name: ALGEBRA LINEAL
+          needs: exam
+        - type: subject
+          subject_needed_code: CM14
+          subject_needed_name: CREDITOS ASIGNADOS POR REVALIDA
+          needs: exam
+        - type: subject
+          subject_needed_code: MAT33
+          subject_needed_name: CREDITOS ASIGNADOS POR REVALIDA
+          needs: exam
+        - type: subject
+          subject_needed_code: M9
+          subject_needed_name: CREDITOS ASIGNADOS POR REVALIDA
+          needs: exam
+        - type: subject
+          subject_needed_code: 1030P
+          subject_needed_name: CREDITOS NO ACUM GAL1
+          needs: exam
+        - type: subject
+          subject_needed_code: CP2
+          subject_needed_name: GEOMETRIA Y ALGEBRA LINEAL
+          needs: exam
+        - type: subject
+          subject_needed_code: CP23
+          subject_needed_name: GEOMETRIA Y ALGEBRA LINEAL (P. 74)
+          needs: exam
+        - type: subject
+          subject_needed_code: '1030'
+          subject_needed_name: GEOMETRIA Y ALGEBRA LINEAL 1
+          needs: exam
+        - type: subject
+          subject_needed_code: '1071'
+          subject_needed_name: GEOMETRIA Y ALGEBRA LINEAL 1
+          needs: exam
+        - type: subject
+          subject_needed_code: 171L
+          subject_needed_name: GEOMETRIA Y ALGEBRA LINEAL 1
+          needs: exam
+        - type: subject
+          subject_needed_code: 171Q
+          subject_needed_name: GEOMETRIA Y ALGEBRA LINEAL 1
+          needs: exam
+        - type: subject
+          subject_needed_code: '1053'
+          subject_needed_name: GEOMETRIA Y ALGEBRA LINEAL 1 (ANUAL)
+          needs: exam
+        - type: subject
+          subject_needed_code: GAL1P
+          subject_needed_name: GEOMETRIA Y ALGEBRA LINEAL 1 INTERACTIVA
+          needs: exam
+      - type: logical
+        logical_operator: or
+        operands:
+        - type: subject
+          subject_needed_code: CP1
+          subject_needed_name: ANALISIS MATEMATICO I
+          needs: exam
+        - type: subject
+          subject_needed_code: CP22
+          subject_needed_name: ANALISIS MATEMATICO I (P. 74)
+          needs: exam
+        - type: subject
+          subject_needed_code: '1061'
+          subject_needed_name: CALCULO DIF. E INTEGRAL EN UNA VARIABLE
+          needs: exam
+        - type: subject
+          subject_needed_code: '1020'
+          subject_needed_name: CALCULO 1
+          needs: exam
+        - type: subject
+          subject_needed_code: 107L
+          subject_needed_name: CALCULO 1
+          needs: exam
+        - type: subject
+          subject_needed_code: '1070'
+          subject_needed_name: CALCULO 1
+          needs: exam
+        - type: subject
+          subject_needed_code: 170Q
+          subject_needed_name: CALCULO 1
+          needs: exam
+        - type: subject
+          subject_needed_code: '1052'
+          subject_needed_name: CALCULO 1 (ANUAL)
+          needs: exam
+        - type: subject
+          subject_needed_code: CAL10
+          subject_needed_name: CREDITOS ASIGNADOS POR REVALIDA
+          needs: exam
+        - type: subject
+          subject_needed_code: MAT33
+          subject_needed_name: CREDITOS ASIGNADOS POR REVALIDA
+          needs: exam
+        - type: subject
+          subject_needed_code: MA47
+          subject_needed_name: CREDITOS ASIGNADOS POR REVALIDA
+          needs: exam
+        - type: subject
+          subject_needed_code: M13
+          subject_needed_name: CREDITOS ASIGNADOS POR REVALIDA
+          needs: exam
+        - type: subject
+          subject_needed_code: M14
+          subject_needed_name: CREDITOS ASIGNADOS POR REVALIDA
+          needs: exam
+        - type: subject
+          subject_needed_code: 1020P
+          subject_needed_name: CREDITOS NO ACUM CALCULO 1
+          needs: exam
+        - type: subject
+          subject_needed_code: 1061P
+          subject_needed_name: CREDITOS NO ACUM CDIV
+          needs: exam
+    - type: subject
+      needs: course
+      subject_needed_code: '1063'
+      subject_needed_name: CALCULO VECTORIAL
+  subject_code: '1063'
+  is_exam: true
+- type: logical
+  logical_operator: and
+  operands:
+  - type: logical
+    logical_operator: not
+    operands:
+    - type: logical
+      logical_operator: or
+      operands:
+      - type: subject
+        subject_needed_code: CP6
+        subject_needed_name: ANALISIS MATEMATICO II
+        needs: exam
+      - type: subject
+        subject_needed_code: CP25
+        subject_needed_name: ANALISIS MATEMATICO II (P. 74)
+        needs: exam
+      - type: subject
+        subject_needed_code: CP48
+        subject_needed_name: ANALISIS MATEMATICO II (1ER.SEM.)
+        needs: exam
+      - type: subject
+        subject_needed_code: 1028M
+        subject_needed_name: CREDITOS ASIGNADOS POR REVALIDA
+        needs: exam
+      - type: subject
+        subject_needed_code: 1028P
+        subject_needed_name: CREDITOS NO ACUM EC. DIFERENCIALES
+        needs: exam
+      - type: subject
+        subject_needed_code: '1028'
+        subject_needed_name: ECUACIONES DIFERENCIALES
+        needs: exam
+      - type: subject
+        subject_needed_code: '1074'
+        subject_needed_name: ECUACIONES DIFERENCIALES
+        needs: exam
+  - type: logical
+    logical_operator: or
+    operands:
+    - type: subject
+      subject_needed_code: CP1
+      subject_needed_name: ANALISIS MATEMATICO I
+      needs: exam
+    - type: subject
+      subject_needed_code: CP22
+      subject_needed_name: ANALISIS MATEMATICO I (P. 74)
+      needs: exam
+    - type: subject
+      subject_needed_code: '1062'
+      subject_needed_name: CALCULO DIF. E INTEGRAL EN VARIAS VARIABLES
+      needs: course
+    - type: subject
+      subject_needed_code: '1022'
+      subject_needed_name: CALCULO 2
+      needs: exam
+    - type: subject
+      subject_needed_code: '1072'
+      subject_needed_name: CALCULO 2
+      needs: exam
+    - type: subject
+      subject_needed_code: 172Q
+      subject_needed_name: CALCULO 2
+      needs: exam
+    - type: subject
+      subject_needed_code: MAT33
+      subject_needed_name: CREDITOS ASIGNADOS POR REVALIDA
+      needs: exam
+    - type: subject
+      subject_needed_code: MA47
+      subject_needed_name: CREDITOS ASIGNADOS POR REVALIDA
+      needs: exam
+    - type: subject
+      subject_needed_code: 1062P
+      subject_needed_name: CREDITOS NO ACUM CDIVV
+      needs: exam
+  - type: logical
+    logical_operator: or
+    operands:
+    - type: subject
+      subject_needed_code: CP1
+      subject_needed_name: ANALISIS MATEMATICO I
+      needs: exam
+    - type: subject
+      subject_needed_code: CP22
+      subject_needed_name: ANALISIS MATEMATICO I (P. 74)
+      needs: exam
+    - type: subject
+      subject_needed_code: '1061'
+      subject_needed_name: CALCULO DIF. E INTEGRAL EN UNA VARIABLE
+      needs: exam
+    - type: subject
+      subject_needed_code: '1020'
+      subject_needed_name: CALCULO 1
+      needs: exam
+    - type: subject
+      subject_needed_code: 107L
+      subject_needed_name: CALCULO 1
+      needs: exam
+    - type: subject
+      subject_needed_code: '1070'
+      subject_needed_name: CALCULO 1
+      needs: exam
+    - type: subject
+      subject_needed_code: 170Q
+      subject_needed_name: CALCULO 1
+      needs: exam
+    - type: subject
+      subject_needed_code: '1052'
+      subject_needed_name: CALCULO 1 (ANUAL)
+      needs: exam
+    - type: subject
+      subject_needed_code: CAL10
+      subject_needed_name: CREDITOS ASIGNADOS POR REVALIDA
+      needs: exam
+    - type: subject
+      subject_needed_code: MAT33
+      subject_needed_name: CREDITOS ASIGNADOS POR REVALIDA
+      needs: exam
+    - type: subject
+      subject_needed_code: MA47
+      subject_needed_name: CREDITOS ASIGNADOS POR REVALIDA
+      needs: exam
+    - type: subject
+      subject_needed_code: M13
+      subject_needed_name: CREDITOS ASIGNADOS POR REVALIDA
+      needs: exam
+    - type: subject
+      subject_needed_code: M14
+      subject_needed_name: CREDITOS ASIGNADOS POR REVALIDA
+      needs: exam
+    - type: subject
+      subject_needed_code: 1020P
+      subject_needed_name: CREDITOS NO ACUM CALCULO 1
+      needs: exam
+    - type: subject
+      subject_needed_code: 1061P
+      subject_needed_name: CREDITOS NO ACUM CDIV
+      needs: exam
+  - type: logical
+    logical_operator: or
+    operands:
+    - type: subject
+      subject_needed_code: '1021'
+      subject_needed_name: ALGEBRA LINEAL
+      needs: exam
+    - type: subject
+      subject_needed_code: CM14
+      subject_needed_name: CREDITOS ASIGNADOS POR REVALIDA
+      needs: exam
+    - type: subject
+      subject_needed_code: MAT33
+      subject_needed_name: CREDITOS ASIGNADOS POR REVALIDA
+      needs: exam
+    - type: subject
+      subject_needed_code: M9
+      subject_needed_name: CREDITOS ASIGNADOS POR REVALIDA
+      needs: exam
+    - type: subject
+      subject_needed_code: 1030P
+      subject_needed_name: CREDITOS NO ACUM GAL1
+      needs: exam
+    - type: subject
+      subject_needed_code: CP2
+      subject_needed_name: GEOMETRIA Y ALGEBRA LINEAL
+      needs: exam
+    - type: subject
+      subject_needed_code: CP23
+      subject_needed_name: GEOMETRIA Y ALGEBRA LINEAL (P. 74)
+      needs: exam
+    - type: subject
+      subject_needed_code: '1030'
+      subject_needed_name: GEOMETRIA Y ALGEBRA LINEAL 1
+      needs: exam
+    - type: subject
+      subject_needed_code: '1071'
+      subject_needed_name: GEOMETRIA Y ALGEBRA LINEAL 1
+      needs: exam
+    - type: subject
+      subject_needed_code: 171Q
+      subject_needed_name: GEOMETRIA Y ALGEBRA LINEAL 1
+      needs: exam
+    - type: subject
+      subject_needed_code: '1053'
+      subject_needed_name: GEOMETRIA Y ALGEBRA LINEAL 1 (ANUAL)
+      needs: exam
+    - type: subject
+      subject_needed_code: GAL1P
+      subject_needed_name: GEOMETRIA Y ALGEBRA LINEAL 1 INTERACTIVA
+      needs: exam
+  - type: logical
+    logical_operator: or
+    operands:
+    - type: subject
+      subject_needed_code: '1021'
+      subject_needed_name: ALGEBRA LINEAL
+      needs: exam
+    - type: subject
+      subject_needed_code: MAT33
+      subject_needed_name: CREDITOS ASIGNADOS POR REVALIDA
+      needs: exam
+    - type: subject
+      subject_needed_code: M9
+      subject_needed_name: CREDITOS ASIGNADOS POR REVALIDA
+      needs: exam
+    - type: subject
+      subject_needed_code: 1031P
+      subject_needed_name: CREDITOS NO ACUM GAL2
+      needs: exam
+    - type: subject
+      subject_needed_code: CP2
+      subject_needed_name: GEOMETRIA Y ALGEBRA LINEAL
+      needs: exam
+    - type: subject
+      subject_needed_code: CP23
+      subject_needed_name: GEOMETRIA Y ALGEBRA LINEAL (P. 74)
+      needs: exam
+    - type: subject
+      subject_needed_code: '1031'
+      subject_needed_name: GEOMETRIA Y ALGEBRA LINEAL 2
+      needs: exam
+    - type: subject
+      subject_needed_code: '1058'
+      subject_needed_name: GEOMETRIA Y ALGEBRA LINEAL 2
+      needs: exam
+    - type: subject
+      subject_needed_code: 158Q
+      subject_needed_name: GEOMETRIA Y ALGEBRA LINEAL 2
+      needs: exam
+  subject_code: '1064'
+  is_exam: false
+- type: logical
+  logical_operator: and
+  operands:
+  - type: logical
+    logical_operator: not
+    operands:
+    - type: logical
+      logical_operator: or
+      operands:
+      - type: subject
+        subject_needed_code: CP6
+        subject_needed_name: ANALISIS MATEMATICO II
+        needs: exam
+      - type: subject
+        subject_needed_code: CP25
+        subject_needed_name: ANALISIS MATEMATICO II (P. 74)
+        needs: exam
+      - type: subject
+        subject_needed_code: CP48
+        subject_needed_name: ANALISIS MATEMATICO II (1ER.SEM.)
+        needs: exam
+      - type: subject
+        subject_needed_code: 1028M
+        subject_needed_name: CREDITOS ASIGNADOS POR REVALIDA
+        needs: exam
+      - type: subject
+        subject_needed_code: 1028P
+        subject_needed_name: CREDITOS NO ACUM EC. DIFERENCIALES
+        needs: exam
+      - type: subject
+        subject_needed_code: '1028'
+        subject_needed_name: ECUACIONES DIFERENCIALES
+        needs: exam
+      - type: subject
+        subject_needed_code: '1074'
+        subject_needed_name: ECUACIONES DIFERENCIALES
+        needs: exam
+  - type: logical
+    logical_operator: or
+    operands:
+    - type: logical
+      logical_operator: and
+      operands:
+      - type: logical
+        logical_operator: or
+        operands:
+        - type: subject
+          subject_needed_code: '1021'
+          subject_needed_name: ALGEBRA LINEAL
+          needs: exam
+        - type: subject
+          subject_needed_code: CM14
+          subject_needed_name: CREDITOS ASIGNADOS POR REVALIDA
+          needs: exam
+        - type: subject
+          subject_needed_code: MAT33
+          subject_needed_name: CREDITOS ASIGNADOS POR REVALIDA
+          needs: exam
+        - type: subject
+          subject_needed_code: M9
+          subject_needed_name: CREDITOS ASIGNADOS POR REVALIDA
+          needs: exam
+        - type: subject
+          subject_needed_code: 1030P
+          subject_needed_name: CREDITOS NO ACUM GAL1
+          needs: exam
+        - type: subject
+          subject_needed_code: CP2
+          subject_needed_name: GEOMETRIA Y ALGEBRA LINEAL
+          needs: exam
+        - type: subject
+          subject_needed_code: CP23
+          subject_needed_name: GEOMETRIA Y ALGEBRA LINEAL (P. 74)
+          needs: exam
+        - type: subject
+          subject_needed_code: '1030'
+          subject_needed_name: GEOMETRIA Y ALGEBRA LINEAL 1
+          needs: exam
+        - type: subject
+          subject_needed_code: '1071'
+          subject_needed_name: GEOMETRIA Y ALGEBRA LINEAL 1
+          needs: exam
+        - type: subject
+          subject_needed_code: 171L
+          subject_needed_name: GEOMETRIA Y ALGEBRA LINEAL 1
+          needs: exam
+        - type: subject
+          subject_needed_code: 171Q
+          subject_needed_name: GEOMETRIA Y ALGEBRA LINEAL 1
+          needs: exam
+        - type: subject
+          subject_needed_code: '1053'
+          subject_needed_name: GEOMETRIA Y ALGEBRA LINEAL 1 (ANUAL)
+          needs: exam
+        - type: subject
+          subject_needed_code: GAL1P
+          subject_needed_name: GEOMETRIA Y ALGEBRA LINEAL 1 INTERACTIVA
+          needs: exam
+      - type: logical
+        logical_operator: or
+        operands:
+        - type: subject
+          subject_needed_code: '1021'
+          subject_needed_name: ALGEBRA LINEAL
+          needs: exam
+        - type: subject
+          subject_needed_code: MAT33
+          subject_needed_name: CREDITOS ASIGNADOS POR REVALIDA
+          needs: exam
+        - type: subject
+          subject_needed_code: M9
+          subject_needed_name: CREDITOS ASIGNADOS POR REVALIDA
+          needs: exam
+        - type: subject
+          subject_needed_code: 1031P
+          subject_needed_name: CREDITOS NO ACUM GAL2
+          needs: exam
+        - type: subject
+          subject_needed_code: CP2
+          subject_needed_name: GEOMETRIA Y ALGEBRA LINEAL
+          needs: exam
+        - type: subject
+          subject_needed_code: CP23
+          subject_needed_name: GEOMETRIA Y ALGEBRA LINEAL (P. 74)
+          needs: exam
+        - type: subject
+          subject_needed_code: '1031'
+          subject_needed_name: GEOMETRIA Y ALGEBRA LINEAL 2
+          needs: exam
+        - type: subject
+          subject_needed_code: '1058'
+          subject_needed_name: GEOMETRIA Y ALGEBRA LINEAL 2
+          needs: exam
+        - type: subject
+          subject_needed_code: 158Q
+          subject_needed_name: GEOMETRIA Y ALGEBRA LINEAL 2
+          needs: exam
+      - type: logical
+        logical_operator: or
+        operands:
+        - type: subject
+          subject_needed_code: CP1
+          subject_needed_name: ANALISIS MATEMATICO I
+          needs: exam
+        - type: subject
+          subject_needed_code: CP22
+          subject_needed_name: ANALISIS MATEMATICO I (P. 74)
+          needs: exam
+        - type: subject
+          subject_needed_code: '1061'
+          subject_needed_name: CALCULO DIF. E INTEGRAL EN UNA VARIABLE
+          needs: exam
+        - type: subject
+          subject_needed_code: '1020'
+          subject_needed_name: CALCULO 1
+          needs: exam
+        - type: subject
+          subject_needed_code: 107L
+          subject_needed_name: CALCULO 1
+          needs: exam
+        - type: subject
+          subject_needed_code: '1070'
+          subject_needed_name: CALCULO 1
+          needs: exam
+        - type: subject
+          subject_needed_code: 170Q
+          subject_needed_name: CALCULO 1
+          needs: exam
+        - type: subject
+          subject_needed_code: '1052'
+          subject_needed_name: CALCULO 1 (ANUAL)
+          needs: exam
+        - type: subject
+          subject_needed_code: CAL10
+          subject_needed_name: CREDITOS ASIGNADOS POR REVALIDA
+          needs: exam
+        - type: subject
+          subject_needed_code: MAT33
+          subject_needed_name: CREDITOS ASIGNADOS POR REVALIDA
+          needs: exam
+        - type: subject
+          subject_needed_code: MA47
+          subject_needed_name: CREDITOS ASIGNADOS POR REVALIDA
+          needs: exam
+        - type: subject
+          subject_needed_code: M13
+          subject_needed_name: CREDITOS ASIGNADOS POR REVALIDA
+          needs: exam
+        - type: subject
+          subject_needed_code: M14
+          subject_needed_name: CREDITOS ASIGNADOS POR REVALIDA
+          needs: exam
+        - type: subject
+          subject_needed_code: 1020P
+          subject_needed_name: CREDITOS NO ACUM CALCULO 1
+          needs: exam
+        - type: subject
+          subject_needed_code: 1061P
+          subject_needed_name: CREDITOS NO ACUM CDIV
+          needs: exam
+    - type: subject
+      needs: course
+      subject_needed_code: '1064'
+      subject_needed_name: INT. A LAS ECUACIONES DIFERENCIALES
+  - type: logical
+    logical_operator: or
+    operands:
+    - type: subject
+      subject_needed_code: CP1
+      subject_needed_name: ANALISIS MATEMATICO I
+      needs: exam
+    - type: subject
+      subject_needed_code: CP22
+      subject_needed_name: ANALISIS MATEMATICO I (P. 74)
+      needs: exam
+    - type: subject
+      subject_needed_code: '1062'
+      subject_needed_name: CALCULO DIF. E INTEGRAL EN VARIAS VARIABLES
+      needs: exam
+    - type: subject
+      subject_needed_code: '1022'
+      subject_needed_name: CALCULO 2
+      needs: exam
+    - type: subject
+      subject_needed_code: '1072'
+      subject_needed_name: CALCULO 2
+      needs: exam
+    - type: subject
+      subject_needed_code: 172Q
+      subject_needed_name: CALCULO 2
+      needs: exam
+    - type: subject
+      subject_needed_code: MAT33
+      subject_needed_name: CREDITOS ASIGNADOS POR REVALIDA
+      needs: exam
+    - type: subject
+      subject_needed_code: MA47
+      subject_needed_name: CREDITOS ASIGNADOS POR REVALIDA
+      needs: exam
+    - type: subject
+      subject_needed_code: 1062P
+      subject_needed_name: CREDITOS NO ACUM CDIVV
+      needs: exam
+  subject_code: '1064'
+  is_exam: true
+- type: logical
+  logical_operator: and
+  operands:
+  - type: logical
+    logical_operator: not
+    operands:
+    - type: logical
+      logical_operator: or
+      operands:
+      - type: subject
+        subject_needed_code: CP7
+        subject_needed_name: ANALISIS COMPLEJO
+        needs: exam
+      - type: subject
+        subject_needed_code: CP25
+        subject_needed_name: ANALISIS MATEMATICO II (P. 74)
+        needs: exam
+      - type: subject
+        subject_needed_code: 1036R
+        subject_needed_name: CREDITOS ASIGNADOS POR REVALIDA
+        needs: exam
+      - type: subject
+        subject_needed_code: '1036'
+        subject_needed_name: FUNCIONES DE VARIABLE COMPLEJA
+        needs: exam
+  - type: logical
+    logical_operator: or
+    operands:
+    - type: subject
+      subject_needed_code: '1062'
+      subject_needed_name: CALCULO DIF. E INTEGRAL EN VARIAS VARIABLES
+      needs: exam
+    - type: subject
+      subject_needed_code: '1022'
+      subject_needed_name: CALCULO 2
+      needs: exam
+    - type: subject
+      subject_needed_code: '1072'
+      subject_needed_name: CALCULO 2
+      needs: exam
+    - type: subject
+      subject_needed_code: MAT33
+      subject_needed_name: CREDITOS ASIGNADOS POR REVALIDA
+      needs: exam
+    - type: subject
+      subject_needed_code: 1062P
+      subject_needed_name: CREDITOS NO ACUM CDIVV
+      needs: exam
+  - type: logical
+    logical_operator: or
+    operands:
+    - type: subject
+      subject_needed_code: '1063'
+      subject_needed_name: CALCULO VECTORIAL
+      needs: course
+    - type: subject
+      subject_needed_code: '1024'
+      subject_needed_name: CALCULO 3
+      needs: course
+    - type: subject
+      subject_needed_code: '1076'
+      subject_needed_name: CALCULO 3
+      needs: exam
+    - type: subject
+      subject_needed_code: 1063P
+      subject_needed_name: CREDITOS NO ACUM CAL. VECTORIAL
+      needs: exam
+    - type: subject
+      subject_needed_code: 1024P
+      subject_needed_name: CREDITOS NO ACUM CALCULO 3
+      needs: exam
+  subject_code: '1066'
+  is_exam: false
+- type: logical
+  logical_operator: and
+  operands:
+  - type: logical
+    logical_operator: not
+    operands:
+    - type: logical
+      logical_operator: or
+      operands:
+      - type: subject
+        subject_needed_code: CP7
+        subject_needed_name: ANALISIS COMPLEJO
+        needs: exam
+      - type: subject
+        subject_needed_code: CP25
+        subject_needed_name: ANALISIS MATEMATICO II (P. 74)
+        needs: exam
+      - type: subject
+        subject_needed_code: 1036R
+        subject_needed_name: CREDITOS ASIGNADOS POR REVALIDA
+        needs: exam
+  - type: logical
+    logical_operator: or
+    operands:
+    - type: subject
+      subject_needed_code: '1062'
+      subject_needed_name: CALCULO DIF. E INTEGRAL EN VARIAS VARIABLES
+      needs: exam
+    - type: subject
+      subject_needed_code: '1022'
+      subject_needed_name: CALCULO 2
+      needs: exam
+    - type: subject
+      subject_needed_code: '1072'
+      subject_needed_name: CALCULO 2
+      needs: exam
+    - type: subject
+      subject_needed_code: MAT33
+      subject_needed_name: CREDITOS ASIGNADOS POR REVALIDA
+      needs: exam
+    - type: subject
+      subject_needed_code: 1062P
+      subject_needed_name: CREDITOS NO ACUM CDIVV
+      needs: exam
+  - type: logical
+    logical_operator: or
+    operands:
+    - type: subject
+      subject_needed_code: '1063'
+      subject_needed_name: CALCULO VECTORIAL
+      needs: course
+    - type: subject
+      subject_needed_code: '1024'
+      subject_needed_name: CALCULO 3
+      needs: exam
+    - type: subject
+      subject_needed_code: '1076'
+      subject_needed_name: CALCULO 3
+      needs: exam
+    - type: subject
+      subject_needed_code: 1063P
+      subject_needed_name: CREDITOS NO ACUM CAL. VECTORIAL
+      needs: exam
+    - type: subject
+      subject_needed_code: 1024P
+      subject_needed_name: CREDITOS NO ACUM CALCULO 3
+      needs: exam
+  subject_code: '1066'
+  is_exam: true
+- type: logical
+  logical_operator: and
+  operands:
+  - type: logical
+    logical_operator: not
+    operands:
+    - type: logical
+      logical_operator: or
+      operands:
+      - type: subject
+        subject_needed_code: FI15
+        subject_needed_name: CREDITOS ASIGNADOS POR REVALIDA
+        needs: exam
+      - type: subject
+        subject_needed_code: 1122P
+        subject_needed_name: CREDITOS NO ACUM MEC NEWTONIANA
+        needs: exam
+      - type: subject
+        subject_needed_code: CP26
+        subject_needed_name: MECANICA GENERAL I (P. 74)
+        needs: exam
+  - type: logical
+    logical_operator: or
+    operands:
+    - type: subject
+      subject_needed_code: 1151P
+      subject_needed_name: CREDITOS NO ACUM FISICA 1
+      needs: exam
+    - type: subject
+      subject_needed_code: '1120'
+      subject_needed_name: FISICA GENERAL 1
+      needs: exam
+    - type: subject
+      subject_needed_code: '1170'
+      subject_needed_name: FISICA GENERAL 1
+      needs: exam
+    - type: subject
+      subject_needed_code: '1151'
+      subject_needed_name: FISICA 1
+      needs: exam
+    - type: subject
+      subject_needed_code: '1171'
+      subject_needed_name: FISICA 1
+      needs: exam
+  - type: logical
+    logical_operator: or
+    operands:
+    - type: subject
+      subject_needed_code: '1062'
+      subject_needed_name: CALCULO DIF. E INTEGRAL EN VARIAS VARIABLES
+      needs: course
+    - type: subject
+      subject_needed_code: '1022'
+      subject_needed_name: CALCULO 2
+      needs: exam
+    - type: subject
+      subject_needed_code: '1072'
+      subject_needed_name: CALCULO 2
+      needs: exam
+    - type: subject
+      subject_needed_code: 108L
+      subject_needed_name: CALCULO 2
+      needs: exam
+    - type: subject
+      subject_needed_code: 1022P
+      subject_needed_name: CREDITOS NO ACUM CALCULO 2
+      needs: exam
+    - type: subject
+      subject_needed_code: 1062P
+      subject_needed_name: CREDITOS NO ACUM CDIVV
+      needs: exam
+    - type: subject
+      subject_needed_code: 1022T
+      subject_needed_name: CREDITOS POR CALCULO 2
+      needs: exam
+  - type: logical
+    logical_operator: or
+    operands:
+    - type: subject
+      subject_needed_code: 1152P
+      subject_needed_name: CREDITOS NO ACUM FISICA 2
+      needs: exam
+    - type: subject
+      subject_needed_code: 1153P
+      subject_needed_name: CREDITOS NO ACUM FISICA 3
+      needs: exam
+    - type: subject
+      subject_needed_code: '1121'
+      subject_needed_name: FISICA GENERAL 2
+      needs: exam
+    - type: subject
+      subject_needed_code: '1172'
+      subject_needed_name: FISICA GENERAL 2
+      needs: exam
+    - type: subject
+      subject_needed_code: '1152'
+      subject_needed_name: FISICA 2
+      needs: course
+    - type: subject
+      subject_needed_code: '1153'
+      subject_needed_name: FISICA 3
+      needs: course
+  - type: logical
+    logical_operator: or
+    operands:
+    - type: subject
+      subject_needed_code: '1021'
+      subject_needed_name: ALGEBRA LINEAL
+      needs: course
+    - type: subject
+      subject_needed_code: MAT33
+      subject_needed_name: CREDITOS ASIGNADOS POR REVALIDA
+      needs: exam
+    - type: subject
+      subject_needed_code: 1030P
+      subject_needed_name: CREDITOS NO ACUM GAL1
+      needs: exam
+    - type: subject
+      subject_needed_code: '1030'
+      subject_needed_name: GEOMETRIA Y ALGEBRA LINEAL 1
+      needs: exam
+    - type: subject
+      subject_needed_code: '1071'
+      subject_needed_name: GEOMETRIA Y ALGEBRA LINEAL 1
+      needs: exam
+    - type: subject
+      subject_needed_code: '1053'
+      subject_needed_name: GEOMETRIA Y ALGEBRA LINEAL 1 (ANUAL)
+      needs: exam
+    - type: subject
+      subject_needed_code: GAL1P
+      subject_needed_name: GEOMETRIA Y ALGEBRA LINEAL 1 INTERACTIVA
+      needs: exam
+  - type: logical
+    logical_operator: or
+    operands:
+    - type: subject
+      subject_needed_code: '1061'
+      subject_needed_name: CALCULO DIF. E INTEGRAL EN UNA VARIABLE
+      needs: exam
+    - type: subject
+      subject_needed_code: '1020'
+      subject_needed_name: CALCULO 1
+      needs: exam
+    - type: subject
+      subject_needed_code: '1070'
+      subject_needed_name: CALCULO 1
+      needs: exam
+    - type: subject
+      subject_needed_code: '1052'
+      subject_needed_name: CALCULO 1 (ANUAL)
+      needs: exam
+    - type: subject
+      subject_needed_code: MAT33
+      subject_needed_name: CREDITOS ASIGNADOS POR REVALIDA
+      needs: exam
+    - type: subject
+      subject_needed_code: 1020P
+      subject_needed_name: CREDITOS NO ACUM CALCULO 1
+      needs: exam
+    - type: subject
+      subject_needed_code: 1061P
+      subject_needed_name: CREDITOS NO ACUM CDIV
+      needs: exam
+  subject_code: '1122'
+  is_exam: false
+- type: logical
+  logical_operator: and
+  operands:
+  - type: logical
+    logical_operator: not
+    operands:
+    - type: logical
+      logical_operator: or
+      operands:
+      - type: subject
+        subject_needed_code: FI15
+        subject_needed_name: CREDITOS ASIGNADOS POR REVALIDA
+        needs: exam
+      - type: subject
+        subject_needed_code: 1122P
+        subject_needed_name: CREDITOS NO ACUM MEC NEWTONIANA
+        needs: exam
+      - type: subject
+        subject_needed_code: CP26
+        subject_needed_name: MECANICA GENERAL I (P. 74)
+        needs: exam
+      - type: subject
+        subject_needed_code: CP8
+        subject_needed_name: MECANICA II
+        needs: exam
+  - type: logical
+    logical_operator: or
+    operands:
+    - type: logical
+      logical_operator: and
+      operands:
+      - type: logical
+        logical_operator: or
+        operands:
+        - type: subject
+          subject_needed_code: '1021'
+          subject_needed_name: ALGEBRA LINEAL
+          needs: course
+        - type: subject
+          subject_needed_code: MAT33
+          subject_needed_name: CREDITOS ASIGNADOS POR REVALIDA
+          needs: exam
+        - type: subject
+          subject_needed_code: 1030P
+          subject_needed_name: CREDITOS NO ACUM GAL1
+          needs: exam
+        - type: subject
+          subject_needed_code: '1030'
+          subject_needed_name: GEOMETRIA Y ALGEBRA LINEAL 1
+          needs: exam
+        - type: subject
+          subject_needed_code: '1071'
+          subject_needed_name: GEOMETRIA Y ALGEBRA LINEAL 1
+          needs: exam
+        - type: subject
+          subject_needed_code: '1053'
+          subject_needed_name: GEOMETRIA Y ALGEBRA LINEAL 1 (ANUAL)
+          needs: exam
+        - type: subject
+          subject_needed_code: GAL1P
+          subject_needed_name: GEOMETRIA Y ALGEBRA LINEAL 1 INTERACTIVA
+          needs: exam
+      - type: logical
+        logical_operator: or
+        operands:
+        - type: subject
+          subject_needed_code: '1062'
+          subject_needed_name: CALCULO DIF. E INTEGRAL EN VARIAS VARIABLES
+          needs: course
+        - type: subject
+          subject_needed_code: '1022'
+          subject_needed_name: CALCULO 2
+          needs: exam
+        - type: subject
+          subject_needed_code: '1072'
+          subject_needed_name: CALCULO 2
+          needs: exam
+        - type: subject
+          subject_needed_code: 108L
+          subject_needed_name: CALCULO 2
+          needs: exam
+        - type: subject
+          subject_needed_code: 172Q
+          subject_needed_name: CALCULO 2
+          needs: exam
+        - type: subject
+          subject_needed_code: 1022P
+          subject_needed_name: CREDITOS NO ACUM CALCULO 2
+          needs: exam
+        - type: subject
+          subject_needed_code: 1062P
+          subject_needed_name: CREDITOS NO ACUM CDIVV
+          needs: exam
+        - type: subject
+          subject_needed_code: 1022T
+          subject_needed_name: CREDITOS POR CALCULO 2
+          needs: exam
+      - type: logical
+        logical_operator: or
+        operands:
+        - type: subject
+          subject_needed_code: 1151P
+          subject_needed_name: CREDITOS NO ACUM FISICA 1
+          needs: exam
+        - type: subject
+          subject_needed_code: '1120'
+          subject_needed_name: FISICA GENERAL 1
+          needs: exam
+        - type: subject
+          subject_needed_code: '1170'
+          subject_needed_name: FISICA GENERAL 1
+          needs: exam
+        - type: subject
+          subject_needed_code: '1151'
+          subject_needed_name: FISICA 1
+          needs: exam
+        - type: subject
+          subject_needed_code: '1171'
+          subject_needed_name: FISICA 1
+          needs: exam
+      - type: logical
+        logical_operator: or
+        operands:
+        - type: subject
+          subject_needed_code: '1061'
+          subject_needed_name: CALCULO DIF. E INTEGRAL EN UNA VARIABLE
+          needs: exam
+        - type: subject
+          subject_needed_code: '1020'
+          subject_needed_name: CALCULO 1
+          needs: exam
+        - type: subject
+          subject_needed_code: '1070'
+          subject_needed_name: CALCULO 1
+          needs: exam
+        - type: subject
+          subject_needed_code: '1052'
+          subject_needed_name: CALCULO 1 (ANUAL)
+          needs: exam
+        - type: subject
+          subject_needed_code: MAT33
+          subject_needed_name: CREDITOS ASIGNADOS POR REVALIDA
+          needs: exam
+        - type: subject
+          subject_needed_code: 1020P
+          subject_needed_name: CREDITOS NO ACUM CALCULO 1
+          needs: exam
+        - type: subject
+          subject_needed_code: 1061P
+          subject_needed_name: CREDITOS NO ACUM CDIV
+          needs: exam
+      - type: logical
+        logical_operator: or
+        operands:
+        - type: subject
+          subject_needed_code: 1152P
+          subject_needed_name: CREDITOS NO ACUM FISICA 2
+          needs: exam
+        - type: subject
+          subject_needed_code: 1153P
+          subject_needed_name: CREDITOS NO ACUM FISICA 3
+          needs: exam
+        - type: subject
+          subject_needed_code: '1121'
+          subject_needed_name: FISICA GENERAL 2
+          needs: exam
+        - type: subject
+          subject_needed_code: '1172'
+          subject_needed_name: FISICA GENERAL 2
+          needs: exam
+        - type: subject
+          subject_needed_code: '1152'
+          subject_needed_name: FISICA 2
+          needs: course
+        - type: subject
+          subject_needed_code: '1153'
+          subject_needed_name: FISICA 3
+          needs: course
+    - type: subject
+      needs: course
+      subject_needed_code: '1122'
+      subject_needed_name: MECANICA NEWTONIANA
+  subject_code: '1122'
+  is_exam: true
+- type: logical
+  logical_operator: and
+  operands:
+  - type: logical
+    logical_operator: not
+    operands:
+    - type: logical
+      logical_operator: or
+      operands:
+      - type: subject
+        subject_needed_code: FIS45
+        subject_needed_name: CREDITOS ASIGNADOS POR REVALIDA
+        needs: exam
+      - type: subject
+        subject_needed_code: 1123P
+        subject_needed_name: CREDITOS NO ACUM FIS TERMICA
+        needs: exam
+      - type: subject
+        subject_needed_code: CP42
+        subject_needed_name: FISICA II (P. 74)
+        needs: exam
+      - type: subject
+        subject_needed_code: '1073'
+        subject_needed_name: FISICA TERMICA
+        needs: exam
+      - type: subject
+        subject_needed_code: CP12
+        subject_needed_name: TERMODINAMICA
+        needs: exam
+  - type: logical
+    logical_operator: or
+    operands:
+    - type: subject
+      subject_needed_code: 1121P
+      subject_needed_name: CREDITOS NO ACUM FISICA GRAL. 2
+      needs: exam
+    - type: subject
+      subject_needed_code: 1152P
+      subject_needed_name: CREDITOS NO ACUM FISICA 2
+      needs: exam
+    - type: subject
+      subject_needed_code: 1153P
+      subject_needed_name: CREDITOS NO ACUM FISICA 3
+      needs: exam
+    - type: subject
+      subject_needed_code: '1121'
+      subject_needed_name: FISICA GENERAL 2
+      needs: exam
+    - type: subject
+      subject_needed_code: '1172'
+      subject_needed_name: FISICA GENERAL 2
+      needs: exam
+    - type: subject
+      subject_needed_code: '1152'
+      subject_needed_name: FISICA 2
+      needs: course
+    - type: subject
+      subject_needed_code: '1153'
+      subject_needed_name: FISICA 3
+      needs: course
+  - type: logical
+    logical_operator: or
+    operands:
+    - type: subject
+      subject_needed_code: 1120P
+      subject_needed_name: CREDITOS NO ACUM. FISICA GENERAL 1
+      needs: exam
+    - type: subject
+      subject_needed_code: 1151P
+      subject_needed_name: CREDITOS NO ACUM FISICA 1
+      needs: exam
+    - type: subject
+      subject_needed_code: '1120'
+      subject_needed_name: FISICA GENERAL 1
+      needs: exam
+    - type: subject
+      subject_needed_code: '1170'
+      subject_needed_name: FISICA GENERAL 1
+      needs: exam
+    - type: subject
+      subject_needed_code: '1151'
+      subject_needed_name: FISICA 1
+      needs: exam
+    - type: subject
+      subject_needed_code: '1171'
+      subject_needed_name: FISICA 1
+      needs: exam
+  - type: logical
+    logical_operator: or
+    operands:
+    - type: subject
+      subject_needed_code: '1061'
+      subject_needed_name: CALCULO DIF. E INTEGRAL EN UNA VARIABLE
+      needs: exam
+    - type: subject
+      subject_needed_code: '1020'
+      subject_needed_name: CALCULO 1
+      needs: exam
+    - type: subject
+      subject_needed_code: '1070'
+      subject_needed_name: CALCULO 1
+      needs: exam
+    - type: subject
+      subject_needed_code: '1052'
+      subject_needed_name: CALCULO 1 (ANUAL)
+      needs: exam
+    - type: subject
+      subject_needed_code: MAT33
+      subject_needed_name: CREDITOS ASIGNADOS POR REVALIDA
+      needs: exam
+    - type: subject
+      subject_needed_code: 1020P
+      subject_needed_name: CREDITOS NO ACUM CALCULO 1
+      needs: exam
+    - type: subject
+      subject_needed_code: 1061P
+      subject_needed_name: CREDITOS NO ACUM CDIV
+      needs: exam
+  subject_code: '1123'
+  is_exam: false
+- type: logical
+  logical_operator: and
+  operands:
+  - type: logical
+    logical_operator: not
+    operands:
+    - type: logical
+      logical_operator: or
+      operands:
+      - type: subject
+        subject_needed_code: FIS45
+        subject_needed_name: CREDITOS ASIGNADOS POR REVALIDA
+        needs: exam
+      - type: subject
+        subject_needed_code: 1123P
+        subject_needed_name: CREDITOS NO ACUM FIS TERMICA
+        needs: exam
+      - type: subject
+        subject_needed_code: CP42
+        subject_needed_name: FISICA II (P. 74)
+        needs: exam
+      - type: subject
+        subject_needed_code: '1073'
+        subject_needed_name: FISICA TERMICA
+        needs: exam
+      - type: subject
+        subject_needed_code: CP12
+        subject_needed_name: TERMODINAMICA
+        needs: exam
+  - type: logical
+    logical_operator: or
+    operands:
+    - type: logical
+      logical_operator: and
+      operands:
+      - type: logical
+        logical_operator: or
+        operands:
+        - type: subject
+          subject_needed_code: '1061'
+          subject_needed_name: CALCULO DIF. E INTEGRAL EN UNA VARIABLE
+          needs: exam
+        - type: subject
+          subject_needed_code: '1020'
+          subject_needed_name: CALCULO 1
+          needs: exam
+        - type: subject
+          subject_needed_code: 107L
+          subject_needed_name: CALCULO 1
+          needs: exam
+        - type: subject
+          subject_needed_code: '1070'
+          subject_needed_name: CALCULO 1
+          needs: exam
+        - type: subject
+          subject_needed_code: '1052'
+          subject_needed_name: CALCULO 1 (ANUAL)
+          needs: exam
+        - type: subject
+          subject_needed_code: MAT33
+          subject_needed_name: CREDITOS ASIGNADOS POR REVALIDA
+          needs: exam
+        - type: subject
+          subject_needed_code: 1020P
+          subject_needed_name: CREDITOS NO ACUM CALCULO 1
+          needs: exam
+        - type: subject
+          subject_needed_code: 1061P
+          subject_needed_name: CREDITOS NO ACUM CDIV
+          needs: exam
+      - type: logical
+        logical_operator: or
+        operands:
+        - type: subject
+          subject_needed_code: 1152P
+          subject_needed_name: CREDITOS NO ACUM FISICA 2
+          needs: exam
+        - type: subject
+          subject_needed_code: 1153P
+          subject_needed_name: CREDITOS NO ACUM FISICA 3
+          needs: exam
+        - type: subject
+          subject_needed_code: '1121'
+          subject_needed_name: FISICA GENERAL 2
+          needs: exam
+        - type: subject
+          subject_needed_code: '1172'
+          subject_needed_name: FISICA GENERAL 2
+          needs: exam
+        - type: subject
+          subject_needed_code: '1152'
+          subject_needed_name: FISICA 2
+          needs: course
+        - type: subject
+          subject_needed_code: '1153'
+          subject_needed_name: FISICA 3
+          needs: course
+      - type: logical
+        logical_operator: or
+        operands:
+        - type: subject
+          subject_needed_code: 1151P
+          subject_needed_name: CREDITOS NO ACUM FISICA 1
+          needs: exam
+        - type: subject
+          subject_needed_code: '1120'
+          subject_needed_name: FISICA GENERAL 1
+          needs: exam
+        - type: subject
+          subject_needed_code: '1170'
+          subject_needed_name: FISICA GENERAL 1
+          needs: exam
+        - type: subject
+          subject_needed_code: '1151'
+          subject_needed_name: FISICA 1
+          needs: exam
+        - type: subject
+          subject_needed_code: '1171'
+          subject_needed_name: FISICA 1
+          needs: exam
+    - type: subject
+      needs: course
+      subject_needed_code: '1123'
+      subject_needed_name: FISICA TERMICA
+  subject_code: '1123'
+  is_exam: true
+- type: logical
+  logical_operator: and
+  operands:
+  - type: logical
+    logical_operator: not
+    operands:
+    - type: logical
+      logical_operator: or
+      operands:
+      - type: subject
+        subject_needed_code: FIS45
+        subject_needed_name: CREDITOS ASIGNADOS POR REVALIDA
+        needs: exam
+      - type: subject
+        subject_needed_code: 1128P
+        subject_needed_name: CREDITOS NO ACUM ELECTROMAGNETISMO
+        needs: exam
+      - type: subject
+        subject_needed_code: CP13
+        subject_needed_name: ELECTROMAGNETISMO
+        needs: exam
+      - type: subject
+        subject_needed_code: CP43
+        subject_needed_name: FISICA III (P. 74)
+        needs: exam
+  - type: logical
+    logical_operator: or
+    operands:
+    - type: logical
+      logical_operator: at_least
+      amount_of_subjects_needed: 2
+      operands:
+      - type: subject
+        subject_needed_code: 1152P
+        subject_needed_name: CREDITOS NO ACUM FISICA 2
+        needs: exam
+      - type: subject
+        subject_needed_code: '1077'
+        subject_needed_name: FISICA 2
+        needs: exam
+      - type: subject
+        subject_needed_code: '1152'
+        subject_needed_name: FISICA 2
+        needs: exam
+      - type: subject
+        subject_needed_code: '1153'
+        subject_needed_name: FISICA 3
+        needs: course
+    - type: logical
+      logical_operator: or
+      operands:
+      - type: subject
+        subject_needed_code: 1153P
+        subject_needed_name: CREDITOS NO ACUM FISICA 3
+        needs: exam
+      - type: subject
+        subject_needed_code: '1121'
+        subject_needed_name: FISICA GENERAL 2
+        needs: exam
+      - type: subject
+        subject_needed_code: '1172'
+        subject_needed_name: FISICA GENERAL 2
+        needs: exam
+      - type: subject
+        subject_needed_code: '1153'
+        subject_needed_name: FISICA 3
+        needs: exam
+      - type: subject
+        subject_needed_code: '1173'
+        subject_needed_name: FISICA 3
+        needs: exam
+  - type: logical
+    logical_operator: or
+    operands:
+    - type: subject
+      subject_needed_code: MAT33
+      subject_needed_name: CREDITOS ASIGNADOS POR REVALIDA
+      needs: exam
+    - type: subject
+      subject_needed_code: 1030P
+      subject_needed_name: CREDITOS NO ACUM GAL1
+      needs: exam
+    - type: subject
+      subject_needed_code: '1030'
+      subject_needed_name: GEOMETRIA Y ALGEBRA LINEAL 1
+      needs: exam
+    - type: subject
+      subject_needed_code: '1071'
+      subject_needed_name: GEOMETRIA Y ALGEBRA LINEAL 1
+      needs: exam
+    - type: subject
+      subject_needed_code: '1053'
+      subject_needed_name: GEOMETRIA Y ALGEBRA LINEAL 1 (ANUAL)
+      needs: exam
+    - type: subject
+      subject_needed_code: GAL1P
+      subject_needed_name: GEOMETRIA Y ALGEBRA LINEAL 1 INTERACTIVA
+      needs: exam
+  - type: logical
+    logical_operator: or
+    operands:
+    - type: subject
+      subject_needed_code: MAT33
+      subject_needed_name: CREDITOS ASIGNADOS POR REVALIDA
+      needs: exam
+    - type: subject
+      subject_needed_code: 1031P
+      subject_needed_name: CREDITOS NO ACUM GAL2
+      needs: exam
+    - type: subject
+      subject_needed_code: '1031'
+      subject_needed_name: GEOMETRIA Y ALGEBRA LINEAL 2
+      needs: exam
+    - type: subject
+      subject_needed_code: '1058'
+      subject_needed_name: GEOMETRIA Y ALGEBRA LINEAL 2
+      needs: exam
+  - type: logical
+    logical_operator: or
+    operands:
+    - type: subject
+      subject_needed_code: '1062'
+      subject_needed_name: CALCULO DIF. E INTEGRAL EN VARIAS VARIABLES
+      needs: exam
+    - type: subject
+      subject_needed_code: '1022'
+      subject_needed_name: CALCULO 2
+      needs: exam
+    - type: subject
+      subject_needed_code: '1072'
+      subject_needed_name: CALCULO 2
+      needs: exam
+    - type: subject
+      subject_needed_code: MAT33
+      subject_needed_name: CREDITOS ASIGNADOS POR REVALIDA
+      needs: exam
+    - type: subject
+      subject_needed_code: 1062P
+      subject_needed_name: CREDITOS NO ACUM CDIVV
+      needs: exam
+  - type: logical
+    logical_operator: or
+    operands:
+    - type: subject
+      subject_needed_code: 1151P
+      subject_needed_name: CREDITOS NO ACUM FISICA 1
+      needs: exam
+    - type: subject
+      subject_needed_code: '1120'
+      subject_needed_name: FISICA GENERAL 1
+      needs: exam
+    - type: subject
+      subject_needed_code: '1170'
+      subject_needed_name: FISICA GENERAL 1
+      needs: exam
+    - type: subject
+      subject_needed_code: '1151'
+      subject_needed_name: FISICA 1
+      needs: exam
+    - type: subject
+      subject_needed_code: '1171'
+      subject_needed_name: FISICA 1
+      needs: exam
+  - type: logical
+    logical_operator: or
+    operands:
+    - type: subject
+      subject_needed_code: '1063'
+      subject_needed_name: CALCULO VECTORIAL
+      needs: course
+    - type: subject
+      subject_needed_code: '1024'
+      subject_needed_name: CALCULO 3
+      needs: exam
+    - type: subject
+      subject_needed_code: '1076'
+      subject_needed_name: CALCULO 3
+      needs: exam
+    - type: subject
+      subject_needed_code: 1063P
+      subject_needed_name: CREDITOS NO ACUM CAL. VECTORIAL
+      needs: exam
+    - type: subject
+      subject_needed_code: 1024P
+      subject_needed_name: CREDITOS NO ACUM CALCULO 3
+      needs: exam
+  subject_code: '1128'
+  is_exam: false
+- type: logical
+  logical_operator: and
+  operands:
+  - type: logical
+    logical_operator: not
+    operands:
+    - type: logical
+      logical_operator: or
+      operands:
+      - type: subject
+        subject_needed_code: FIS45
+        subject_needed_name: CREDITOS ASIGNADOS POR REVALIDA
+        needs: exam
+      - type: subject
+        subject_needed_code: 1128P
+        subject_needed_name: CREDITOS NO ACUM ELECTROMAGNETISMO
+        needs: exam
+      - type: subject
+        subject_needed_code: CP13
+        subject_needed_name: ELECTROMAGNETISMO
+        needs: exam
+      - type: subject
+        subject_needed_code: CP43
+        subject_needed_name: FISICA III (P. 74)
+        needs: exam
+  - type: logical
+    logical_operator: or
+    operands:
+    - type: logical
+      logical_operator: and
+      operands:
+      - type: logical
+        logical_operator: or
+        operands:
+        - type: logical
+          logical_operator: at_least
+          amount_of_subjects_needed: 2
+          operands:
+          - type: subject
+            subject_needed_code: 1152P
+            subject_needed_name: CREDITOS NO ACUM FISICA 2
+            needs: exam
+          - type: subject
+            subject_needed_code: '1152'
+            subject_needed_name: FISICA 2
+            needs: exam
+          - type: subject
+            subject_needed_code: '1153'
+            subject_needed_name: FISICA 3
+            needs: course
+        - type: logical
+          logical_operator: or
+          operands:
+          - type: subject
+            subject_needed_code: 1153P
+            subject_needed_name: CREDITOS NO ACUM FISICA 3
+            needs: exam
+          - type: subject
+            subject_needed_code: '1121'
+            subject_needed_name: FISICA GENERAL 2
+            needs: exam
+          - type: subject
+            subject_needed_code: '1172'
+            subject_needed_name: FISICA GENERAL 2
+            needs: exam
+          - type: subject
+            subject_needed_code: '1153'
+            subject_needed_name: FISICA 3
+            needs: exam
+      - type: logical
+        logical_operator: or
+        operands:
+        - type: subject
+          subject_needed_code: MAT33
+          subject_needed_name: CREDITOS ASIGNADOS POR REVALIDA
+          needs: exam
+        - type: subject
+          subject_needed_code: 1031P
+          subject_needed_name: CREDITOS NO ACUM GAL2
+          needs: exam
+        - type: subject
+          subject_needed_code: '1031'
+          subject_needed_name: GEOMETRIA Y ALGEBRA LINEAL 2
+          needs: exam
+        - type: subject
+          subject_needed_code: '1058'
+          subject_needed_name: GEOMETRIA Y ALGEBRA LINEAL 2
+          needs: exam
+      - type: logical
+        logical_operator: or
+        operands:
+        - type: subject
+          subject_needed_code: '1062'
+          subject_needed_name: CALCULO DIF. E INTEGRAL EN VARIAS VARIABLES
+          needs: exam
+        - type: subject
+          subject_needed_code: '1022'
+          subject_needed_name: CALCULO 2
+          needs: exam
+        - type: subject
+          subject_needed_code: '1072'
+          subject_needed_name: CALCULO 2
+          needs: exam
+        - type: subject
+          subject_needed_code: MAT33
+          subject_needed_name: CREDITOS ASIGNADOS POR REVALIDA
+          needs: exam
+        - type: subject
+          subject_needed_code: 1062P
+          subject_needed_name: CREDITOS NO ACUM CDIVV
+          needs: exam
+      - type: logical
+        logical_operator: or
+        operands:
+        - type: subject
+          subject_needed_code: MAT33
+          subject_needed_name: CREDITOS ASIGNADOS POR REVALIDA
+          needs: exam
+        - type: subject
+          subject_needed_code: 1030P
+          subject_needed_name: CREDITOS NO ACUM GAL1
+          needs: exam
+        - type: subject
+          subject_needed_code: '1030'
+          subject_needed_name: GEOMETRIA Y ALGEBRA LINEAL 1
+          needs: exam
+        - type: subject
+          subject_needed_code: '1071'
+          subject_needed_name: GEOMETRIA Y ALGEBRA LINEAL 1
+          needs: exam
+        - type: subject
+          subject_needed_code: '1053'
+          subject_needed_name: GEOMETRIA Y ALGEBRA LINEAL 1 (ANUAL)
+          needs: exam
+        - type: subject
+          subject_needed_code: GAL1P
+          subject_needed_name: GEOMETRIA Y ALGEBRA LINEAL 1 INTERACTIVA
+          needs: exam
+      - type: logical
+        logical_operator: or
+        operands:
+        - type: subject
+          subject_needed_code: 1151P
+          subject_needed_name: CREDITOS NO ACUM FISICA 1
+          needs: exam
+        - type: subject
+          subject_needed_code: '1120'
+          subject_needed_name: FISICA GENERAL 1
+          needs: exam
+        - type: subject
+          subject_needed_code: '1170'
+          subject_needed_name: FISICA GENERAL 1
+          needs: exam
+        - type: subject
+          subject_needed_code: '1151'
+          subject_needed_name: FISICA 1
+          needs: exam
+        - type: subject
+          subject_needed_code: '1171'
+          subject_needed_name: FISICA 1
+          needs: exam
+      - type: logical
+        logical_operator: or
+        operands:
+        - type: subject
+          subject_needed_code: '1063'
+          subject_needed_name: CALCULO VECTORIAL
+          needs: course
+        - type: subject
+          subject_needed_code: '1024'
+          subject_needed_name: CALCULO 3
+          needs: exam
+        - type: subject
+          subject_needed_code: '1076'
+          subject_needed_name: CALCULO 3
+          needs: exam
+        - type: subject
+          subject_needed_code: 1063P
+          subject_needed_name: CREDITOS NO ACUM CAL. VECTORIAL
+          needs: exam
+        - type: subject
+          subject_needed_code: 1024P
+          subject_needed_name: CREDITOS NO ACUM CALCULO 3
+          needs: exam
+    - type: subject
+      needs: course
+      subject_needed_code: '1128'
+      subject_needed_name: ELECTROMAGNETISMO
+  subject_code: '1128'
+  is_exam: true
+- type: logical
+  logical_operator: and
+  operands:
+  - type: logical
+    logical_operator: or
+    operands:
+    - type: subject
+      subject_needed_code: 1153P
+      subject_needed_name: CREDITOS NO ACUM FISICA 3
+      needs: exam
+    - type: subject
+      subject_needed_code: '1153'
+      subject_needed_name: FISICA 3
+      needs: exam
+    - type: subject
+      subject_needed_code: '1173'
+      subject_needed_name: FISICA 3
+      needs: exam
+    - type: subject
+      subject_needed_code: 119Q
+      subject_needed_name: FISICA 3
+      needs: exam
+  - type: logical
+    logical_operator: or
+    operands:
+    - type: subject
+      subject_needed_code: '1063'
+      subject_needed_name: CALCULO VECTORIAL
+      needs: course
+    - type: subject
+      subject_needed_code: '1024'
+      subject_needed_name: CALCULO 3
+      needs: exam
+    - type: subject
+      subject_needed_code: '1076'
+      subject_needed_name: CALCULO 3
+      needs: exam
+    - type: subject
+      subject_needed_code: 176Q
+      subject_needed_name: CALCULO 3
+      needs: exam
+    - type: subject
+      subject_needed_code: 1063P
+      subject_needed_name: CREDITOS NO ACUM CAL. VECTORIAL
+      needs: exam
+    - type: subject
+      subject_needed_code: 1024P
+      subject_needed_name: CREDITOS NO ACUM CALCULO 3
+      needs: exam
+  subject_code: '1129'
+  is_exam: false
+- type: logical
+  logical_operator: and
+  operands:
+  - type: subject
+    needs: course
+    subject_needed_code: '1129'
+    subject_needed_name: OPTICA
+  subject_code: '1129'
+  is_exam: true
+- type: logical
+  logical_operator: and
+  operands:
+  - type: logical
+    logical_operator: not
+    operands:
+    - type: logical
+      logical_operator: or
+      operands:
+      - type: subject
+        subject_needed_code: 1131P
+        subject_needed_name: CREDITOS NO ACUM INT. A LA FISICA MODERNA
+        needs: all
+      - type: subject
+        subject_needed_code: 1131I
+        subject_needed_name: INT. A LA FISICA MODERNA
+        needs: all
+      - type: subject
+        subject_needed_code: '1138'
+        subject_needed_name: INT. A LA FISICA MODERNA
+        needs: all
+  - type: logical
+    logical_operator: or
+    operands:
+    - type: subject
+      subject_needed_code: '1128'
+      subject_needed_name: ELECTROMAGNETISMO
+      needs: course
+    - type: subject
+      subject_needed_code: '1126'
+      subject_needed_name: MEC.DE SIST.Y FENOMENOS ONDULATORIOS
+      needs: exam
+    - type: subject
+      subject_needed_code: '1144'
+      subject_needed_name: VIBRACIONES Y ONDAS
+      needs: course
+  subject_code: '1131'
+  is_exam: false
+- type: logical
+  logical_operator: and
+  operands:
+  - type: logical
+    logical_operator: not
+    operands:
+    - type: logical
+      logical_operator: or
+      operands:
+      - type: subject
+        subject_needed_code: 1131P
+        subject_needed_name: CREDITOS NO ACUM INT. A LA FISICA MODERNA
+        needs: exam
+      - type: subject
+        subject_needed_code: 1131I
+        subject_needed_name: INT. A LA FISICA MODERNA
+        needs: exam
+      - type: subject
+        subject_needed_code: '1138'
+        subject_needed_name: INT. A LA FISICA MODERNA
+        needs: exam
+  - type: logical
+    logical_operator: or
+    operands:
+    - type: subject
+      needs: course
+      subject_needed_code: '1131'
+      subject_needed_name: INT. A LA FISICA MODERNA
+    - type: logical
+      logical_operator: or
+      operands:
+      - type: subject
+        subject_needed_code: '1128'
+        subject_needed_name: ELECTROMAGNETISMO
+        needs: course
+      - type: subject
+        subject_needed_code: '1126'
+        subject_needed_name: MEC.DE SIST.Y FENOMENOS ONDULATORIOS
+        needs: exam
+      - type: subject
+        subject_needed_code: '1144'
+        subject_needed_name: VIBRACIONES Y ONDAS
+        needs: course
+  subject_code: '1131'
+  is_exam: true
+- type: logical
+  logical_operator: and
+  operands:
+  - type: subject
+    needs: exam
+    subject_needed_code: '1144'
+    subject_needed_name: VIBRACIONES Y ONDAS
+  subject_code: '1139'
+  is_exam: false
+- type: logical
+  logical_operator: and
+  operands:
+  - type: logical
+    logical_operator: not
+    operands:
+    - type: logical
+      logical_operator: or
+      operands:
+      - type: subject
+        subject_needed_code: FI15
+        subject_needed_name: CREDITOS ASIGNADOS POR REVALIDA
+        needs: exam
+      - type: subject
+        subject_needed_code: 1144P
+        subject_needed_name: CREDITOS NO ACUM VIBRACIONES Y ONDAS
+        needs: exam
+      - type: subject
+        subject_needed_code: '1126'
+        subject_needed_name: MEC.DE SIST.Y FENOMENOS ONDULATORIOS
+        needs: exam
+  - type: logical
+    logical_operator: or
+    operands:
+    - type: logical
+      logical_operator: or
+      operands:
+      - type: subject
+        subject_needed_code: 1153P
+        subject_needed_name: CREDITOS NO ACUM FISICA 3
+        needs: exam
+      - type: subject
+        subject_needed_code: '1121'
+        subject_needed_name: FISICA GENERAL 2
+        needs: exam
+      - type: subject
+        subject_needed_code: '1172'
+        subject_needed_name: FISICA GENERAL 2
+        needs: exam
+      - type: subject
+        subject_needed_code: '1153'
+        subject_needed_name: FISICA 3
+        needs: exam
+    - type: logical
+      logical_operator: at_least
+      amount_of_subjects_needed: 2
+      operands:
+      - type: subject
+        subject_needed_code: 1152P
+        subject_needed_name: CREDITOS NO ACUM FISICA 2
+        needs: exam
+      - type: subject
+        subject_needed_code: '1152'
+        subject_needed_name: FISICA 2
+        needs: exam
+      - type: subject
+        subject_needed_code: '1153'
+        subject_needed_name: FISICA 3
+        needs: course
+  - type: logical
+    logical_operator: or
+    operands:
+    - type: subject
+      subject_needed_code: '1021'
+      subject_needed_name: ALGEBRA LINEAL
+      needs: exam
+    - type: subject
+      subject_needed_code: MAT33
+      subject_needed_name: CREDITOS ASIGNADOS POR REVALIDA
+      needs: exam
+    - type: subject
+      subject_needed_code: 1030P
+      subject_needed_name: CREDITOS NO ACUM GAL1
+      needs: exam
+    - type: subject
+      subject_needed_code: '1030'
+      subject_needed_name: GEOMETRIA Y ALGEBRA LINEAL 1
+      needs: exam
+    - type: subject
+      subject_needed_code: '1071'
+      subject_needed_name: GEOMETRIA Y ALGEBRA LINEAL 1
+      needs: exam
+    - type: subject
+      subject_needed_code: '1053'
+      subject_needed_name: GEOMETRIA Y ALGEBRA LINEAL 1 (ANUAL)
+      needs: exam
+    - type: subject
+      subject_needed_code: GAL1P
+      subject_needed_name: GEOMETRIA Y ALGEBRA LINEAL 1 INTERACTIVA
+      needs: exam
+  - type: logical
+    logical_operator: or
+    operands:
+    - type: subject
+      subject_needed_code: 1122P
+      subject_needed_name: CREDITOS NO ACUM MEC NEWTONIANA
+      needs: exam
+    - type: subject
+      subject_needed_code: '1078'
+      subject_needed_name: MECANICA NEWTONIANA
+      needs: exam
+    - type: subject
+      subject_needed_code: '1122'
+      subject_needed_name: MECANICA NEWTONIANA
+      needs: course
+  - type: logical
+    logical_operator: or
+    operands:
+    - type: subject
+      subject_needed_code: '1062'
+      subject_needed_name: CALCULO DIF. E INTEGRAL EN VARIAS VARIABLES
+      needs: exam
+    - type: subject
+      subject_needed_code: '1022'
+      subject_needed_name: CALCULO 2
+      needs: exam
+    - type: subject
+      subject_needed_code: '1072'
+      subject_needed_name: CALCULO 2
+      needs: exam
+    - type: subject
+      subject_needed_code: MAT33
+      subject_needed_name: CREDITOS ASIGNADOS POR REVALIDA
+      needs: exam
+    - type: subject
+      subject_needed_code: 1062P
+      subject_needed_name: CREDITOS NO ACUM CDIVV
+      needs: exam
+  subject_code: '1144'
+  is_exam: false
+- type: logical
+  logical_operator: and
+  operands:
+  - type: logical
+    logical_operator: not
+    operands:
+    - type: logical
+      logical_operator: or
+      operands:
+      - type: subject
+        subject_needed_code: FI15
+        subject_needed_name: CREDITOS ASIGNADOS POR REVALIDA
+        needs: exam
+      - type: subject
+        subject_needed_code: 1144P
+        subject_needed_name: CREDITOS NO ACUM VIBRACIONES Y ONDAS
+        needs: exam
+      - type: subject
+        subject_needed_code: '1126'
+        subject_needed_name: MEC.DE SIST.Y FENOMENOS ONDULATORIOS
+        needs: exam
+  - type: logical
+    logical_operator: or
+    operands:
+    - type: logical
+      logical_operator: and
+      operands:
+      - type: logical
+        logical_operator: or
+        operands:
+        - type: logical
+          logical_operator: or
+          operands:
+          - type: subject
+            subject_needed_code: 1153P
+            subject_needed_name: CREDITOS NO ACUM FISICA 3
+            needs: exam
+          - type: subject
+            subject_needed_code: '1121'
+            subject_needed_name: FISICA GENERAL 2
+            needs: exam
+          - type: subject
+            subject_needed_code: '1172'
+            subject_needed_name: FISICA GENERAL 2
+            needs: exam
+          - type: subject
+            subject_needed_code: '1153'
+            subject_needed_name: FISICA 3
+            needs: exam
+        - type: logical
+          logical_operator: at_least
+          amount_of_subjects_needed: 2
+          operands:
+          - type: subject
+            subject_needed_code: 1152P
+            subject_needed_name: CREDITOS NO ACUM FISICA 2
+            needs: exam
+          - type: subject
+            subject_needed_code: '1152'
+            subject_needed_name: FISICA 2
+            needs: exam
+          - type: subject
+            subject_needed_code: '1153'
+            subject_needed_name: FISICA 3
+            needs: course
+      - type: logical
+        logical_operator: or
+        operands:
+        - type: subject
+          subject_needed_code: '1021'
+          subject_needed_name: ALGEBRA LINEAL
+          needs: exam
+        - type: subject
+          subject_needed_code: MAT33
+          subject_needed_name: CREDITOS ASIGNADOS POR REVALIDA
+          needs: exam
+        - type: subject
+          subject_needed_code: 1030P
+          subject_needed_name: CREDITOS NO ACUM GAL1
+          needs: exam
+        - type: subject
+          subject_needed_code: '1030'
+          subject_needed_name: GEOMETRIA Y ALGEBRA LINEAL 1
+          needs: exam
+        - type: subject
+          subject_needed_code: '1071'
+          subject_needed_name: GEOMETRIA Y ALGEBRA LINEAL 1
+          needs: exam
+        - type: subject
+          subject_needed_code: '1053'
+          subject_needed_name: GEOMETRIA Y ALGEBRA LINEAL 1 (ANUAL)
+          needs: exam
+        - type: subject
+          subject_needed_code: GAL1P
+          subject_needed_name: GEOMETRIA Y ALGEBRA LINEAL 1 INTERACTIVA
+          needs: exam
+      - type: logical
+        logical_operator: or
+        operands:
+        - type: subject
+          subject_needed_code: '1062'
+          subject_needed_name: CALCULO DIF. E INTEGRAL EN VARIAS VARIABLES
+          needs: exam
+        - type: subject
+          subject_needed_code: '1022'
+          subject_needed_name: CALCULO 2
+          needs: exam
+        - type: subject
+          subject_needed_code: '1072'
+          subject_needed_name: CALCULO 2
+          needs: exam
+        - type: subject
+          subject_needed_code: MAT33
+          subject_needed_name: CREDITOS ASIGNADOS POR REVALIDA
+          needs: exam
+        - type: subject
+          subject_needed_code: 1062P
+          subject_needed_name: CREDITOS NO ACUM CDIVV
+          needs: exam
+      - type: logical
+        logical_operator: or
+        operands:
+        - type: subject
+          subject_needed_code: 1122P
+          subject_needed_name: CREDITOS NO ACUM MEC NEWTONIANA
+          needs: exam
+        - type: subject
+          subject_needed_code: '1078'
+          subject_needed_name: MECANICA NEWTONIANA
+          needs: exam
+        - type: subject
+          subject_needed_code: '1122'
+          subject_needed_name: MECANICA NEWTONIANA
+          needs: course
+    - type: subject
+      needs: course
+      subject_needed_code: '1144'
+      subject_needed_name: VIBRACIONES Y ONDAS
+  subject_code: '1144'
+  is_exam: true
+- type: logical
+  logical_operator: not
+  operands:
+  - type: logical
+    logical_operator: or
+    operands:
+    - type: subject
+      subject_needed_code: FF12
+      subject_needed_name: CREDITOS ASIGNADOS POR REVALIDA
+      needs: all
+    - type: subject
+      subject_needed_code: FG
+      subject_needed_name: CREDITOS ASIGNADOS POR REVALIDA
+      needs: all
+    - type: subject
+      subject_needed_code: FIS13
+      subject_needed_name: CREDITOS ASIGNADOS POR REVALIDA
+      needs: all
+    - type: subject
+      subject_needed_code: FIS14
+      subject_needed_name: CREDITOS ASIGNADOS POR REVALIDA
+      needs: all
+    - type: subject
+      subject_needed_code: FI10
+      subject_needed_name: CREDITOS ASIGNADOS POR REVALIDA
+      needs: all
+    - type: subject
+      subject_needed_code: FI13
+      subject_needed_name: CREDITOS ASIGNADOS POR REVALIDA
+      needs: all
+    - type: subject
+      subject_needed_code: F1Y3
+      subject_needed_name: CREDITOS ASIGNADOS POR REVALIDA
+      needs: all
+    - type: subject
+      subject_needed_code: F10
+      subject_needed_name: CREDITOS ASIGNADOS POR REVALIDA
+      needs: all
+    - type: subject
+      subject_needed_code: F30
+      subject_needed_name: CREDITOS ASIGNADOS POR REVALIDA
+      needs: all
+    - type: subject
+      subject_needed_code: 1151P
+      subject_needed_name: CREDITOS NO ACUM FISICA 1
+      needs: all
+    - type: subject
+      subject_needed_code: CP04
+      subject_needed_name: CRÉDITOS POR FÍSICA I
+      needs: all
+    - type: subject
+      subject_needed_code: '1120'
+      subject_needed_name: FISICA GENERAL 1
+      needs: all
+    - type: subject
+      subject_needed_code: 117Q
+      subject_needed_name: FISICA GENERAL 1
+      needs: all
+    - type: subject
+      subject_needed_code: '1170'
+      subject_needed_name: FISICA GENERAL 1
+      needs: all
+    - type: subject
+      subject_needed_code: CP41
+      subject_needed_name: FISICA I (P. 74)
+      needs: all
+    - type: subject
+      subject_needed_code: '1171'
+      subject_needed_name: FISICA 1
+      needs: all
+    - type: subject
+      subject_needed_code: CP26
+      subject_needed_name: MECANICA GENERAL I (P. 74)
+      needs: all
+    - type: subject
+      subject_needed_code: CP3
+      subject_needed_name: MECANICA I
+      needs: all
+    - type: subject
+      subject_needed_code: CP17
+      subject_needed_name: MECANICA I (TRANSICION)
+      needs: all
+  subject_code: '1151'
+  is_exam: false
+- type: logical
+  logical_operator: not
+  operands:
+  - type: logical
+    logical_operator: or
+    operands:
+    - type: subject
+      subject_needed_code: FF12
+      subject_needed_name: CREDITOS ASIGNADOS POR REVALIDA
+      needs: all
+    - type: subject
+      subject_needed_code: FG
+      subject_needed_name: CREDITOS ASIGNADOS POR REVALIDA
+      needs: all
+    - type: subject
+      subject_needed_code: FIS13
+      subject_needed_name: CREDITOS ASIGNADOS POR REVALIDA
+      needs: all
+    - type: subject
+      subject_needed_code: FIS14
+      subject_needed_name: CREDITOS ASIGNADOS POR REVALIDA
+      needs: all
+    - type: subject
+      subject_needed_code: FI10
+      subject_needed_name: CREDITOS ASIGNADOS POR REVALIDA
+      needs: all
+    - type: subject
+      subject_needed_code: FI13
+      subject_needed_name: CREDITOS ASIGNADOS POR REVALIDA
+      needs: all
+    - type: subject
+      subject_needed_code: F1Y3
+      subject_needed_name: CREDITOS ASIGNADOS POR REVALIDA
+      needs: all
+    - type: subject
+      subject_needed_code: F10
+      subject_needed_name: CREDITOS ASIGNADOS POR REVALIDA
+      needs: all
+    - type: subject
+      subject_needed_code: F30
+      subject_needed_name: CREDITOS ASIGNADOS POR REVALIDA
+      needs: all
+    - type: subject
+      subject_needed_code: 1151P
+      subject_needed_name: CREDITOS NO ACUM FISICA 1
+      needs: all
+    - type: subject
+      subject_needed_code: CP04
+      subject_needed_name: CRÉDITOS POR FÍSICA I
+      needs: all
+    - type: subject
+      subject_needed_code: '1120'
+      subject_needed_name: FISICA GENERAL 1
+      needs: all
+    - type: subject
+      subject_needed_code: 117Q
+      subject_needed_name: FISICA GENERAL 1
+      needs: all
+    - type: subject
+      subject_needed_code: '1170'
+      subject_needed_name: FISICA GENERAL 1
+      needs: all
+    - type: subject
+      subject_needed_code: CP41
+      subject_needed_name: FISICA I (P. 74)
+      needs: all
+    - type: subject
+      subject_needed_code: '1171'
+      subject_needed_name: FISICA 1
+      needs: all
+    - type: subject
+      subject_needed_code: CP26
+      subject_needed_name: MECANICA GENERAL I (P. 74)
+      needs: all
+    - type: subject
+      subject_needed_code: CP3
+      subject_needed_name: MECANICA I
+      needs: all
+    - type: subject
+      subject_needed_code: CP17
+      subject_needed_name: MECANICA I (TRANSICION)
+      needs: all
+  subject_code: '1151'
+  is_exam: true
+- type: logical
+  logical_operator: and
+  operands:
+  - type: logical
+    logical_operator: not
+    operands:
+    - type: subject
+      needs: exam
+      subject_needed_code: 1152P
+      subject_needed_name: CREDITOS NO ACUM FISICA 2
+  - type: logical
+    logical_operator: or
+    operands:
+    - type: subject
+      subject_needed_code: '1061'
+      subject_needed_name: CALCULO DIF. E INTEGRAL EN UNA VARIABLE
+      needs: course
+    - type: subject
+      subject_needed_code: '1020'
+      subject_needed_name: CALCULO 1
+      needs: exam
+    - type: subject
+      subject_needed_code: '1070'
+      subject_needed_name: CALCULO 1
+      needs: exam
+    - type: subject
+      subject_needed_code: '1052'
+      subject_needed_name: CALCULO 1 (ANUAL)
+      needs: exam
+    - type: subject
+      subject_needed_code: MAT33
+      subject_needed_name: CREDITOS ASIGNADOS POR REVALIDA
+      needs: exam
+    - type: subject
+      subject_needed_code: 1020P
+      subject_needed_name: CREDITOS NO ACUM CALCULO 1
+      needs: exam
+    - type: subject
+      subject_needed_code: 1061P
+      subject_needed_name: CREDITOS NO ACUM CDIV
+      needs: exam
+  - type: logical
+    logical_operator: or
+    operands:
+    - type: subject
+      subject_needed_code: 1120P
+      subject_needed_name: CREDITOS NO ACUM. FISICA GENERAL 1
+      needs: exam
+    - type: subject
+      subject_needed_code: 1151P
+      subject_needed_name: CREDITOS NO ACUM FISICA 1
+      needs: exam
+    - type: subject
+      subject_needed_code: '1120'
+      subject_needed_name: FISICA GENERAL 1
+      needs: exam
+    - type: subject
+      subject_needed_code: '1170'
+      subject_needed_name: FISICA GENERAL 1
+      needs: exam
+    - type: subject
+      subject_needed_code: '1151'
+      subject_needed_name: FISICA 1
+      needs: course
+    - type: subject
+      subject_needed_code: '1171'
+      subject_needed_name: FISICA 1
+      needs: exam
+  subject_code: '1152'
+  is_exam: false
+- type: logical
+  logical_operator: and
+  operands:
+  - type: logical
+    logical_operator: not
+    operands:
+    - type: subject
+      needs: exam
+      subject_needed_code: 1152P
+      subject_needed_name: CREDITOS NO ACUM FISICA 2
+  - type: logical
+    logical_operator: or
+    operands:
+    - type: subject
+      subject_needed_code: 1151P
+      subject_needed_name: CREDITOS NO ACUM FISICA 1
+      needs: exam
+    - type: subject
+      subject_needed_code: '1120'
+      subject_needed_name: FISICA GENERAL 1
+      needs: exam
+    - type: subject
+      subject_needed_code: '1170'
+      subject_needed_name: FISICA GENERAL 1
+      needs: exam
+    - type: subject
+      subject_needed_code: '1151'
+      subject_needed_name: FISICA 1
+      needs: exam
+    - type: subject
+      subject_needed_code: '1171'
+      subject_needed_name: FISICA 1
+      needs: exam
+  - type: logical
+    logical_operator: or
+    operands:
+    - type: subject
+      subject_needed_code: '1061'
+      subject_needed_name: CALCULO DIF. E INTEGRAL EN UNA VARIABLE
+      needs: exam
+    - type: subject
+      subject_needed_code: '1020'
+      subject_needed_name: CALCULO 1
+      needs: exam
+    - type: subject
+      subject_needed_code: '1070'
+      subject_needed_name: CALCULO 1
+      needs: exam
+    - type: subject
+      subject_needed_code: '1052'
+      subject_needed_name: CALCULO 1 (ANUAL)
+      needs: exam
+    - type: subject
+      subject_needed_code: MAT33
+      subject_needed_name: CREDITOS ASIGNADOS POR REVALIDA
+      needs: exam
+    - type: subject
+      subject_needed_code: 1020P
+      subject_needed_name: CREDITOS NO ACUM CALCULO 1
+      needs: exam
+    - type: subject
+      subject_needed_code: 1061P
+      subject_needed_name: CREDITOS NO ACUM CDIV
+      needs: exam
+  subject_code: '1152'
+  is_exam: true
+- type: logical
+  logical_operator: and
+  operands:
+  - type: logical
+    logical_operator: not
+    operands:
+    - type: subject
+      needs: exam
+      subject_needed_code: CCT20
+      subject_needed_name: FÍSICA II
+  - type: logical
+    logical_operator: not
+    operands:
+    - type: logical
+      logical_operator: or
+      operands:
+      - type: subject
+        subject_needed_code: FF12
+        subject_needed_name: CREDITOS ASIGNADOS POR REVALIDA
+        needs: exam
+      - type: subject
+        subject_needed_code: FG2
+        subject_needed_name: CREDITOS ASIGNADOS POR REVALIDA
+        needs: exam
+      - type: subject
+        subject_needed_code: FIS14
+        subject_needed_name: CREDITOS ASIGNADOS POR REVALIDA
+        needs: exam
+      - type: subject
+        subject_needed_code: F7
+        subject_needed_name: CREDITOS ASIGNADOS POR REVALIDA
+        needs: exam
+      - type: subject
+        subject_needed_code: F8
+        subject_needed_name: CREDITOS ASIGNADOS POR REVALIDA
+        needs: exam
+      - type: subject
+        subject_needed_code: 1153P
+        subject_needed_name: CREDITOS NO ACUM FISICA 3
+        needs: exam
+      - type: subject
+        subject_needed_code: CP13
+        subject_needed_name: ELECTROMAGNETISMO
+        needs: exam
+      - type: subject
+        subject_needed_code: '1121'
+        subject_needed_name: FISICA GENERAL 2
+        needs: exam
+      - type: subject
+        subject_needed_code: '1172'
+        subject_needed_name: FISICA GENERAL 2
+        needs: exam
+      - type: subject
+        subject_needed_code: CP43
+        subject_needed_name: FISICA III (P. 74)
+        needs: exam
+  - type: logical
+    logical_operator: or
+    operands:
+    - type: logical
+      logical_operator: at_least
+      amount_of_subjects_needed: 2
+      operands:
+      - type: subject
+        subject_needed_code: 1152P
+        subject_needed_name: CREDITOS NO ACUM FISICA 2
+        needs: exam
+      - type: subject
+        subject_needed_code: '1151'
+        subject_needed_name: FISICA 1
+        needs: course
+      - type: subject
+        subject_needed_code: '1152'
+        subject_needed_name: FISICA 2
+        needs: course
+    - type: logical
+      logical_operator: or
+      operands:
+      - type: subject
+        subject_needed_code: 1151P
+        subject_needed_name: CREDITOS NO ACUM FISICA 1
+        needs: exam
+      - type: subject
+        subject_needed_code: '1120'
+        subject_needed_name: FISICA GENERAL 1
+        needs: exam
+      - type: subject
+        subject_needed_code: '1170'
+        subject_needed_name: FISICA GENERAL 1
+        needs: exam
+      - type: subject
+        subject_needed_code: '1151'
+        subject_needed_name: FISICA 1
+        needs: exam
+      - type: subject
+        subject_needed_code: '1171'
+        subject_needed_name: FISICA 1
+        needs: exam
+  - type: logical
+    logical_operator: or
+    operands:
+    - type: subject
+      subject_needed_code: '1061'
+      subject_needed_name: CALCULO DIF. E INTEGRAL EN UNA VARIABLE
+      needs: course
+    - type: subject
+      subject_needed_code: '1020'
+      subject_needed_name: CALCULO 1
+      needs: exam
+    - type: subject
+      subject_needed_code: '1070'
+      subject_needed_name: CALCULO 1
+      needs: exam
+    - type: subject
+      subject_needed_code: '1052'
+      subject_needed_name: CALCULO 1 (ANUAL)
+      needs: exam
+    - type: subject
+      subject_needed_code: MAT33
+      subject_needed_name: CREDITOS ASIGNADOS POR REVALIDA
+      needs: exam
+    - type: subject
+      subject_needed_code: 1020P
+      subject_needed_name: CREDITOS NO ACUM CALCULO 1
+      needs: exam
+    - type: subject
+      subject_needed_code: 1061P
+      subject_needed_name: CREDITOS NO ACUM CDIV
+      needs: exam
+  subject_code: '1153'
+  is_exam: false
+- type: logical
+  logical_operator: and
+  operands:
+  - type: logical
+    logical_operator: not
+    operands:
+    - type: subject
+      needs: exam
+      subject_needed_code: CCT20
+      subject_needed_name: FÍSICA II
+  - type: logical
+    logical_operator: not
+    operands:
+    - type: logical
+      logical_operator: or
+      operands:
+      - type: subject
+        subject_needed_code: FF12
+        subject_needed_name: CREDITOS ASIGNADOS POR REVALIDA
+        needs: exam
+      - type: subject
+        subject_needed_code: FG2
+        subject_needed_name: CREDITOS ASIGNADOS POR REVALIDA
+        needs: exam
+      - type: subject
+        subject_needed_code: FIS14
+        subject_needed_name: CREDITOS ASIGNADOS POR REVALIDA
+        needs: exam
+      - type: subject
+        subject_needed_code: F7
+        subject_needed_name: CREDITOS ASIGNADOS POR REVALIDA
+        needs: exam
+      - type: subject
+        subject_needed_code: F8
+        subject_needed_name: CREDITOS ASIGNADOS POR REVALIDA
+        needs: exam
+      - type: subject
+        subject_needed_code: 1153P
+        subject_needed_name: CREDITOS NO ACUM FISICA 3
+        needs: exam
+      - type: subject
+        subject_needed_code: CP13
+        subject_needed_name: ELECTROMAGNETISMO
+        needs: exam
+      - type: subject
+        subject_needed_code: '1121'
+        subject_needed_name: FISICA GENERAL 2
+        needs: exam
+      - type: subject
+        subject_needed_code: '1172'
+        subject_needed_name: FISICA GENERAL 2
+        needs: exam
+      - type: subject
+        subject_needed_code: CP43
+        subject_needed_name: FISICA III (P. 74)
+        needs: exam
+  - type: logical
+    logical_operator: or
+    operands:
+    - type: subject
+      subject_needed_code: '1061'
+      subject_needed_name: CALCULO DIF. E INTEGRAL EN UNA VARIABLE
+      needs: exam
+    - type: subject
+      subject_needed_code: '1020'
+      subject_needed_name: CALCULO 1
+      needs: exam
+    - type: subject
+      subject_needed_code: '1070'
+      subject_needed_name: CALCULO 1
+      needs: exam
+    - type: subject
+      subject_needed_code: '1052'
+      subject_needed_name: CALCULO 1 (ANUAL)
+      needs: exam
+    - type: subject
+      subject_needed_code: MAT33
+      subject_needed_name: CREDITOS ASIGNADOS POR REVALIDA
+      needs: exam
+    - type: subject
+      subject_needed_code: 1020P
+      subject_needed_name: CREDITOS NO ACUM CALCULO 1
+      needs: exam
+    - type: subject
+      subject_needed_code: 1061P
+      subject_needed_name: CREDITOS NO ACUM CDIV
+      needs: exam
+  - type: logical
+    logical_operator: or
+    operands:
+    - type: subject
+      subject_needed_code: 1151P
+      subject_needed_name: CREDITOS NO ACUM FISICA 1
+      needs: exam
+    - type: subject
+      subject_needed_code: '1120'
+      subject_needed_name: FISICA GENERAL 1
+      needs: exam
+    - type: subject
+      subject_needed_code: '1151'
+      subject_needed_name: FISICA 1
+      needs: exam
+  subject_code: '1153'
+  is_exam: true
+- type: logical
+  logical_operator: and
+  operands:
+  - type: logical
+    logical_operator: not
+    operands:
+    - type: logical
+      logical_operator: or
+      operands:
+      - type: subject
+        subject_needed_code: 1154P
+        subject_needed_name: CREDITOS NO ACUM FISICA EXPERIMENTAL 1
+        needs: exam
+      - type: subject
+        subject_needed_code: 1154I
+        subject_needed_name: FISICA EXPERIMENTAL 1
+        needs: exam
+      - type: subject
+        subject_needed_code: '1124'
+        subject_needed_name: LABORATORIO 1
+        needs: course
+  - type: logical
+    logical_operator: or
+    operands:
+    - type: logical
+      logical_operator: or
+      operands:
+      - type: subject
+        subject_needed_code: 1120P
+        subject_needed_name: CREDITOS NO ACUM. FISICA GENERAL 1
+        needs: exam
+      - type: subject
+        subject_needed_code: '1120'
+        subject_needed_name: FISICA GENERAL 1
+        needs: exam
+    - type: logical
+      logical_operator: at_least
+      amount_of_subjects_needed: 2
+      operands:
+      - type: subject
+        subject_needed_code: 1151P
+        subject_needed_name: CREDITOS NO ACUM FISICA 1
+        needs: exam
+      - type: subject
+        subject_needed_code: 1152P
+        subject_needed_name: CREDITOS NO ACUM FISICA 2
+        needs: exam
+      - type: subject
+        subject_needed_code: '1151'
+        subject_needed_name: FISICA 1
+        needs: exam
+      - type: subject
+        subject_needed_code: '1152'
+        subject_needed_name: FISICA 2
+        needs: course
+  subject_code: '1154'
+  is_exam: false
+- type: logical
+  logical_operator: and
+  operands:
+  - type: logical
+    logical_operator: not
+    operands:
+    - type: logical
+      logical_operator: or
+      operands:
+      - type: subject
+        subject_needed_code: 1155P
+        subject_needed_name: CREDITOS NO ACUM FISICA EXPERIMENTAL 2
+        needs: all
+      - type: subject
+        subject_needed_code: 1155I
+        subject_needed_name: FISICA EXPERIMENTAL 2
+        needs: all
+      - type: subject
+        subject_needed_code: '1127'
+        subject_needed_name: LABORATORIO 2
+        needs: all
+      - type: subject
+        subject_needed_code: CP14
+        subject_needed_name: TALLER LABORATORIO II (MODULO DE FISICA)
+        needs: all
+  - type: logical
+    logical_operator: or
+    operands:
+    - type: subject
+      subject_needed_code: 1154R
+      subject_needed_name: CREDITOS ASIGNADOS POR REVALIDA
+      needs: exam
+    - type: subject
+      subject_needed_code: 1154P
+      subject_needed_name: CREDITOS NO ACUM FISICA EXPERIMENTAL 1
+      needs: exam
+    - type: subject
+      subject_needed_code: '1154'
+      subject_needed_name: FISICA EXPERIMENTAL 1
+      needs: course
+    - type: subject
+      subject_needed_code: 1154I
+      subject_needed_name: FISICA EXPERIMENTAL 1
+      needs: exam
+    - type: subject
+      subject_needed_code: '1124'
+      subject_needed_name: LABORATORIO 1
+      needs: course
+  - type: logical
+    logical_operator: or
+    operands:
+    - type: subject
+      subject_needed_code: 1153P
+      subject_needed_name: CREDITOS NO ACUM FISICA 3
+      needs: exam
+    - type: subject
+      subject_needed_code: '1121'
+      subject_needed_name: FISICA GENERAL 2
+      needs: exam
+    - type: subject
+      subject_needed_code: '1172'
+      subject_needed_name: FISICA GENERAL 2
+      needs: exam
+    - type: subject
+      subject_needed_code: '1153'
+      subject_needed_name: FISICA 3
+      needs: course
+  subject_code: '1155'
+  is_exam: false
+- type: logical
+  logical_operator: and
+  operands:
+  - type: credits
+    credits: 55
+    group: 12
+  - type: subject
+    needs: course
+    subject_needed_code: '1155'
+    subject_needed_name: FISICA EXPERIMENTAL 2
+  - type: subject
+    needs: course
+    subject_needed_code: '1140'
+    subject_needed_name: LABORATORIO 3
+  - type: subject
+    needs: course
+    subject_needed_code: '1154'
+    subject_needed_name: FISICA EXPERIMENTAL 1
+  subject_code: '1156'
+  is_exam: false
+- type: logical
+  logical_operator: and
+  operands:
+  - type: logical
+    logical_operator: or
+    operands:
+    - type: subject
+      subject_needed_code: 1025P
+      subject_needed_name: CREDITOS NO ACUM PROB Y EST.
+      needs: exam
+    - type: subject
+      subject_needed_code: 1025T
+      subject_needed_name: CREDITOS NO ACUM PROBABILIDAD Y ESTADISTICA
+      needs: exam
+    - type: subject
+      subject_needed_code: '1025'
+      subject_needed_name: PROBABILIDAD Y ESTADISTICA
+      needs: exam
+    - type: subject
+      subject_needed_code: '1075'
+      subject_needed_name: PROBABILIDAD Y ESTADISTICA
+      needs: exam
+    - type: subject
+      subject_needed_code: 125L
+      subject_needed_name: PROBABILIDAD Y ESTADISTICA
+      needs: exam
+  - type: logical
+    logical_operator: or
+    operands:
+    - type: subject
+      subject_needed_code: 1031P
+      subject_needed_name: CREDITOS NO ACUM GAL2
+      needs: exam
+    - type: subject
+      subject_needed_code: '1031'
+      subject_needed_name: GEOMETRIA Y ALGEBRA LINEAL 2
+      needs: exam
+    - type: subject
+      subject_needed_code: '1058'
+      subject_needed_name: GEOMETRIA Y ALGEBRA LINEAL 2
+      needs: exam
+    - type: subject
+      subject_needed_code: 158Q
+      subject_needed_name: GEOMETRIA Y ALGEBRA LINEAL 2
+      needs: exam
+  - type: logical
+    logical_operator: or
+    operands:
+    - type: subject
+      subject_needed_code: '1062'
+      subject_needed_name: CALCULO DIF. E INTEGRAL EN VARIAS VARIABLES
+      needs: exam
+    - type: subject
+      subject_needed_code: '1022'
+      subject_needed_name: CALCULO 2
+      needs: exam
+    - type: subject
+      subject_needed_code: '1072'
+      subject_needed_name: CALCULO 2
+      needs: exam
+    - type: subject
+      subject_needed_code: 1022P
+      subject_needed_name: CREDITOS NO ACUM CALCULO 2
+      needs: exam
+    - type: subject
+      subject_needed_code: 1062P
+      subject_needed_name: CREDITOS NO ACUM CDIVV
+      needs: exam
+  subject_code: '1158'
+  is_exam: false
+- type: logical
+  logical_operator: and
+  operands:
+  - type: subject
+    needs: course
+    subject_needed_code: '1158'
+    subject_needed_name: PROCESAMIENTO CUÁNTICO DE LA INFORMACIÓN
+  subject_code: '1158'
+  is_exam: true
+- type: logical
+  logical_operator: not
+  operands:
+  - type: logical
+    logical_operator: or
+    operands:
+    - type: subject
+      subject_needed_code: IYS12
+      subject_needed_name: CREDITOS ASIGNADOS POR REVALIDA
+      needs: all
+    - type: subject
+      subject_needed_code: IYS14
+      subject_needed_name: CREDITOS ASIGNADOS POR REVALIDA
+      needs: all
+    - type: subject
+      subject_needed_code: CP18
+      subject_needed_name: TECNOLOGIA Y SOCIEDAD
+      needs: all
+  subject_code: '1223'
+  is_exam: true
+- type: logical
+  logical_operator: not
+  operands:
+  - type: logical
+    logical_operator: or
+    operands:
+    - type: subject
+      subject_needed_code: IYS12
+      subject_needed_name: CREDITOS ASIGNADOS POR REVALIDA
+      needs: all
+    - type: subject
+      subject_needed_code: IYS14
+      subject_needed_name: CREDITOS ASIGNADOS POR REVALIDA
+      needs: all
+    - type: subject
+      subject_needed_code: 1224P
+      subject_needed_name: CREDITOS NO ACUM ECONOMIA
+      needs: all
+    - type: subject
+      subject_needed_code: '1221'
+      subject_needed_name: ECONOMIA
+      needs: all
+    - type: subject
+      subject_needed_code: CP20
+      subject_needed_name: ECONOMIA POLITICA
+      needs: all
+  subject_code: '1224'
+  is_exam: false
+- type: logical
+  logical_operator: not
+  operands:
+  - type: logical
+    logical_operator: or
+    operands:
+    - type: subject
+      subject_needed_code: IYS12
+      subject_needed_name: CREDITOS ASIGNADOS POR REVALIDA
+      needs: all
+    - type: subject
+      subject_needed_code: IYS14
+      subject_needed_name: CREDITOS ASIGNADOS POR REVALIDA
+      needs: all
+    - type: subject
+      subject_needed_code: 1224P
+      subject_needed_name: CREDITOS NO ACUM ECONOMIA
+      needs: all
+    - type: subject
+      subject_needed_code: '1221'
+      subject_needed_name: ECONOMIA
+      needs: all
+    - type: subject
+      subject_needed_code: CP20
+      subject_needed_name: ECONOMIA POLITICA
+      needs: all
+  subject_code: '1224'
+  is_exam: true
+- type: logical
+  logical_operator: and
+  operands:
+  - type: credits
+    credits: 80
+  - type: logical
+    logical_operator: or
+    operands:
+    - type: subject
+      subject_needed_code: '1021'
+      subject_needed_name: ALGEBRA LINEAL
+      needs: all
+    - type: subject
+      subject_needed_code: CM14
+      subject_needed_name: CREDITOS ASIGNADOS POR REVALIDA
+      needs: all
+    - type: subject
+      subject_needed_code: MAT33
+      subject_needed_name: CREDITOS ASIGNADOS POR REVALIDA
+      needs: all
+    - type: subject
+      subject_needed_code: M9
+      subject_needed_name: CREDITOS ASIGNADOS POR REVALIDA
+      needs: all
+    - type: subject
+      subject_needed_code: 1031P
+      subject_needed_name: CREDITOS NO ACUM GAL2
+      needs: all
+    - type: subject
+      subject_needed_code: CP2
+      subject_needed_name: GEOMETRIA Y ALGEBRA LINEAL
+      needs: all
+    - type: subject
+      subject_needed_code: R101
+      subject_needed_name: GEOMETRIA Y ALGEBRA LINEAL
+      needs: all
+    - type: subject
+      subject_needed_code: CP23
+      subject_needed_name: GEOMETRIA Y ALGEBRA LINEAL (P. 74)
+      needs: all
+    - type: subject
+      subject_needed_code: '1031'
+      subject_needed_name: GEOMETRIA Y ALGEBRA LINEAL 2
+      needs: all
+    - type: subject
+      subject_needed_code: '1058'
+      subject_needed_name: GEOMETRIA Y ALGEBRA LINEAL 2
+      needs: all
+    - type: subject
+      subject_needed_code: 158Q
+      subject_needed_name: GEOMETRIA Y ALGEBRA LINEAL 2
+      needs: all
+  - type: logical
+    logical_operator: or
+    operands:
+    - type: subject
+      subject_needed_code: CP1
+      subject_needed_name: ANALISIS MATEMATICO I
+      needs: all
+    - type: subject
+      subject_needed_code: R100
+      subject_needed_name: ANALISIS MATEMATICO I
+      needs: all
+    - type: subject
+      subject_needed_code: CP22
+      subject_needed_name: ANALISIS MATEMATICO I (P. 74)
+      needs: all
+    - type: subject
+      subject_needed_code: '1061'
+      subject_needed_name: CALCULO DIF. E INTEGRAL EN UNA VARIABLE
+      needs: all
+    - type: subject
+      subject_needed_code: '1020'
+      subject_needed_name: CALCULO 1
+      needs: all
+    - type: subject
+      subject_needed_code: '1070'
+      subject_needed_name: CALCULO 1
+      needs: all
+    - type: subject
+      subject_needed_code: '1052'
+      subject_needed_name: CALCULO 1 (ANUAL)
+      needs: all
+    - type: subject
+      subject_needed_code: MAT33
+      subject_needed_name: CREDITOS ASIGNADOS POR REVALIDA
+      needs: all
+    - type: subject
+      subject_needed_code: 1020P
+      subject_needed_name: CREDITOS NO ACUM CALCULO 1
+      needs: all
+    - type: subject
+      subject_needed_code: 1061P
+      subject_needed_name: CREDITOS NO ACUM CDIV
+      needs: all
+  - type: logical
+    logical_operator: or
+    operands:
+    - type: subject
+      subject_needed_code: CP1
+      subject_needed_name: ANALISIS MATEMATICO I
+      needs: all
+    - type: subject
+      subject_needed_code: CP22
+      subject_needed_name: ANALISIS MATEMATICO I (P. 74)
+      needs: all
+    - type: subject
+      subject_needed_code: '1062'
+      subject_needed_name: CALCULO DIF. E INTEGRAL EN VARIAS VARIABLES
+      needs: all
+    - type: subject
+      subject_needed_code: '1022'
+      subject_needed_name: CALCULO 2
+      needs: all
+    - type: subject
+      subject_needed_code: '1072'
+      subject_needed_name: CALCULO 2
+      needs: all
+    - type: subject
+      subject_needed_code: MAT33
+      subject_needed_name: CREDITOS ASIGNADOS POR REVALIDA
+      needs: all
+    - type: subject
+      subject_needed_code: 1062P
+      subject_needed_name: CREDITOS NO ACUM CDIVV
+      needs: all
+  - type: logical
+    logical_operator: or
+    operands:
+    - type: subject
+      subject_needed_code: '1021'
+      subject_needed_name: ALGEBRA LINEAL
+      needs: all
+    - type: subject
+      subject_needed_code: CM14
+      subject_needed_name: CREDITOS ASIGNADOS POR REVALIDA
+      needs: all
+    - type: subject
+      subject_needed_code: MAT33
+      subject_needed_name: CREDITOS ASIGNADOS POR REVALIDA
+      needs: all
+    - type: subject
+      subject_needed_code: M9
+      subject_needed_name: CREDITOS ASIGNADOS POR REVALIDA
+      needs: all
+    - type: subject
+      subject_needed_code: 1030P
+      subject_needed_name: CREDITOS NO ACUM GAL1
+      needs: all
+    - type: subject
+      subject_needed_code: CP2
+      subject_needed_name: GEOMETRIA Y ALGEBRA LINEAL
+      needs: all
+    - type: subject
+      subject_needed_code: R101
+      subject_needed_name: GEOMETRIA Y ALGEBRA LINEAL
+      needs: all
+    - type: subject
+      subject_needed_code: CP23
+      subject_needed_name: GEOMETRIA Y ALGEBRA LINEAL (P. 74)
+      needs: all
+    - type: subject
+      subject_needed_code: '1030'
+      subject_needed_name: GEOMETRIA Y ALGEBRA LINEAL 1
+      needs: all
+    - type: subject
+      subject_needed_code: '1071'
+      subject_needed_name: GEOMETRIA Y ALGEBRA LINEAL 1
+      needs: all
+    - type: subject
+      subject_needed_code: 171Q
+      subject_needed_name: GEOMETRIA Y ALGEBRA LINEAL 1
+      needs: all
+    - type: subject
+      subject_needed_code: '1053'
+      subject_needed_name: GEOMETRIA Y ALGEBRA LINEAL 1 (ANUAL)
+      needs: all
+    - type: subject
+      subject_needed_code: GAL1P
+      subject_needed_name: GEOMETRIA Y ALGEBRA LINEAL 1 INTERACTIVA
+      needs: all
+  subject_code: '1233'
+  is_exam: false
+- type: logical
+  logical_operator: and
+  operands:
+  - type: credits
+    credits: 270
+  - type: logical
+    logical_operator: or
+    operands:
+    - type: subject
+      subject_needed_code: 1456P
+      subject_needed_name: CREDITOS NO ACUM TEORIA DE CIRCUITOS
+      needs: course
+    - type: subject
+      subject_needed_code: '1456'
+      subject_needed_name: TEORIA DE CIRCUITOS
+      needs: exam
+  - type: logical
+    logical_operator: or
+    operands:
+    - type: subject
+      subject_needed_code: 1064P
+      subject_needed_name: CREDITOS NO ACUM INT. A LAS ECUACIONES DIFERENCIALES
+      needs: exam
+    - type: subject
+      subject_needed_code: '1028'
+      subject_needed_name: ECUACIONES DIFERENCIALES
+      needs: exam
+    - type: subject
+      subject_needed_code: '1074'
+      subject_needed_name: ECUACIONES DIFERENCIALES
+      needs: exam
+    - type: subject
+      subject_needed_code: '1064'
+      subject_needed_name: INT. A LAS ECUACIONES DIFERENCIALES
+      needs: exam
+  - type: logical
+    logical_operator: or
+    operands:
+    - type: subject
+      subject_needed_code: 1128P
+      subject_needed_name: CREDITOS NO ACUM ELECTROMAGNETISMO
+      needs: exam
+    - type: subject
+      subject_needed_code: '1128'
+      subject_needed_name: ELECTROMAGNETISMO
+      needs: exam
+    - type: subject
+      subject_needed_code: '1178'
+      subject_needed_name: ELECTROMAGNETISMO
+      needs: exam
+  subject_code: '1235'
+  is_exam: false
+- type: logical
+  logical_operator: and
+  operands:
+  - type: credits
+    credits: 90
+  subject_code: '1236'
+  is_exam: false
+- type: logical
+  logical_operator: not
+  operands:
+  - type: logical
+    logical_operator: or
+    operands:
+    - type: subject
+      subject_needed_code: ACT5
+      subject_needed_name: CREDITOS ASIGNADOS POR REVALIDA
+      needs: all
+    - type: subject
+      subject_needed_code: TD6
+      subject_needed_name: CREDITOS ASIGNADOS POR REVALIDA
+      needs: all
+    - type: subject
+      subject_needed_code: 1220P
+      subject_needed_name: CREDITOS NO ACUM TALLER DE DISEÑO, COM. Y REP. GRAFICA
+      needs: all
+    - type: subject
+      subject_needed_code: '1220'
+      subject_needed_name: TALLER DE DISEÑO, COM. Y REPRES. GRAFICA
+      needs: all
+    - type: subject
+      subject_needed_code: '5904'
+      subject_needed_name: TALLER DE INTRODUCCION A LA ING. ELECTRICA
+      needs: all
+    - type: subject
+      subject_needed_code: CP55
+      subject_needed_name: TALLER LABORATORIO I (MODULO DE DIBUJO)
+      needs: all
+  subject_code: '1266'
+  is_exam: false
+- type: logical
+  logical_operator: and
+  operands:
+  - type: logical
+    logical_operator: or
+    operands:
+    - type: subject
+      subject_needed_code: '1320'
+      subject_needed_name: PROGRAMACION 1
+      needs: exam
+    - type: subject
+      subject_needed_code: '1322'
+      subject_needed_name: PROGRAMACION 1
+      needs: exam
+    - type: subject
+      subject_needed_code: '1373'
+      subject_needed_name: PROGRAMACION 1
+      needs: exam
+  subject_code: '1307'
+  is_exam: false
+- type: logical
+  logical_operator: and
+  operands:
+  - type: logical
+    logical_operator: or
+    operands:
+    - type: subject
+      subject_needed_code: '1322'
+      subject_needed_name: PROGRAMACION 1
+      needs: course
+    - type: subject
+      subject_needed_code: '1373'
+      subject_needed_name: PROGRAMACION 1
+      needs: course
+  subject_code: '1321'
+  is_exam: false
+- type: logical
+  logical_operator: and
+  operands:
+  - type: subject
+    needs: course
+    subject_needed_code: '1321'
+    subject_needed_name: PROGRAMACION 2
+  subject_code: '1321'
+  is_exam: true
+- type: logical
+  logical_operator: and
+  operands:
+  - type: logical
+    logical_operator: not
+    operands:
+    - type: subject
+      needs: exam
+      subject_needed_code: CP29
+      subject_needed_name: PROGRAMACION III
+  - type: subject
+    needs: course
+    subject_needed_code: '1321'
+    subject_needed_name: PROGRAMACION 2
+  - type: subject
+    needs: exam
+    subject_needed_code: '1023'
+    subject_needed_name: MATEMATICA DISCRETA 1
+  - type: logical
+    logical_operator: or
+    operands:
+    - type: subject
+      subject_needed_code: CP9
+      subject_needed_name: PROGRAMACION I
+      needs: exam
+    - type: subject
+      subject_needed_code: '1320'
+      subject_needed_name: PROGRAMACION 1
+      needs: exam
+    - type: subject
+      subject_needed_code: '1322'
+      subject_needed_name: PROGRAMACION 1
+      needs: exam
+    - type: subject
+      subject_needed_code: '1373'
+      subject_needed_name: PROGRAMACION 1
+      needs: exam
+  subject_code: '1323'
+  is_exam: false
+- type: logical
+  logical_operator: or
+  operands:
+  - type: logical
+    logical_operator: and
+    operands:
+    - type: logical
+      logical_operator: or
+      operands:
+      - type: subject
+        subject_needed_code: 1023P
+        subject_needed_name: CREDITOS NO ACUM MATEMATICA DISCRETA 1
+        needs: exam
+      - type: subject
+        subject_needed_code: '1023'
+        subject_needed_name: MATEMATICA DISCRETA 1
+        needs: exam
+    - type: logical
+      logical_operator: or
+      operands:
+      - type: subject
+        subject_needed_code: 1322P
+        subject_needed_name: CREDITOS NO ACUM PROGRAMACION 1
+        needs: exam
+      - type: subject
+        subject_needed_code: '1322'
+        subject_needed_name: PROGRAMACION 1
+        needs: exam
+      - type: subject
+        subject_needed_code: 1322T
+        subject_needed_name: PROGRAMACION 1
+        needs: exam
+      - type: subject
+        subject_needed_code: '1373'
+        subject_needed_name: PROGRAMACION 1
+        needs: exam
+      - type: subject
+        subject_needed_code: SRN17
+        subject_needed_name: PROGRAMACIÓN I- CIO CT-LHRH
+        needs: exam
+    - type: logical
+      logical_operator: or
+      operands:
+      - type: subject
+        subject_needed_code: 1321P
+        subject_needed_name: CREDITOS NO ACUM PROGRAMACION 2
+        needs: exam
+      - type: subject
+        subject_needed_code: '1321'
+        subject_needed_name: PROGRAMACION 2
+        needs: course
+  - type: subject
+    needs: course
+    subject_needed_code: '1323'
+    subject_needed_name: PROGRAMACION 3
+  subject_code: '1323'
+  is_exam: true
+- type: logical
+  logical_operator: and
+  operands:
+  - type: logical
+    logical_operator: or
+    operands:
+    - type: subject
+      needs: exam
+      subject_needed_code: CP51
+      subject_needed_name: DISEÑO LOGICO
+    - type: logical
+      logical_operator: at_least
+      amount_of_subjects_needed: 2
+      operands:
+      - type: subject
+        subject_needed_code: '1512'
+        subject_needed_name: DISEÑO LOGICO
+        needs: course
+      - type: subject
+        subject_needed_code: '1534'
+        subject_needed_name: DISEÑO LOGICO 2
+        needs: course
+      - type: subject
+        subject_needed_code: '1513'
+        subject_needed_name: INT. A LOS MICROPROCESADORES
+        needs: course
+  - type: logical
+    logical_operator: or
+    operands:
+    - type: subject
+      subject_needed_code: CP52
+      subject_needed_name: COMPUTACION
+      needs: exam
+    - type: subject
+      subject_needed_code: CP24
+      subject_needed_name: COMPUTACION (P. 74)
+      needs: exam
+    - type: subject
+      subject_needed_code: CP9
+      subject_needed_name: PROGRAMACION I
+      needs: exam
+    - type: subject
+      subject_needed_code: '1320'
+      subject_needed_name: PROGRAMACION 1
+      needs: exam
+    - type: subject
+      subject_needed_code: '1322'
+      subject_needed_name: PROGRAMACION 1
+      needs: exam
+    - type: subject
+      subject_needed_code: '1373'
+      subject_needed_name: PROGRAMACION 1
+      needs: exam
+    - type: subject
+      subject_needed_code: CP10
+      subject_needed_name: TALLER II
+      needs: course
+  - type: logical
+    logical_operator: or
+    operands:
+    - type: subject
+      subject_needed_code: MAT33
+      subject_needed_name: CREDITOS ASIGNADOS POR REVALIDA
+      needs: exam
+    - type: subject
+      subject_needed_code: 1030P
+      subject_needed_name: CREDITOS NO ACUM GAL1
+      needs: exam
+    - type: subject
+      subject_needed_code: '1030'
+      subject_needed_name: GEOMETRIA Y ALGEBRA LINEAL 1
+      needs: exam
+    - type: subject
+      subject_needed_code: '1053'
+      subject_needed_name: GEOMETRIA Y ALGEBRA LINEAL 1 (ANUAL)
+      needs: exam
+    - type: subject
+      subject_needed_code: GAL1P
+      subject_needed_name: GEOMETRIA Y ALGEBRA LINEAL 1 INTERACTIVA
+      needs: exam
+  - type: logical
+    logical_operator: or
+    operands:
+    - type: subject
+      subject_needed_code: '1061'
+      subject_needed_name: CALCULO DIF. E INTEGRAL EN UNA VARIABLE
+      needs: exam
+    - type: subject
+      subject_needed_code: '1020'
+      subject_needed_name: CALCULO 1
+      needs: exam
+    - type: subject
+      subject_needed_code: '1052'
+      subject_needed_name: CALCULO 1 (ANUAL)
+      needs: exam
+    - type: subject
+      subject_needed_code: MAT33
+      subject_needed_name: CREDITOS ASIGNADOS POR REVALIDA
+      needs: exam
+    - type: subject
+      subject_needed_code: 1020P
+      subject_needed_name: CREDITOS NO ACUM CALCULO 1
+      needs: exam
+    - type: subject
+      subject_needed_code: 1061P
+      subject_needed_name: CREDITOS NO ACUM CDIV
+      needs: exam
+  subject_code: '1324'
+  is_exam: false
+- type: logical
+  logical_operator: and
+  operands:
+  - type: logical
+    logical_operator: or
+    operands:
+    - type: subject
+      needs: exam
+      subject_needed_code: CP51
+      subject_needed_name: DISEÑO LOGICO
+    - type: logical
+      logical_operator: and
+      operands:
+      - type: subject
+        subject_needed_code: '1512'
+        subject_needed_name: DISEÑO LOGICO
+        needs: exam
+      - type: subject
+        subject_needed_code: '1513'
+        subject_needed_name: INT. A LOS MICROPROCESADORES
+        needs: exam
+  - type: subject
+    needs: course
+    subject_needed_code: '1324'
+    subject_needed_name: PROGRAMACION 4
+  - type: logical
+    logical_operator: or
+    operands:
+    - type: subject
+      subject_needed_code: CP52
+      subject_needed_name: COMPUTACION
+      needs: exam
+    - type: subject
+      subject_needed_code: CP24
+      subject_needed_name: COMPUTACION (P. 74)
+      needs: exam
+    - type: subject
+      subject_needed_code: CP9
+      subject_needed_name: PROGRAMACION I
+      needs: exam
+    - type: subject
+      subject_needed_code: '1320'
+      subject_needed_name: PROGRAMACION 1
+      needs: exam
+    - type: subject
+      subject_needed_code: '1322'
+      subject_needed_name: PROGRAMACION 1
+      needs: exam
+  subject_code: '1324'
+  is_exam: true
+- type: logical
+  logical_operator: not
+  operands:
+  - type: logical
+    logical_operator: or
+    operands:
+    - type: subject
+      subject_needed_code: CP52
+      subject_needed_name: COMPUTACION
+      needs: all
+    - type: subject
+      subject_needed_code: CP24
+      subject_needed_name: COMPUTACION (P. 74)
+      needs: all
+    - type: subject
+      subject_needed_code: INF20
+      subject_needed_name: CREDITOS ASIGNADOS POR REVALIDA
+      needs: all
+    - type: subject
+      subject_needed_code: INF6
+      subject_needed_name: CREDITOS ASIGNADOS POR REVALIDA
+      needs: all
+    - type: subject
+      subject_needed_code: CP9
+      subject_needed_name: PROGRAMACION I
+      needs: all
+    - type: subject
+      subject_needed_code: CP38
+      subject_needed_name: PROGRAMACION II (P. 74)
+      needs: all
+    - type: subject
+      subject_needed_code: '1322'
+      subject_needed_name: PROGRAMACION 1
+      needs: all
+  subject_code: '1373'
+  is_exam: false
+- type: logical
+  logical_operator: and
+  operands:
+  - type: logical
+    logical_operator: not
+    operands:
+    - type: subject
+      needs: all
+      subject_needed_code: '1322'
+      subject_needed_name: PROGRAMACION 1
+  - type: logical
+    logical_operator: or
+    operands:
+    - type: subject
+      subject_needed_code: '1322'
+      subject_needed_name: PROGRAMACION 1
+      needs: course
+    - type: subject
+      subject_needed_code: '1373'
+      subject_needed_name: PROGRAMACION 1
+      needs: course
+  subject_code: '1373'
+  is_exam: true
+- type: logical
+  logical_operator: and
+  operands:
+  - type: logical
+    logical_operator: or
+    operands:
+    - type: subject
+      subject_needed_code: '1410'
+      subject_needed_name: MEDIDAS ELECTRICAS
+      needs: exam
+    - type: subject
+      subject_needed_code: '1451'
+      subject_needed_name: MEDIDAS ELECTRICAS
+      needs: exam
+    - type: subject
+      subject_needed_code: '1461'
+      subject_needed_name: MEDIDAS ELECTRICAS
+      needs: course
+  subject_code: '1413'
+  is_exam: false
+- type: logical
+  logical_operator: and
+  operands:
+  - type: subject
+    needs: exam
+    subject_needed_code: '1513'
+    subject_needed_name: INT. A LOS MICROPROCESADORES
+  - type: logical
+    logical_operator: or
+    operands:
+    - type: subject
+      subject_needed_code: '1307'
+      subject_needed_name: PROGRAMACION PARA INGENIERIA ELECTRICA
+      needs: course
+    - type: subject
+      subject_needed_code: '1321'
+      subject_needed_name: PROGRAMACION 2
+      needs: course
+  - type: logical
+    logical_operator: or
+    operands:
+    - type: subject
+      subject_needed_code: 1025P
+      subject_needed_name: CREDITOS NO ACUM PROB Y EST.
+      needs: exam
+    - type: subject
+      subject_needed_code: '1025'
+      subject_needed_name: PROBABILIDAD Y ESTADISTICA
+      needs: exam
+  subject_code: '1438'
+  is_exam: false
+- type: logical
+  logical_operator: and
+  operands:
+  - type: subject
+    needs: exam
+    subject_needed_code: '1025'
+    subject_needed_name: PROBABILIDAD Y ESTADISTICA
+  subject_code: '1450'
+  is_exam: false
+- type: logical
+  logical_operator: and
+  operands:
+  - type: credits
+    credits: 15
+    group: 12
+  - type: logical
+    logical_operator: or
+    operands:
+    - type: subject
+      subject_needed_code: '1061'
+      subject_needed_name: CALCULO DIF. E INTEGRAL EN UNA VARIABLE
+      needs: all
+    - type: subject
+      subject_needed_code: '1020'
+      subject_needed_name: CALCULO 1
+      needs: all
+    - type: subject
+      subject_needed_code: '1070'
+      subject_needed_name: CALCULO 1
+      needs: all
+    - type: subject
+      subject_needed_code: '1052'
+      subject_needed_name: CALCULO 1 (ANUAL)
+      needs: all
+    - type: subject
+      subject_needed_code: MAT33
+      subject_needed_name: CREDITOS ASIGNADOS POR REVALIDA
+      needs: all
+    - type: subject
+      subject_needed_code: 1020P
+      subject_needed_name: CREDITOS NO ACUM CALCULO 1
+      needs: all
+    - type: subject
+      subject_needed_code: 1061P
+      subject_needed_name: CREDITOS NO ACUM CDIV
+      needs: all
+  - type: logical
+    logical_operator: or
+    operands:
+    - type: subject
+      subject_needed_code: '1062'
+      subject_needed_name: CALCULO DIF. E INTEGRAL EN VARIAS VARIABLES
+      needs: all
+    - type: subject
+      subject_needed_code: '1022'
+      subject_needed_name: CALCULO 2
+      needs: all
+    - type: subject
+      subject_needed_code: '1072'
+      subject_needed_name: CALCULO 2
+      needs: all
+    - type: subject
+      subject_needed_code: MAT33
+      subject_needed_name: CREDITOS ASIGNADOS POR REVALIDA
+      needs: all
+    - type: subject
+      subject_needed_code: 1022P
+      subject_needed_name: CREDITOS NO ACUM CALCULO 2
+      needs: all
+    - type: subject
+      subject_needed_code: 1062P
+      subject_needed_name: CREDITOS NO ACUM CDIVV
+      needs: all
+  - type: logical
+    logical_operator: or
+    operands:
+    - type: subject
+      subject_needed_code: MAT33
+      subject_needed_name: CREDITOS ASIGNADOS POR REVALIDA
+      needs: all
+    - type: subject
+      subject_needed_code: 1030P
+      subject_needed_name: CREDITOS NO ACUM GAL1
+      needs: all
+    - type: subject
+      subject_needed_code: '1030'
+      subject_needed_name: GEOMETRIA Y ALGEBRA LINEAL 1
+      needs: all
+    - type: subject
+      subject_needed_code: '1071'
+      subject_needed_name: GEOMETRIA Y ALGEBRA LINEAL 1
+      needs: all
+    - type: subject
+      subject_needed_code: '1053'
+      subject_needed_name: GEOMETRIA Y ALGEBRA LINEAL 1 (ANUAL)
+      needs: all
+    - type: subject
+      subject_needed_code: GAL1P
+      subject_needed_name: GEOMETRIA Y ALGEBRA LINEAL 1 INTERACTIVA
+      needs: all
+  - type: logical
+    logical_operator: or
+    operands:
+    - type: subject
+      subject_needed_code: 1153P
+      subject_needed_name: CREDITOS NO ACUM FISICA 3
+      needs: exam
+    - type: subject
+      subject_needed_code: '1121'
+      subject_needed_name: FISICA GENERAL 2
+      needs: exam
+    - type: subject
+      subject_needed_code: '1172'
+      subject_needed_name: FISICA GENERAL 2
+      needs: exam
+    - type: subject
+      subject_needed_code: '1153'
+      subject_needed_name: FISICA 3
+      needs: course
+    - type: subject
+      subject_needed_code: '1173'
+      subject_needed_name: FISICA 3
+      needs: exam
+  - type: logical
+    logical_operator: or
+    operands:
+    - type: subject
+      subject_needed_code: 1151P
+      subject_needed_name: CREDITOS NO ACUM FISICA 1
+      needs: all
+    - type: subject
+      subject_needed_code: '1120'
+      subject_needed_name: FISICA GENERAL 1
+      needs: all
+    - type: subject
+      subject_needed_code: '1170'
+      subject_needed_name: FISICA GENERAL 1
+      needs: all
+    - type: subject
+      subject_needed_code: '1151'
+      subject_needed_name: FISICA 1
+      needs: all
+    - type: subject
+      subject_needed_code: '1171'
+      subject_needed_name: FISICA 1
+      needs: all
+  subject_code: '1456'
+  is_exam: false
+- type: logical
+  logical_operator: or
+  operands:
+  - type: logical
+    logical_operator: and
+    operands:
+    - type: credits
+      credits: 15
+      group: 12
+    - type: logical
+      logical_operator: or
+      operands:
+      - type: subject
+        subject_needed_code: MAT33
+        subject_needed_name: CREDITOS ASIGNADOS POR REVALIDA
+        needs: all
+      - type: subject
+        subject_needed_code: 1030P
+        subject_needed_name: CREDITOS NO ACUM GAL1
+        needs: all
+      - type: subject
+        subject_needed_code: '1030'
+        subject_needed_name: GEOMETRIA Y ALGEBRA LINEAL 1
+        needs: all
+      - type: subject
+        subject_needed_code: '1071'
+        subject_needed_name: GEOMETRIA Y ALGEBRA LINEAL 1
+        needs: all
+      - type: subject
+        subject_needed_code: '1053'
+        subject_needed_name: GEOMETRIA Y ALGEBRA LINEAL 1 (ANUAL)
+        needs: all
+      - type: subject
+        subject_needed_code: GAL1P
+        subject_needed_name: GEOMETRIA Y ALGEBRA LINEAL 1 INTERACTIVA
+        needs: all
+    - type: logical
+      logical_operator: or
+      operands:
+      - type: subject
+        subject_needed_code: 1151P
+        subject_needed_name: CREDITOS NO ACUM FISICA 1
+        needs: all
+      - type: subject
+        subject_needed_code: '1120'
+        subject_needed_name: FISICA GENERAL 1
+        needs: all
+      - type: subject
+        subject_needed_code: '1170'
+        subject_needed_name: FISICA GENERAL 1
+        needs: all
+      - type: subject
+        subject_needed_code: '1151'
+        subject_needed_name: FISICA 1
+        needs: all
+      - type: subject
+        subject_needed_code: '1171'
+        subject_needed_name: FISICA 1
+        needs: all
+    - type: logical
+      logical_operator: or
+      operands:
+      - type: subject
+        subject_needed_code: 1153P
+        subject_needed_name: CREDITOS NO ACUM FISICA 3
+        needs: exam
+      - type: subject
+        subject_needed_code: '1121'
+        subject_needed_name: FISICA GENERAL 2
+        needs: exam
+      - type: subject
+        subject_needed_code: '1172'
+        subject_needed_name: FISICA GENERAL 2
+        needs: exam
+      - type: subject
+        subject_needed_code: '1153'
+        subject_needed_name: FISICA 3
+        needs: course
+      - type: subject
+        subject_needed_code: '1173'
+        subject_needed_name: FISICA 3
+        needs: exam
+    - type: logical
+      logical_operator: or
+      operands:
+      - type: subject
+        subject_needed_code: '1061'
+        subject_needed_name: CALCULO DIF. E INTEGRAL EN UNA VARIABLE
+        needs: all
+      - type: subject
+        subject_needed_code: '1020'
+        subject_needed_name: CALCULO 1
+        needs: all
+      - type: subject
+        subject_needed_code: '1070'
+        subject_needed_name: CALCULO 1
+        needs: all
+      - type: subject
+        subject_needed_code: '1052'
+        subject_needed_name: CALCULO 1 (ANUAL)
+        needs: all
+      - type: subject
+        subject_needed_code: MAT33
+        subject_needed_name: CREDITOS ASIGNADOS POR REVALIDA
+        needs: all
+      - type: subject
+        subject_needed_code: 1020P
+        subject_needed_name: CREDITOS NO ACUM CALCULO 1
+        needs: all
+      - type: subject
+        subject_needed_code: 1061P
+        subject_needed_name: CREDITOS NO ACUM CDIV
+        needs: all
+    - type: logical
+      logical_operator: or
+      operands:
+      - type: subject
+        subject_needed_code: '1062'
+        subject_needed_name: CALCULO DIF. E INTEGRAL EN VARIAS VARIABLES
+        needs: all
+      - type: subject
+        subject_needed_code: '1022'
+        subject_needed_name: CALCULO 2
+        needs: all
+      - type: subject
+        subject_needed_code: '1072'
+        subject_needed_name: CALCULO 2
+        needs: all
+      - type: subject
+        subject_needed_code: MAT33
+        subject_needed_name: CREDITOS ASIGNADOS POR REVALIDA
+        needs: all
+      - type: subject
+        subject_needed_code: 1062P
+        subject_needed_name: CREDITOS NO ACUM CDIVV
+        needs: all
+  - type: subject
+    needs: course
+    subject_needed_code: '1456'
+    subject_needed_name: TEORIA DE CIRCUITOS
+  subject_code: '1456'
+  is_exam: true
+- type: logical
+  logical_operator: and
+  operands:
+  - type: logical
+    logical_operator: not
+    operands:
+    - type: subject
+      needs: all
+      subject_needed_code: 1457P
+      subject_needed_name: CREDITOS NO ACUM SEÑALES Y SISTEMAS
+  - type: logical
+    logical_operator: or
+    operands:
+    - type: credits
+      credits: 35
+      group: 12
+    - type: subject
+      needs: course
+      subject_needed_code: '1128'
+      subject_needed_name: ELECTROMAGNETISMO
+  - type: credits
+    credits: 50
+    group: 11
+  - type: subject
+    needs: course
+    subject_needed_code: '1456'
+    subject_needed_name: TEORIA DE CIRCUITOS
+  - type: logical
+    logical_operator: or
+    operands:
+    - type: subject
+      subject_needed_code: '1021'
+      subject_needed_name: ALGEBRA LINEAL
+      needs: all
+    - type: subject
+      subject_needed_code: MAT33
+      subject_needed_name: CREDITOS ASIGNADOS POR REVALIDA
+      needs: all
+    - type: subject
+      subject_needed_code: 1031P
+      subject_needed_name: CREDITOS NO ACUM GAL2
+      needs: all
+    - type: subject
+      subject_needed_code: '1031'
+      subject_needed_name: GEOMETRIA Y ALGEBRA LINEAL 2
+      needs: all
+    - type: subject
+      subject_needed_code: '1058'
+      subject_needed_name: GEOMETRIA Y ALGEBRA LINEAL 2
+      needs: all
+  - type: logical
+    logical_operator: or
+    operands:
+    - type: subject
+      subject_needed_code: 1153P
+      subject_needed_name: CREDITOS NO ACUM FISICA 3
+      needs: all
+    - type: subject
+      subject_needed_code: '1121'
+      subject_needed_name: FISICA GENERAL 2
+      needs: all
+    - type: subject
+      subject_needed_code: '1172'
+      subject_needed_name: FISICA GENERAL 2
+      needs: all
+    - type: subject
+      subject_needed_code: '1153'
+      subject_needed_name: FISICA 3
+      needs: all
+    - type: subject
+      subject_needed_code: '1173'
+      subject_needed_name: FISICA 3
+      needs: all
+  - type: logical
+    logical_operator: or
+    operands:
+    - type: subject
+      subject_needed_code: '1021'
+      subject_needed_name: ALGEBRA LINEAL
+      needs: all
+    - type: subject
+      subject_needed_code: MAT33
+      subject_needed_name: CREDITOS ASIGNADOS POR REVALIDA
+      needs: all
+    - type: subject
+      subject_needed_code: 1030P
+      subject_needed_name: CREDITOS NO ACUM GAL1
+      needs: all
+    - type: subject
+      subject_needed_code: '1030'
+      subject_needed_name: GEOMETRIA Y ALGEBRA LINEAL 1
+      needs: all
+    - type: subject
+      subject_needed_code: '1071'
+      subject_needed_name: GEOMETRIA Y ALGEBRA LINEAL 1
+      needs: all
+    - type: subject
+      subject_needed_code: '1053'
+      subject_needed_name: GEOMETRIA Y ALGEBRA LINEAL 1 (ANUAL)
+      needs: all
+    - type: subject
+      subject_needed_code: GAL1P
+      subject_needed_name: GEOMETRIA Y ALGEBRA LINEAL 1 INTERACTIVA
+      needs: all
+  - type: logical
+    logical_operator: or
+    operands:
+    - type: subject
+      subject_needed_code: '1062'
+      subject_needed_name: CALCULO DIF. E INTEGRAL EN VARIAS VARIABLES
+      needs: all
+    - type: subject
+      subject_needed_code: '1022'
+      subject_needed_name: CALCULO 2
+      needs: all
+    - type: subject
+      subject_needed_code: '1072'
+      subject_needed_name: CALCULO 2
+      needs: all
+    - type: subject
+      subject_needed_code: MAT33
+      subject_needed_name: CREDITOS ASIGNADOS POR REVALIDA
+      needs: all
+    - type: subject
+      subject_needed_code: 1022P
+      subject_needed_name: CREDITOS NO ACUM CALCULO 2
+      needs: all
+    - type: subject
+      subject_needed_code: 1062P
+      subject_needed_name: CREDITOS NO ACUM CDIVV
+      needs: all
+  - type: logical
+    logical_operator: or
+    operands:
+    - type: subject
+      subject_needed_code: '1061'
+      subject_needed_name: CALCULO DIF. E INTEGRAL EN UNA VARIABLE
+      needs: all
+    - type: subject
+      subject_needed_code: '1020'
+      subject_needed_name: CALCULO 1
+      needs: all
+    - type: subject
+      subject_needed_code: '1070'
+      subject_needed_name: CALCULO 1
+      needs: all
+    - type: subject
+      subject_needed_code: '1052'
+      subject_needed_name: CALCULO 1 (ANUAL)
+      needs: all
+    - type: subject
+      subject_needed_code: MAT33
+      subject_needed_name: CREDITOS ASIGNADOS POR REVALIDA
+      needs: all
+    - type: subject
+      subject_needed_code: 1020P
+      subject_needed_name: CREDITOS NO ACUM CALCULO 1
+      needs: all
+    - type: subject
+      subject_needed_code: 1061P
+      subject_needed_name: CREDITOS NO ACUM CDIV
+      needs: all
+  - type: logical
+    logical_operator: or
+    operands:
+    - type: subject
+      subject_needed_code: 1028P
+      subject_needed_name: CREDITOS NO ACUM EC. DIFERENCIALES
+      needs: exam
+    - type: subject
+      subject_needed_code: '1028'
+      subject_needed_name: ECUACIONES DIFERENCIALES
+      needs: exam
+    - type: subject
+      subject_needed_code: '1074'
+      subject_needed_name: ECUACIONES DIFERENCIALES
+      needs: exam
+    - type: subject
+      subject_needed_code: '1064'
+      subject_needed_name: INT. A LAS ECUACIONES DIFERENCIALES
+      needs: course
+  - type: logical
+    logical_operator: or
+    operands:
+    - type: subject
+      subject_needed_code: 1154P
+      subject_needed_name: CREDITOS NO ACUM FISICA EXPERIMENTAL 1
+      needs: all
+    - type: subject
+      subject_needed_code: '1154'
+      subject_needed_name: FISICA EXPERIMENTAL 1
+      needs: all
+    - type: subject
+      subject_needed_code: 1154I
+      subject_needed_name: FISICA EXPERIMENTAL 1
+      needs: all
+    - type: subject
+      subject_needed_code: '1124'
+      subject_needed_name: LABORATORIO 1
+      needs: all
+  - type: logical
+    logical_operator: or
+    operands:
+    - type: subject
+      subject_needed_code: 1151P
+      subject_needed_name: CREDITOS NO ACUM FISICA 1
+      needs: all
+    - type: subject
+      subject_needed_code: '1120'
+      subject_needed_name: FISICA GENERAL 1
+      needs: all
+    - type: subject
+      subject_needed_code: '1170'
+      subject_needed_name: FISICA GENERAL 1
+      needs: all
+    - type: subject
+      subject_needed_code: '1151'
+      subject_needed_name: FISICA 1
+      needs: all
+    - type: subject
+      subject_needed_code: '1171'
+      subject_needed_name: FISICA 1
+      needs: all
+  subject_code: '1457'
+  is_exam: false
+- type: logical
+  logical_operator: and
+  operands:
+  - type: logical
+    logical_operator: not
+    operands:
+    - type: subject
+      needs: all
+      subject_needed_code: 1457P
+      subject_needed_name: CREDITOS NO ACUM SEÑALES Y SISTEMAS
+  - type: logical
+    logical_operator: or
+    operands:
+    - type: logical
+      logical_operator: and
+      operands:
+      - type: logical
+        logical_operator: or
+        operands:
+        - type: credits
+          credits: 35
+          group: 12
+        - type: subject
+          needs: course
+          subject_needed_code: '1128'
+          subject_needed_name: ELECTROMAGNETISMO
+      - type: subject
+        needs: course
+        subject_needed_code: '1456'
+        subject_needed_name: TEORIA DE CIRCUITOS
+      - type: logical
+        logical_operator: or
+        operands:
+        - type: subject
+          subject_needed_code: '1061'
+          subject_needed_name: CALCULO DIF. E INTEGRAL EN UNA VARIABLE
+          needs: all
+        - type: subject
+          subject_needed_code: '1020'
+          subject_needed_name: CALCULO 1
+          needs: all
+        - type: subject
+          subject_needed_code: '1070'
+          subject_needed_name: CALCULO 1
+          needs: all
+        - type: subject
+          subject_needed_code: '1052'
+          subject_needed_name: CALCULO 1 (ANUAL)
+          needs: all
+        - type: subject
+          subject_needed_code: MAT33
+          subject_needed_name: CREDITOS ASIGNADOS POR REVALIDA
+          needs: all
+        - type: subject
+          subject_needed_code: 1020P
+          subject_needed_name: CREDITOS NO ACUM CALCULO 1
+          needs: all
+        - type: subject
+          subject_needed_code: 1061P
+          subject_needed_name: CREDITOS NO ACUM CDIV
+          needs: all
+      - type: logical
+        logical_operator: or
+        operands:
+        - type: subject
+          subject_needed_code: '1062'
+          subject_needed_name: CALCULO DIF. E INTEGRAL EN VARIAS VARIABLES
+          needs: all
+        - type: subject
+          subject_needed_code: '1022'
+          subject_needed_name: CALCULO 2
+          needs: all
+        - type: subject
+          subject_needed_code: '1072'
+          subject_needed_name: CALCULO 2
+          needs: all
+        - type: subject
+          subject_needed_code: MAT33
+          subject_needed_name: CREDITOS ASIGNADOS POR REVALIDA
+          needs: all
+        - type: subject
+          subject_needed_code: 1062P
+          subject_needed_name: CREDITOS NO ACUM CDIVV
+          needs: all
+      - type: logical
+        logical_operator: or
+        operands:
+        - type: subject
+          subject_needed_code: '1021'
+          subject_needed_name: ALGEBRA LINEAL
+          needs: all
+        - type: subject
+          subject_needed_code: MAT33
+          subject_needed_name: CREDITOS ASIGNADOS POR REVALIDA
+          needs: all
+        - type: subject
+          subject_needed_code: 1030P
+          subject_needed_name: CREDITOS NO ACUM GAL1
+          needs: all
+        - type: subject
+          subject_needed_code: '1030'
+          subject_needed_name: GEOMETRIA Y ALGEBRA LINEAL 1
+          needs: all
+        - type: subject
+          subject_needed_code: '1071'
+          subject_needed_name: GEOMETRIA Y ALGEBRA LINEAL 1
+          needs: all
+        - type: subject
+          subject_needed_code: '1053'
+          subject_needed_name: GEOMETRIA Y ALGEBRA LINEAL 1 (ANUAL)
+          needs: all
+        - type: subject
+          subject_needed_code: GAL1P
+          subject_needed_name: GEOMETRIA Y ALGEBRA LINEAL 1 INTERACTIVA
+          needs: all
+      - type: logical
+        logical_operator: or
+        operands:
+        - type: subject
+          subject_needed_code: 1153P
+          subject_needed_name: CREDITOS NO ACUM FISICA 3
+          needs: all
+        - type: subject
+          subject_needed_code: '1121'
+          subject_needed_name: FISICA GENERAL 2
+          needs: all
+        - type: subject
+          subject_needed_code: '1172'
+          subject_needed_name: FISICA GENERAL 2
+          needs: all
+        - type: subject
+          subject_needed_code: '1153'
+          subject_needed_name: FISICA 3
+          needs: all
+        - type: subject
+          subject_needed_code: '1173'
+          subject_needed_name: FISICA 3
+          needs: all
+      - type: logical
+        logical_operator: or
+        operands:
+        - type: subject
+          subject_needed_code: 1028P
+          subject_needed_name: CREDITOS NO ACUM EC. DIFERENCIALES
+          needs: exam
+        - type: subject
+          subject_needed_code: '1028'
+          subject_needed_name: ECUACIONES DIFERENCIALES
+          needs: exam
+        - type: subject
+          subject_needed_code: '1074'
+          subject_needed_name: ECUACIONES DIFERENCIALES
+          needs: exam
+        - type: subject
+          subject_needed_code: '1064'
+          subject_needed_name: INT. A LAS ECUACIONES DIFERENCIALES
+          needs: course
+      - type: logical
+        logical_operator: or
+        operands:
+        - type: subject
+          subject_needed_code: 1151P
+          subject_needed_name: CREDITOS NO ACUM FISICA 1
+          needs: all
+        - type: subject
+          subject_needed_code: '1120'
+          subject_needed_name: FISICA GENERAL 1
+          needs: all
+        - type: subject
+          subject_needed_code: '1170'
+          subject_needed_name: FISICA GENERAL 1
+          needs: all
+        - type: subject
+          subject_needed_code: '1151'
+          subject_needed_name: FISICA 1
+          needs: all
+        - type: subject
+          subject_needed_code: '1171'
+          subject_needed_name: FISICA 1
+          needs: all
+      - type: logical
+        logical_operator: or
+        operands:
+        - type: subject
+          subject_needed_code: 1154P
+          subject_needed_name: CREDITOS NO ACUM FISICA EXPERIMENTAL 1
+          needs: all
+        - type: subject
+          subject_needed_code: '1154'
+          subject_needed_name: FISICA EXPERIMENTAL 1
+          needs: all
+        - type: subject
+          subject_needed_code: 1154I
+          subject_needed_name: FISICA EXPERIMENTAL 1
+          needs: all
+        - type: subject
+          subject_needed_code: '1124'
+          subject_needed_name: LABORATORIO 1
+          needs: all
+      - type: logical
+        logical_operator: or
+        operands:
+        - type: subject
+          subject_needed_code: '1021'
+          subject_needed_name: ALGEBRA LINEAL
+          needs: all
+        - type: subject
+          subject_needed_code: MAT33
+          subject_needed_name: CREDITOS ASIGNADOS POR REVALIDA
+          needs: all
+        - type: subject
+          subject_needed_code: 1031P
+          subject_needed_name: CREDITOS NO ACUM GAL2
+          needs: all
+        - type: subject
+          subject_needed_code: '1031'
+          subject_needed_name: GEOMETRIA Y ALGEBRA LINEAL 2
+          needs: all
+        - type: subject
+          subject_needed_code: '1058'
+          subject_needed_name: GEOMETRIA Y ALGEBRA LINEAL 2
+          needs: all
+    - type: subject
+      needs: course
+      subject_needed_code: '1457'
+      subject_needed_name: SEÑALES Y SISTEMAS
+  - type: credits
+    credits: 50
+    group: 11
+  subject_code: '1457'
+  is_exam: true
+- type: logical
+  logical_operator: and
+  operands:
+  - type: credits
+    credits: 35
+    group: 12
+  - type: credits
+    credits: 50
+    group: 11
+  - type: credits
+    credits: 5
+    group: 21
+  - type: subject
+    needs: course
+    subject_needed_code: '1457'
+    subject_needed_name: SEÑALES Y SISTEMAS
+  - type: subject
+    needs: course
+    subject_needed_code: '1456'
+    subject_needed_name: TEORIA DE CIRCUITOS
+  - type: logical
+    logical_operator: or
+    operands:
+    - type: subject
+      subject_needed_code: 1154P
+      subject_needed_name: CREDITOS NO ACUM FISICA EXPERIMENTAL 1
+      needs: exam
+    - type: subject
+      subject_needed_code: '1154'
+      subject_needed_name: FISICA EXPERIMENTAL 1
+      needs: course
+    - type: subject
+      subject_needed_code: 1154I
+      subject_needed_name: FISICA EXPERIMENTAL 1
+      needs: exam
+    - type: subject
+      subject_needed_code: '1124'
+      subject_needed_name: LABORATORIO 1
+      needs: course
+  - type: logical
+    logical_operator: or
+    operands:
+    - type: subject
+      subject_needed_code: '1128'
+      subject_needed_name: ELECTROMAGNETISMO
+      needs: course
+    - type: subject
+      subject_needed_code: '1178'
+      subject_needed_name: ELECTROMAGNETISMO
+      needs: exam
+  subject_code: '1459'
+  is_exam: false
+- type: logical
+  logical_operator: or
+  operands:
+  - type: logical
+    logical_operator: and
+    operands:
+    - type: credits
+      credits: 5
+      group: 21
+    - type: credits
+      credits: 40
+      group: 12
+    - type: credits
+      credits: 59
+      group: 11
+    - type: subject
+      needs: course
+      subject_needed_code: '1457'
+      subject_needed_name: SEÑALES Y SISTEMAS
+    - type: subject
+      needs: course
+      subject_needed_code: '1456'
+      subject_needed_name: TEORIA DE CIRCUITOS
+    - type: logical
+      logical_operator: or
+      operands:
+      - type: subject
+        subject_needed_code: 1025P
+        subject_needed_name: CREDITOS NO ACUM PROB Y EST.
+        needs: exam
+      - type: subject
+        subject_needed_code: '1025'
+        subject_needed_name: PROBABILIDAD Y ESTADISTICA
+        needs: exam
+      - type: subject
+        subject_needed_code: '1075'
+        subject_needed_name: PROBABILIDAD Y ESTADISTICA
+        needs: exam
+  - type: logical
+    logical_operator: and
+    operands:
+    - type: logical
+      logical_operator: or
+      operands:
+      - type: subject
+        subject_needed_code: '1401'
+        subject_needed_name: SISTEMAS LINEALES 1
+        needs: exam
+      - type: subject
+        subject_needed_code: '1423'
+        subject_needed_name: SISTEMAS LINEALES 1
+        needs: exam
+      - type: subject
+        subject_needed_code: '1407'
+        subject_needed_name: SISTEMAS LINEALES 2
+        needs: exam
+    - type: logical
+      logical_operator: or
+      operands:
+      - type: subject
+        subject_needed_code: 1025P
+        subject_needed_name: CREDITOS NO ACUM PROB Y EST.
+        needs: exam
+      - type: subject
+        subject_needed_code: '1025'
+        subject_needed_name: PROBABILIDAD Y ESTADISTICA
+        needs: course
+      - type: subject
+        subject_needed_code: '1075'
+        subject_needed_name: PROBABILIDAD Y ESTADISTICA
+        needs: exam
+  subject_code: '1460'
+  is_exam: false
+- type: logical
+  logical_operator: or
+  operands:
+  - type: logical
+    logical_operator: and
+    operands:
+    - type: logical
+      logical_operator: or
+      operands:
+      - type: subject
+        subject_needed_code: 1025P
+        subject_needed_name: CREDITOS NO ACUM PROB Y EST.
+        needs: exam
+      - type: subject
+        subject_needed_code: '1025'
+        subject_needed_name: PROBABILIDAD Y ESTADISTICA
+        needs: exam
+      - type: subject
+        subject_needed_code: '1075'
+        subject_needed_name: PROBABILIDAD Y ESTADISTICA
+        needs: exam
+    - type: logical
+      logical_operator: or
+      operands:
+      - type: subject
+        subject_needed_code: '1401'
+        subject_needed_name: SISTEMAS LINEALES 1
+        needs: exam
+      - type: subject
+        subject_needed_code: '1423'
+        subject_needed_name: SISTEMAS LINEALES 1
+        needs: exam
+      - type: subject
+        subject_needed_code: '1407'
+        subject_needed_name: SISTEMAS LINEALES 2
+        needs: exam
+  - type: logical
+    logical_operator: and
+    operands:
+    - type: credits
+      credits: 40
+      group: 12
+    - type: credits
+      credits: 5
+      group: 21
+    - type: credits
+      credits: 59
+      group: 11
+    - type: subject
+      needs: course
+      subject_needed_code: '1456'
+      subject_needed_name: TEORIA DE CIRCUITOS
+    - type: subject
+      needs: course
+      subject_needed_code: '1457'
+      subject_needed_name: SEÑALES Y SISTEMAS
+    - type: logical
+      logical_operator: or
+      operands:
+      - type: subject
+        subject_needed_code: 1025P
+        subject_needed_name: CREDITOS NO ACUM PROB Y EST.
+        needs: exam
+      - type: subject
+        subject_needed_code: '1025'
+        subject_needed_name: PROBABILIDAD Y ESTADISTICA
+        needs: exam
+      - type: subject
+        subject_needed_code: '1075'
+        subject_needed_name: PROBABILIDAD Y ESTADISTICA
+        needs: exam
+  - type: subject
+    needs: course
+    subject_needed_code: '1460'
+    subject_needed_name: SEÑALES ALEATORIAS Y MODULACION
+  subject_code: '1460'
+  is_exam: true
+- type: logical
+  logical_operator: and
+  operands:
+  - type: logical
+    logical_operator: not
+    operands:
+    - type: logical
+      logical_operator: or
+      operands:
+      - type: subject
+        subject_needed_code: FUN12
+        subject_needed_name: CREDITOS ASIGNADOS POR REVALIDA
+        needs: all
+      - type: subject
+        subject_needed_code: 1461P
+        subject_needed_name: CREDITOS NO ACUM MEDIDAS ELECTRICAS
+        needs: all
+      - type: subject
+        subject_needed_code: CP59
+        subject_needed_name: MEDIDAS ELECTRICAS
+        needs: all
+      - type: subject
+        subject_needed_code: '1410'
+        subject_needed_name: MEDIDAS ELECTRICAS
+        needs: all
+      - type: subject
+        subject_needed_code: '1451'
+        subject_needed_name: MEDIDAS ELECTRICAS
+        needs: all
+  - type: logical
+    logical_operator: or
+    operands:
+    - type: logical
+      logical_operator: and
+      operands:
+      - type: logical
+        logical_operator: or
+        operands:
+        - type: subject
+          subject_needed_code: 1457P
+          subject_needed_name: CREDITOS NO ACUM SEÑALES Y SISTEMAS
+          needs: exam
+        - type: subject
+          subject_needed_code: '1460'
+          subject_needed_name: SEÑALES ALEATORIAS Y MODULACION
+          needs: course
+        - type: subject
+          subject_needed_code: '1457'
+          subject_needed_name: SEÑALES Y SISTEMAS
+          needs: exam
+      - type: logical
+        logical_operator: at_least
+        amount_of_subjects_needed: 2
+        operands:
+        - type: subject
+          subject_needed_code: 1512P
+          subject_needed_name: CREDITOS NO ACUM DISEÑO LOGICO
+          needs: all
+        - type: subject
+          subject_needed_code: 1456P
+          subject_needed_name: CREDITOS NO ACUM TEORIA DE CIRCUITOS
+          needs: all
+        - type: subject
+          subject_needed_code: 1456R
+          subject_needed_name: CREDITOS NO ACUM TEORIA DE CIRCUITOS
+          needs: all
+        - type: subject
+          subject_needed_code: '1512'
+          subject_needed_name: DISEÑO LOGICO
+          needs: all
+        - type: subject
+          subject_needed_code: '1456'
+          subject_needed_name: TEORIA DE CIRCUITOS
+          needs: all
+    - type: logical
+      logical_operator: or
+      operands:
+      - type: subject
+        subject_needed_code: '1401'
+        subject_needed_name: SISTEMAS LINEALES 1
+        needs: exam
+      - type: subject
+        subject_needed_code: '1423'
+        subject_needed_name: SISTEMAS LINEALES 1
+        needs: exam
+      - type: subject
+        subject_needed_code: '1407'
+        subject_needed_name: SISTEMAS LINEALES 2
+        needs: exam
+  subject_code: '1461'
+  is_exam: false
+- type: logical
+  logical_operator: and
+  operands:
+  - type: subject
+    needs: course
+    subject_needed_code: '1461'
+    subject_needed_name: MEDIDAS ELECTRICAS
+  subject_code: '1461'
+  is_exam: true
+- type: logical
+  logical_operator: and
+  operands:
+  - type: logical
+    logical_operator: not
+    operands:
+    - type: subject
+      needs: exam
+      subject_needed_code: '5808'
+      subject_needed_name: SISTEMAS DE COMUNICACION
+  - type: credits
+    credits: 70
+    group: 11
+  - type: subject
+    needs: exam
+    subject_needed_code: '1456'
+    subject_needed_name: TEORIA DE CIRCUITOS
+  - type: subject
+    needs: exam
+    subject_needed_code: '1128'
+    subject_needed_name: ELECTROMAGNETISMO
+  - type: subject
+    needs: course
+    subject_needed_code: '1460'
+    subject_needed_name: SEÑALES ALEATORIAS Y MODULACION
+  - type: subject
+    needs: exam
+    subject_needed_code: '1457'
+    subject_needed_name: SEÑALES Y SISTEMAS
+  - type: logical
+    logical_operator: or
+    operands:
+    - type: subject
+      subject_needed_code: 1322P
+      subject_needed_name: CREDITOS NO ACUM PROGRAMACION 1
+      needs: exam
+    - type: subject
+      subject_needed_code: '1322'
+      subject_needed_name: PROGRAMACION 1
+      needs: exam
+    - type: subject
+      subject_needed_code: '1373'
+      subject_needed_name: PROGRAMACION 1
+      needs: exam
+  subject_code: '1462'
+  is_exam: false
+- type: logical
+  logical_operator: and
+  operands:
+  - type: subject
+    needs: course
+    subject_needed_code: '1462'
+    subject_needed_name: COMUNICACIONES DIGITALES
+  subject_code: '1462'
+  is_exam: true
+- type: logical
+  logical_operator: and
+  operands:
+  - type: credits
+    credits: 7
+    group: 26
+  - type: credits
+    credits: 50
+    group: 11
+  - type: logical
+    logical_operator: or
+    operands:
+    - type: subject
+      subject_needed_code: '1025'
+      subject_needed_name: PROBABILIDAD Y ESTADISTICA
+      needs: exam
+    - type: subject
+      subject_needed_code: '1075'
+      subject_needed_name: PROBABILIDAD Y ESTADISTICA
+      needs: exam
+  - type: logical
+    logical_operator: or
+    operands:
+    - type: subject
+      subject_needed_code: '5852'
+      subject_needed_name: FUNDAMENTOS DE APRENDIZAJE AUTOMATICO Y RECONOCIMIENTO
+        DE PATRONES
+      needs: all
+    - type: subject
+      subject_needed_code: '5842'
+      subject_needed_name: RECONOCIMIENTO DE PATRONES
+      needs: all
+  subject_code: '1463'
+  is_exam: false
+- type: logical
+  logical_operator: and
+  operands:
+  - type: logical
+    logical_operator: not
+    operands:
+    - type: logical
+      logical_operator: or
+      operands:
+      - type: subject
+        subject_needed_code: CP102
+        subject_needed_name: CONTROL DE CALIDAD
+        needs: exam
+      - type: subject
+        subject_needed_code: 1510R
+        subject_needed_name: CREDITOS ASIGNADOS POR REVALIDA
+        needs: exam
+      - type: subject
+        subject_needed_code: 1510P
+        subject_needed_name: CREDITOS NO ACUM CONTROL DE CALIDAD
+        needs: exam
+  - type: credits
+    credits: 80
+  - type: logical
+    logical_operator: or
+    operands:
+    - type: subject
+      subject_needed_code: 1025P
+      subject_needed_name: CREDITOS NO ACUM PROB Y EST.
+      needs: exam
+    - type: subject
+      subject_needed_code: '1025'
+      subject_needed_name: PROBABILIDAD Y ESTADISTICA
+      needs: course
+    - type: subject
+      subject_needed_code: '1075'
+      subject_needed_name: PROBABILIDAD Y ESTADISTICA
+      needs: exam
+  subject_code: '1510'
+  is_exam: false
+- type: logical
+  logical_operator: or
+  operands:
+  - type: logical
+    logical_operator: and
+    operands:
+    - type: logical
+      logical_operator: not
+      operands:
+      - type: logical
+        logical_operator: or
+        operands:
+        - type: subject
+          subject_needed_code: CP102
+          subject_needed_name: CONTROL DE CALIDAD
+          needs: all
+        - type: subject
+          subject_needed_code: 1510R
+          subject_needed_name: CREDITOS ASIGNADOS POR REVALIDA
+          needs: all
+        - type: subject
+          subject_needed_code: 1510P
+          subject_needed_name: CREDITOS NO ACUM CONTROL DE CALIDAD
+          needs: all
+    - type: credits
+      credits: 80
+    - type: logical
+      logical_operator: or
+      operands:
+      - type: subject
+        subject_needed_code: 1025P
+        subject_needed_name: CREDITOS NO ACUM PROB Y EST.
+        needs: exam
+      - type: subject
+        subject_needed_code: '1025'
+        subject_needed_name: PROBABILIDAD Y ESTADISTICA
+        needs: course
+      - type: subject
+        subject_needed_code: '1075'
+        subject_needed_name: PROBABILIDAD Y ESTADISTICA
+        needs: exam
+  - type: subject
+    needs: course
+    subject_needed_code: '1510'
+    subject_needed_name: CONTROL DE CALIDAD
+  subject_code: '1510'
+  is_exam: true
+- type: logical
+  logical_operator: not
+  operands:
+  - type: logical
+    logical_operator: or
+    operands:
+    - type: subject
+      subject_needed_code: SD10
+      subject_needed_name: CREDITOS ASIGNADOS POR REVALIDA
+      needs: all
+    - type: subject
+      subject_needed_code: 1512P
+      subject_needed_name: CREDITOS NO ACUM DISEÑO LOGICO
+      needs: all
+    - type: subject
+      subject_needed_code: CP51
+      subject_needed_name: DISEÑO LOGICO
+      needs: all
+  subject_code: '1512'
+  is_exam: false
+- type: logical
+  logical_operator: and
+  operands:
+  - type: subject
+    needs: course
+    subject_needed_code: '1512'
+    subject_needed_name: DISEÑO LOGICO
+  subject_code: '1512'
+  is_exam: true
+- type: logical
+  logical_operator: and
+  operands:
+  - type: logical
+    logical_operator: not
+    operands:
+    - type: subject
+      needs: all
+      subject_needed_code: SIS10
+      subject_needed_name: CREDITOS ASIGNADOS POR REVALIDA
+  - type: subject
+    needs: course
+    subject_needed_code: '1512'
+    subject_needed_name: DISEÑO LOGICO
+  - type: logical
+    logical_operator: or
+    operands:
+    - type: subject
+      subject_needed_code: 1322P
+      subject_needed_name: CREDITOS NO ACUM PROGRAMACION 1
+      needs: exam
+    - type: subject
+      subject_needed_code: '1320'
+      subject_needed_name: PROGRAMACION 1
+      needs: exam
+    - type: subject
+      subject_needed_code: '1322'
+      subject_needed_name: PROGRAMACION 1
+      needs: exam
+    - type: subject
+      subject_needed_code: '1373'
+      subject_needed_name: PROGRAMACION 1
+      needs: exam
+  subject_code: '1513'
+  is_exam: false
+- type: logical
+  logical_operator: and
+  operands:
+  - type: subject
+    needs: course
+    subject_needed_code: '1513'
+    subject_needed_name: INT. A LOS MICROPROCESADORES
+  subject_code: '1513'
+  is_exam: true
+- type: logical
+  logical_operator: and
+  operands:
+  - type: logical
+    logical_operator: not
+    operands:
+    - type: logical
+      logical_operator: or
+      operands:
+      - type: subject
+        subject_needed_code: 1534P
+        subject_needed_name: CREDITOS NO ACUM DISEÑO LOGICO 2
+        needs: course
+      - type: subject
+        subject_needed_code: '1516'
+        subject_needed_name: DISEÑO LOGICO 2
+        needs: course
+  - type: subject
+    needs: exam
+    subject_needed_code: '1513'
+    subject_needed_name: INT. A LOS MICROPROCESADORES
+  - type: subject
+    needs: exam
+    subject_needed_code: '1512'
+    subject_needed_name: DISEÑO LOGICO
+  - type: logical
+    logical_operator: or
+    operands:
+    - type: subject
+      subject_needed_code: '5715'
+      subject_needed_name: ELECTRONICA FUNDAMENTAL
+      needs: course
+    - type: subject
+      subject_needed_code: '1001'
+      subject_needed_name: ELECTRONICA II
+      needs: exam
+    - type: subject
+      subject_needed_code: '5701'
+      subject_needed_name: ELECTRONICA 1
+      needs: exam
+  subject_code: '1534'
+  is_exam: false
+- type: logical
+  logical_operator: and
+  operands:
+  - type: logical
+    logical_operator: not
+    operands:
+    - type: logical
+      logical_operator: or
+      operands:
+      - type: subject
+        subject_needed_code: '1511'
+        subject_needed_name: SISTEMAS OPERATIVOS
+        needs: all
+      - type: subject
+        subject_needed_code: '1518'
+        subject_needed_name: SISTEMAS OPERATIVOS
+        needs: all
+      - type: subject
+        subject_needed_code: '1532'
+        subject_needed_name: SISTEMAS OPERATIVOS
+        needs: all
+  - type: credits
+    credits: 20
+    group: 12
+  - type: subject
+    needs: course
+    subject_needed_code: '1513'
+    subject_needed_name: INT. A LOS MICROPROCESADORES
+  - type: logical
+    logical_operator: or
+    operands:
+    - type: subject
+      subject_needed_code: 1030P
+      subject_needed_name: CREDITOS NO ACUM GAL1
+      needs: exam
+    - type: subject
+      subject_needed_code: '1030'
+      subject_needed_name: GEOMETRIA Y ALGEBRA LINEAL 1
+      needs: exam
+  - type: logical
+    logical_operator: or
+    operands:
+    - type: subject
+      subject_needed_code: '1307'
+      subject_needed_name: PROGRAMACION PARA INGENIERIA ELECTRICA
+      needs: course
+    - type: subject
+      subject_needed_code: '1321'
+      subject_needed_name: PROGRAMACION 2
+      needs: course
+  - type: logical
+    logical_operator: or
+    operands:
+    - type: subject
+      subject_needed_code: '1061'
+      subject_needed_name: CALCULO DIF. E INTEGRAL EN UNA VARIABLE
+      needs: exam
+    - type: subject
+      subject_needed_code: 1061P
+      subject_needed_name: CREDITOS NO ACUM CDIV
+      needs: exam
+  subject_code: '1537'
+  is_exam: false
+- type: logical
+  logical_operator: and
+  operands:
+  - type: logical
+    logical_operator: not
+    operands:
+    - type: logical
+      logical_operator: or
+      operands:
+      - type: subject
+        subject_needed_code: '1511'
+        subject_needed_name: SISTEMAS OPERATIVOS
+        needs: exam
+      - type: subject
+        subject_needed_code: '1518'
+        subject_needed_name: SISTEMAS OPERATIVOS
+        needs: exam
+      - type: subject
+        subject_needed_code: '1532'
+        subject_needed_name: SISTEMAS OPERATIVOS
+        needs: exam
+  - type: subject
+    needs: course
+    subject_needed_code: '1537'
+    subject_needed_name: SISTEMAS OPERATIVOS
+  subject_code: '1537'
+  is_exam: true
+- type: logical
+  logical_operator: and
+  operands:
+  - type: subject
+    needs: exam
+    subject_needed_code: '1513'
+    subject_needed_name: INT. A LOS MICROPROCESADORES
+  - type: logical
+    logical_operator: or
+    operands:
+    - type: subject
+      subject_needed_code: '1307'
+      subject_needed_name: PROGRAMACION PARA INGENIERIA ELECTRICA
+      needs: course
+    - type: subject
+      subject_needed_code: '1321'
+      subject_needed_name: PROGRAMACION 2
+      needs: exam
+  - type: logical
+    logical_operator: or
+    operands:
+    - type: subject
+      subject_needed_code: '5715'
+      subject_needed_name: ELECTRONICA FUNDAMENTAL
+      needs: course
+    - type: subject
+      subject_needed_code: '5701'
+      subject_needed_name: ELECTRONICA 1
+      needs: exam
+  subject_code: '1538'
+  is_exam: false
+- type: logical
+  logical_operator: and
+  operands:
+  - type: credits
+    credits: 8
+    group: 26
+  - type: credits
+    credits: 50
+    group: 12
+  - type: credits
+    credits: 60
+    group: 11
+  subject_code: '1544'
+  is_exam: false
+- type: logical
+  logical_operator: and
+  operands:
+  - type: logical
+    logical_operator: not
+    operands:
+    - type: subject
+      needs: course
+      subject_needed_code: '1536'
+      subject_needed_name: SISTEMAS EMBEBIDOS PARA TIEMPO REAL
+  - type: subject
+    needs: exam
+    subject_needed_code: '1513'
+    subject_needed_name: INT. A LOS MICROPROCESADORES
+  - type: logical
+    logical_operator: or
+    operands:
+    - type: subject
+      subject_needed_code: '1326'
+      subject_needed_name: DESARROLLO DE SOFTWARE PARA ING.ELECT.
+      needs: course
+    - type: subject
+      subject_needed_code: '1306'
+      subject_needed_name: PROGRAMACION ORIENTADA A OBJETOS
+      needs: course
+    - type: subject
+      subject_needed_code: '1307'
+      subject_needed_name: PROGRAMACION PARA INGENIERIA ELECTRICA
+      needs: course
+    - type: subject
+      subject_needed_code: '1321'
+      subject_needed_name: PROGRAMACION 2
+      needs: exam
+  - type: logical
+    logical_operator: or
+    operands:
+    - type: subject
+      subject_needed_code: '5715'
+      subject_needed_name: ELECTRONICA FUNDAMENTAL
+      needs: course
+    - type: subject
+      subject_needed_code: '5701'
+      subject_needed_name: ELECTRONICA 1
+      needs: exam
+  subject_code: '1556'
+  is_exam: false
+- type: logical
+  logical_operator: not
+  operands:
+  - type: logical
+    logical_operator: or
+    operands:
+    - type: subject
+      subject_needed_code: CP120
+      subject_needed_name: QUIMICA
+      needs: all
+    - type: subject
+      subject_needed_code: CP119
+      subject_needed_name: QUIMICA TECNICA
+      needs: all
+    - type: subject
+      subject_needed_code: '102'
+      subject_needed_name: QUÍMICA GENERAL I
+      needs: all
+  subject_code: '1620'
+  is_exam: false
+- type: logical
+  logical_operator: not
+  operands:
+  - type: logical
+    logical_operator: or
+    operands:
+    - type: subject
+      subject_needed_code: CP120
+      subject_needed_name: QUIMICA
+      needs: all
+    - type: subject
+      subject_needed_code: CP119
+      subject_needed_name: QUIMICA TECNICA
+      needs: all
+    - type: subject
+      subject_needed_code: '102'
+      subject_needed_name: QUÍMICA GENERAL I
+      needs: all
+  subject_code: '1620'
+  is_exam: true
+- type: logical
+  logical_operator: and
+  operands:
+  - type: logical
+    logical_operator: not
+    operands:
+    - type: logical
+      logical_operator: or
+      operands:
+      - type: subject
+        subject_needed_code: 1610P
+        subject_needed_name: CREDITOS NO ACUM INT. A LA INVESTIGACION DE OPERACIONES
+        needs: exam
+      - type: subject
+        subject_needed_code: '1610'
+        subject_needed_name: INT. A LA INVESTIGACION DE OPERACIONES
+        needs: exam
+      - type: subject
+        subject_needed_code: CP27
+        subject_needed_name: INVESTIGACION OPERATIVA
+        needs: exam
+  - type: logical
+    logical_operator: or
+    operands:
+    - type: subject
+      subject_needed_code: '1021'
+      subject_needed_name: ALGEBRA LINEAL
+      needs: all
+    - type: subject
+      subject_needed_code: MAT33
+      subject_needed_name: CREDITOS ASIGNADOS POR REVALIDA
+      needs: all
+    - type: subject
+      subject_needed_code: 1031P
+      subject_needed_name: CREDITOS NO ACUM GAL2
+      needs: all
+    - type: subject
+      subject_needed_code: '1031'
+      subject_needed_name: GEOMETRIA Y ALGEBRA LINEAL 2
+      needs: all
+    - type: subject
+      subject_needed_code: '1058'
+      subject_needed_name: GEOMETRIA Y ALGEBRA LINEAL 2
+      needs: all
+  - type: logical
+    logical_operator: or
+    operands:
+    - type: subject
+      subject_needed_code: '1021'
+      subject_needed_name: ALGEBRA LINEAL
+      needs: all
+    - type: subject
+      subject_needed_code: MAT33
+      subject_needed_name: CREDITOS ASIGNADOS POR REVALIDA
+      needs: all
+    - type: subject
+      subject_needed_code: 1030P
+      subject_needed_name: CREDITOS NO ACUM GAL1
+      needs: all
+    - type: subject
+      subject_needed_code: '1030'
+      subject_needed_name: GEOMETRIA Y ALGEBRA LINEAL 1
+      needs: all
+    - type: subject
+      subject_needed_code: '1071'
+      subject_needed_name: GEOMETRIA Y ALGEBRA LINEAL 1
+      needs: all
+    - type: subject
+      subject_needed_code: '1053'
+      subject_needed_name: GEOMETRIA Y ALGEBRA LINEAL 1 (ANUAL)
+      needs: all
+    - type: subject
+      subject_needed_code: GAL1P
+      subject_needed_name: GEOMETRIA Y ALGEBRA LINEAL 1 INTERACTIVA
+      needs: all
+  - type: logical
+    logical_operator: or
+    operands:
+    - type: subject
+      subject_needed_code: 1025P
+      subject_needed_name: CREDITOS NO ACUM PROB Y EST.
+      needs: all
+    - type: subject
+      subject_needed_code: '1025'
+      subject_needed_name: PROBABILIDAD Y ESTADISTICA
+      needs: all
+    - type: subject
+      subject_needed_code: '1075'
+      subject_needed_name: PROBABILIDAD Y ESTADISTICA
+      needs: all
+  - type: logical
+    logical_operator: or
+    operands:
+    - type: subject
+      subject_needed_code: '1062'
+      subject_needed_name: CALCULO DIF. E INTEGRAL EN VARIAS VARIABLES
+      needs: all
+    - type: subject
+      subject_needed_code: '1022'
+      subject_needed_name: CALCULO 2
+      needs: all
+    - type: subject
+      subject_needed_code: '1072'
+      subject_needed_name: CALCULO 2
+      needs: all
+    - type: subject
+      subject_needed_code: MAT33
+      subject_needed_name: CREDITOS ASIGNADOS POR REVALIDA
+      needs: all
+    - type: subject
+      subject_needed_code: 1062P
+      subject_needed_name: CREDITOS NO ACUM CDIVV
+      needs: all
+  - type: logical
+    logical_operator: or
+    operands:
+    - type: subject
+      subject_needed_code: '1061'
+      subject_needed_name: CALCULO DIF. E INTEGRAL EN UNA VARIABLE
+      needs: all
+    - type: subject
+      subject_needed_code: '1020'
+      subject_needed_name: CALCULO 1
+      needs: all
+    - type: subject
+      subject_needed_code: '1070'
+      subject_needed_name: CALCULO 1
+      needs: all
+    - type: subject
+      subject_needed_code: '1052'
+      subject_needed_name: CALCULO 1 (ANUAL)
+      needs: all
+    - type: subject
+      subject_needed_code: MAT33
+      subject_needed_name: CREDITOS ASIGNADOS POR REVALIDA
+      needs: all
+    - type: subject
+      subject_needed_code: 1020P
+      subject_needed_name: CREDITOS NO ACUM CALCULO 1
+      needs: all
+    - type: subject
+      subject_needed_code: 1061P
+      subject_needed_name: CREDITOS NO ACUM CDIV
+      needs: all
+  - type: logical
+    logical_operator: or
+    operands:
+    - type: subject
+      subject_needed_code: '1512'
+      subject_needed_name: DISEÑO LOGICO
+      needs: exam
+    - type: subject
+      subject_needed_code: '1322'
+      subject_needed_name: PROGRAMACION 1
+      needs: exam
+    - type: subject
+      subject_needed_code: '1373'
+      subject_needed_name: PROGRAMACION 1
+      needs: exam
+  subject_code: '1650'
+  is_exam: false
+- type: logical
+  logical_operator: and
+  operands:
+  - type: logical
+    logical_operator: not
+    operands:
+    - type: logical
+      logical_operator: or
+      operands:
+      - type: subject
+        subject_needed_code: 1610P
+        subject_needed_name: CREDITOS NO ACUM INT. A LA INVESTIGACION DE OPERACIONES
+        needs: exam
+      - type: subject
+        subject_needed_code: '1610'
+        subject_needed_name: INT. A LA INVESTIGACION DE OPERACIONES
+        needs: exam
+  - type: logical
+    logical_operator: or
+    operands:
+    - type: subject
+      subject_needed_code: '1610'
+      subject_needed_name: INT. A LA INVESTIGACION DE OPERACIONES
+      needs: course
+    - type: subject
+      subject_needed_code: '1650'
+      subject_needed_name: INT. A LA INVESTIGACIÓN DE OPERACIONES
+      needs: course
+  subject_code: '1650'
+  is_exam: true
+- type: logical
+  logical_operator: and
+  operands:
+  - type: logical
+    logical_operator: not
+    operands:
+    - type: logical
+      logical_operator: or
+      operands:
+      - type: subject
+        subject_needed_code: 1723R
+        subject_needed_name: CREDITOS ASIGNADOS POR REVALIDA
+        needs: all
+      - type: subject
+        subject_needed_code: '1701'
+        subject_needed_name: INT. A LA CIENCIA DE MATERIALES
+        needs: all
+  - type: credits
+    credits: 60
+  - type: logical
+    logical_operator: or
+    operands:
+    - type: subject
+      subject_needed_code: MAT33
+      subject_needed_name: CREDITOS ASIGNADOS POR REVALIDA
+      needs: all
+    - type: subject
+      subject_needed_code: 1030P
+      subject_needed_name: CREDITOS NO ACUM GAL1
+      needs: all
+    - type: subject
+      subject_needed_code: '1030'
+      subject_needed_name: GEOMETRIA Y ALGEBRA LINEAL 1
+      needs: all
+    - type: subject
+      subject_needed_code: '1071'
+      subject_needed_name: GEOMETRIA Y ALGEBRA LINEAL 1
+      needs: all
+    - type: subject
+      subject_needed_code: '1053'
+      subject_needed_name: GEOMETRIA Y ALGEBRA LINEAL 1 (ANUAL)
+      needs: all
+    - type: subject
+      subject_needed_code: GAL1P
+      subject_needed_name: GEOMETRIA Y ALGEBRA LINEAL 1 INTERACTIVA
+      needs: all
+  - type: logical
+    logical_operator: or
+    operands:
+    - type: subject
+      subject_needed_code: 1151P
+      subject_needed_name: CREDITOS NO ACUM FISICA 1
+      needs: all
+    - type: subject
+      subject_needed_code: '1120'
+      subject_needed_name: FISICA GENERAL 1
+      needs: all
+    - type: subject
+      subject_needed_code: '1170'
+      subject_needed_name: FISICA GENERAL 1
+      needs: all
+    - type: subject
+      subject_needed_code: '1151'
+      subject_needed_name: FISICA 1
+      needs: all
+    - type: subject
+      subject_needed_code: '1171'
+      subject_needed_name: FISICA 1
+      needs: all
+  - type: logical
+    logical_operator: or
+    operands:
+    - type: subject
+      subject_needed_code: 1152P
+      subject_needed_name: CREDITOS NO ACUM FISICA 2
+      needs: exam
+    - type: subject
+      subject_needed_code: '1152'
+      subject_needed_name: FISICA 2
+      needs: course
+  - type: logical
+    logical_operator: or
+    operands:
+    - type: subject
+      subject_needed_code: '1061'
+      subject_needed_name: CALCULO DIF. E INTEGRAL EN UNA VARIABLE
+      needs: all
+    - type: subject
+      subject_needed_code: '1020'
+      subject_needed_name: CALCULO 1
+      needs: all
+    - type: subject
+      subject_needed_code: '1070'
+      subject_needed_name: CALCULO 1
+      needs: all
+    - type: subject
+      subject_needed_code: '1052'
+      subject_needed_name: CALCULO 1 (ANUAL)
+      needs: all
+    - type: subject
+      subject_needed_code: MAT33
+      subject_needed_name: CREDITOS ASIGNADOS POR REVALIDA
+      needs: all
+    - type: subject
+      subject_needed_code: 1020P
+      subject_needed_name: CREDITOS NO ACUM CALCULO 1
+      needs: all
+    - type: subject
+      subject_needed_code: 1061P
+      subject_needed_name: CREDITOS NO ACUM CDIV
+      needs: all
+  subject_code: '1723'
+  is_exam: false
+- type: logical
+  logical_operator: and
+  operands:
+  - type: logical
+    logical_operator: not
+    operands:
+    - type: logical
+      logical_operator: or
+      operands:
+      - type: subject
+        subject_needed_code: 1723R
+        subject_needed_name: CREDITOS ASIGNADOS POR REVALIDA
+        needs: exam
+      - type: subject
+        subject_needed_code: '1701'
+        subject_needed_name: INT. A LA CIENCIA DE MATERIALES
+        needs: exam
+  - type: subject
+    needs: course
+    subject_needed_code: '1723'
+    subject_needed_name: INT. A LA CIENCIA DE MATERIALES
+  - type: logical
+    logical_operator: or
+    operands:
+    - type: subject
+      subject_needed_code: 1152P
+      subject_needed_name: CREDITOS NO ACUM FISICA 2
+      needs: all
+    - type: subject
+      subject_needed_code: '1152'
+      subject_needed_name: FISICA 2
+      needs: all
+  subject_code: '1723'
+  is_exam: true
+- type: logical
+  logical_operator: and
+  operands:
+  - type: credits
+    credits: 50
+    group: 12
+  - type: credits
+    credits: 50
+    group: 11
+  - type: subject
+    needs: exam
+    subject_needed_code: '1512'
+    subject_needed_name: DISEÑO LOGICO
+  - type: subject
+    needs: exam
+    subject_needed_code: '1373'
+    subject_needed_name: PROGRAMACION 1
+  - type: subject
+    needs: course
+    subject_needed_code: '1307'
+    subject_needed_name: PROGRAMACION PARA INGENIERIA ELECTRICA
+  subject_code: '1848'
+  is_exam: false
+- type: logical
+  logical_operator: and
+  operands:
+  - type: credits
+    credits: 100
+  - type: logical
+    logical_operator: or
+    operands:
+    - type: subject
+      subject_needed_code: 1322P
+      subject_needed_name: CREDITOS NO ACUM PROGRAMACION 1
+      needs: all
+    - type: subject
+      subject_needed_code: '1320'
+      subject_needed_name: PROGRAMACION 1
+      needs: all
+    - type: subject
+      subject_needed_code: '1322'
+      subject_needed_name: PROGRAMACION 1
+      needs: all
+    - type: subject
+      subject_needed_code: '1373'
+      subject_needed_name: PROGRAMACION 1
+      needs: all
+  subject_code: '1849'
+  is_exam: false
+- type: logical
+  logical_operator: and
+  operands:
+  - type: logical
+    logical_operator: not
+    operands:
+    - type: logical
+      logical_operator: or
+      operands:
+      - type: subject
+        subject_needed_code: '1849'
+        subject_needed_name: 'BUTIA: ROBOTICA EDUCATIVA'
+        needs: course
+      - type: subject
+        subject_needed_code: '1848'
+        subject_needed_name: ROBOTICA BASADA EN COMPORTAMIENTOS
+        needs: course
+      - type: subject
+        subject_needed_code: '1442'
+        subject_needed_name: ROBOTICA EMBEBIDA
+        needs: course
+  - type: credits
+    credits: 50
+    group: 11
+  - type: credits
+    credits: 50
+    group: 12
+  - type: subject
+    needs: exam
+    subject_needed_code: '1512'
+    subject_needed_name: DISEÑO LOGICO
+  - type: subject
+    needs: course
+    subject_needed_code: '1307'
+    subject_needed_name: PROGRAMACION PARA INGENIERIA ELECTRICA
+  - type: subject
+    needs: exam
+    subject_needed_code: '1373'
+    subject_needed_name: PROGRAMACION 1
+  subject_code: '1857'
+  is_exam: false
+- type: logical
+  logical_operator: and
+  operands:
+  - type: logical
+    logical_operator: or
+    operands:
+    - type: subject
+      subject_needed_code: CP1
+      subject_needed_name: ANALISIS MATEMATICO I
+      needs: all
+    - type: subject
+      subject_needed_code: CP22
+      subject_needed_name: ANALISIS MATEMATICO I (P. 74)
+      needs: all
+    - type: subject
+      subject_needed_code: '1062'
+      subject_needed_name: CALCULO DIF. E INTEGRAL EN VARIAS VARIABLES
+      needs: all
+    - type: subject
+      subject_needed_code: '1022'
+      subject_needed_name: CALCULO 2
+      needs: all
+    - type: subject
+      subject_needed_code: '1072'
+      subject_needed_name: CALCULO 2
+      needs: all
+    - type: subject
+      subject_needed_code: MAT33
+      subject_needed_name: CREDITOS ASIGNADOS POR REVALIDA
+      needs: all
+    - type: subject
+      subject_needed_code: 1062P
+      subject_needed_name: CREDITOS NO ACUM CDIVV
+      needs: all
+  - type: logical
+    logical_operator: or
+    operands:
+    - type: subject
+      subject_needed_code: '1021'
+      subject_needed_name: ALGEBRA LINEAL
+      needs: all
+    - type: subject
+      subject_needed_code: MAT33
+      subject_needed_name: CREDITOS ASIGNADOS POR REVALIDA
+      needs: all
+    - type: subject
+      subject_needed_code: MA09
+      subject_needed_name: CREDITOS ASIGNADOS POR REVALIDA
+      needs: all
+    - type: subject
+      subject_needed_code: M9
+      subject_needed_name: CREDITOS ASIGNADOS POR REVALIDA
+      needs: all
+    - type: subject
+      subject_needed_code: 1031P
+      subject_needed_name: CREDITOS NO ACUM GAL2
+      needs: all
+    - type: subject
+      subject_needed_code: CP2
+      subject_needed_name: GEOMETRIA Y ALGEBRA LINEAL
+      needs: all
+    - type: subject
+      subject_needed_code: R101
+      subject_needed_name: GEOMETRIA Y ALGEBRA LINEAL
+      needs: all
+    - type: subject
+      subject_needed_code: CP23
+      subject_needed_name: GEOMETRIA Y ALGEBRA LINEAL (P. 74)
+      needs: all
+    - type: subject
+      subject_needed_code: '1031'
+      subject_needed_name: GEOMETRIA Y ALGEBRA LINEAL 2
+      needs: all
+    - type: subject
+      subject_needed_code: '1058'
+      subject_needed_name: GEOMETRIA Y ALGEBRA LINEAL 2
+      needs: all
+  - type: logical
+    logical_operator: or
+    operands:
+    - type: subject
+      subject_needed_code: '1025'
+      subject_needed_name: PROBABILIDAD Y ESTADISTICA
+      needs: all
+    - type: subject
+      subject_needed_code: '1075'
+      subject_needed_name: PROBABILIDAD Y ESTADISTICA
+      needs: all
+    - type: subject
+      subject_needed_code: 125L
+      subject_needed_name: PROBABILIDAD Y ESTADISTICA
+      needs: all
+    - type: subject
+      subject_needed_code: 175Q
+      subject_needed_name: PROBABILIDAD Y ESTADISTICA
+      needs: all
+  subject_code: '1868'
+  is_exam: false
+- type: logical
+  logical_operator: and
+  operands:
+  - type: logical
+    logical_operator: or
+    operands:
+    - type: subject
+      subject_needed_code: '1025'
+      subject_needed_name: PROBABILIDAD Y ESTADISTICA
+      needs: all
+    - type: subject
+      subject_needed_code: '1075'
+      subject_needed_name: PROBABILIDAD Y ESTADISTICA
+      needs: all
+    - type: subject
+      subject_needed_code: 125L
+      subject_needed_name: PROBABILIDAD Y ESTADISTICA
+      needs: all
+    - type: subject
+      subject_needed_code: 175Q
+      subject_needed_name: PROBABILIDAD Y ESTADISTICA
+      needs: all
+  - type: logical
+    logical_operator: or
+    operands:
+    - type: subject
+      subject_needed_code: '1021'
+      subject_needed_name: ALGEBRA LINEAL
+      needs: all
+    - type: subject
+      subject_needed_code: MAT33
+      subject_needed_name: CREDITOS ASIGNADOS POR REVALIDA
+      needs: all
+    - type: subject
+      subject_needed_code: MA09
+      subject_needed_name: CREDITOS ASIGNADOS POR REVALIDA
+      needs: all
+    - type: subject
+      subject_needed_code: M9
+      subject_needed_name: CREDITOS ASIGNADOS POR REVALIDA
+      needs: all
+    - type: subject
+      subject_needed_code: 1031P
+      subject_needed_name: CREDITOS NO ACUM GAL2
+      needs: all
+    - type: subject
+      subject_needed_code: CP2
+      subject_needed_name: GEOMETRIA Y ALGEBRA LINEAL
+      needs: all
+    - type: subject
+      subject_needed_code: R101
+      subject_needed_name: GEOMETRIA Y ALGEBRA LINEAL
+      needs: all
+    - type: subject
+      subject_needed_code: CP23
+      subject_needed_name: GEOMETRIA Y ALGEBRA LINEAL (P. 74)
+      needs: all
+    - type: subject
+      subject_needed_code: '1031'
+      subject_needed_name: GEOMETRIA Y ALGEBRA LINEAL 2
+      needs: all
+    - type: subject
+      subject_needed_code: '1058'
+      subject_needed_name: GEOMETRIA Y ALGEBRA LINEAL 2
+      needs: all
+  - type: logical
+    logical_operator: or
+    operands:
+    - type: subject
+      subject_needed_code: CP1
+      subject_needed_name: ANALISIS MATEMATICO I
+      needs: all
+    - type: subject
+      subject_needed_code: CP22
+      subject_needed_name: ANALISIS MATEMATICO I (P. 74)
+      needs: all
+    - type: subject
+      subject_needed_code: '1062'
+      subject_needed_name: CALCULO DIF. E INTEGRAL EN VARIAS VARIABLES
+      needs: all
+    - type: subject
+      subject_needed_code: '1022'
+      subject_needed_name: CALCULO 2
+      needs: all
+    - type: subject
+      subject_needed_code: '1072'
+      subject_needed_name: CALCULO 2
+      needs: all
+    - type: subject
+      subject_needed_code: MAT33
+      subject_needed_name: CREDITOS ASIGNADOS POR REVALIDA
+      needs: all
+    - type: subject
+      subject_needed_code: 1062P
+      subject_needed_name: CREDITOS NO ACUM CDIVV
+      needs: all
+  subject_code: '1869'
+  is_exam: false
+- type: logical
+  logical_operator: and
+  operands:
+  - type: logical
+    logical_operator: or
+    operands:
+    - type: subject
+      subject_needed_code: 1322P
+      subject_needed_name: CREDITOS NO ACUM PROGRAMACION 1
+      needs: exam
+    - type: subject
+      subject_needed_code: '1320'
+      subject_needed_name: PROGRAMACION 1
+      needs: exam
+    - type: subject
+      subject_needed_code: '1322'
+      subject_needed_name: PROGRAMACION 1
+      needs: exam
+    - type: subject
+      subject_needed_code: 1322T
+      subject_needed_name: PROGRAMACION 1
+      needs: exam
+    - type: subject
+      subject_needed_code: '1373'
+      subject_needed_name: PROGRAMACION 1
+      needs: course
+  - type: logical
+    logical_operator: or
+    operands:
+    - type: subject
+      subject_needed_code: '1062'
+      subject_needed_name: CALCULO DIF. E INTEGRAL EN VARIAS VARIABLES
+      needs: all
+    - type: subject
+      subject_needed_code: '1022'
+      subject_needed_name: CALCULO 2
+      needs: all
+    - type: subject
+      subject_needed_code: '1072'
+      subject_needed_name: CALCULO 2
+      needs: all
+    - type: subject
+      subject_needed_code: MAT33
+      subject_needed_name: CREDITOS ASIGNADOS POR REVALIDA
+      needs: all
+    - type: subject
+      subject_needed_code: 1062P
+      subject_needed_name: CREDITOS NO ACUM CDIVV
+      needs: all
+  - type: logical
+    logical_operator: or
+    operands:
+    - type: subject
+      subject_needed_code: '1021'
+      subject_needed_name: ALGEBRA LINEAL
+      needs: all
+    - type: subject
+      subject_needed_code: MAT33
+      subject_needed_name: CREDITOS ASIGNADOS POR REVALIDA
+      needs: all
+    - type: subject
+      subject_needed_code: 1031P
+      subject_needed_name: CREDITOS NO ACUM GAL2
+      needs: all
+    - type: subject
+      subject_needed_code: '1031'
+      subject_needed_name: GEOMETRIA Y ALGEBRA LINEAL 2
+      needs: all
+    - type: subject
+      subject_needed_code: '1058'
+      subject_needed_name: GEOMETRIA Y ALGEBRA LINEAL 2
+      needs: all
+  subject_code: '1871'
+  is_exam: false
+- type: logical
+  logical_operator: and
+  operands:
+  - type: logical
+    logical_operator: or
+    operands:
+    - type: subject
+      subject_needed_code: MAT33
+      subject_needed_name: CREDITOS ASIGNADOS POR REVALIDA
+      needs: exam
+    - type: subject
+      subject_needed_code: 1031P
+      subject_needed_name: CREDITOS NO ACUM GAL2
+      needs: exam
+    - type: subject
+      subject_needed_code: '1031'
+      subject_needed_name: GEOMETRIA Y ALGEBRA LINEAL 2
+      needs: exam
+  - type: logical
+    logical_operator: or
+    operands:
+    - type: subject
+      subject_needed_code: '1061'
+      subject_needed_name: CALCULO DIF. E INTEGRAL EN UNA VARIABLE
+      needs: exam
+    - type: subject
+      subject_needed_code: CAL12
+      subject_needed_name: CREDITOS ASIGNADOS POR REVALIDA
+      needs: exam
+    - type: subject
+      subject_needed_code: M13
+      subject_needed_name: CREDITOS ASIGNADOS POR REVALIDA
+      needs: exam
+    - type: subject
+      subject_needed_code: 1020P
+      subject_needed_name: CREDITOS NO ACUM CALCULO 1
+      needs: exam
+    - type: subject
+      subject_needed_code: 1061P
+      subject_needed_name: CREDITOS NO ACUM CDIV
+      needs: exam
+  subject_code: '1872'
+  is_exam: false
+- type: logical
+  logical_operator: and
+  operands:
+  - type: subject
+    needs: course
+    subject_needed_code: '1872'
+    subject_needed_name: APLICACIONES DEL ALGEBRA LINEAL
+  subject_code: '1872'
+  is_exam: true
+- type: logical
+  logical_operator: and
+  operands:
+  - type: logical
+    logical_operator: or
+    operands:
+    - type: subject
+      subject_needed_code: '1061'
+      subject_needed_name: CALCULO DIF. E INTEGRAL EN UNA VARIABLE
+      needs: exam
+    - type: subject
+      subject_needed_code: 1061I
+      subject_needed_name: CALCULO DIF. E INTEGRAL EN UNA VARIABLE
+      needs: exam
+    - type: subject
+      subject_needed_code: 1061R
+      subject_needed_name: CALCULO DIF. E INTEGRAL EN UNA VARIABLE
+      needs: exam
+    - type: subject
+      subject_needed_code: '1020'
+      subject_needed_name: CALCULO 1
+      needs: exam
+    - type: subject
+      subject_needed_code: '1070'
+      subject_needed_name: CALCULO 1
+      needs: exam
+    - type: subject
+      subject_needed_code: '1052'
+      subject_needed_name: CALCULO 1 (ANUAL)
+      needs: exam
+    - type: subject
+      subject_needed_code: 1061P
+      subject_needed_name: CREDITOS NO ACUM CDIV
+      needs: exam
+  - type: logical
+    logical_operator: or
+    operands:
+    - type: subject
+      subject_needed_code: 1064P
+      subject_needed_name: CREDITOS NO ACUM INT. A LAS ECUACIONES DIFERENCIALES
+      needs: exam
+    - type: subject
+      subject_needed_code: '1028'
+      subject_needed_name: ECUACIONES DIFERENCIALES
+      needs: course
+    - type: subject
+      subject_needed_code: '1074'
+      subject_needed_name: ECUACIONES DIFERENCIALES
+      needs: exam
+    - type: subject
+      subject_needed_code: 174Q
+      subject_needed_name: ECUACIONES DIFERENCIALES
+      needs: exam
+    - type: subject
+      subject_needed_code: '1064'
+      subject_needed_name: INT. A LAS ECUACIONES DIFERENCIALES
+      needs: course
+  - type: logical
+    logical_operator: or
+    operands:
+    - type: subject
+      subject_needed_code: 1031P
+      subject_needed_name: CREDITOS NO ACUM GAL2
+      needs: exam
+    - type: subject
+      subject_needed_code: '1031'
+      subject_needed_name: GEOMETRIA Y ALGEBRA LINEAL 2
+      needs: exam
+    - type: subject
+      subject_needed_code: '1058'
+      subject_needed_name: GEOMETRIA Y ALGEBRA LINEAL 2
+      needs: exam
+    - type: subject
+      subject_needed_code: 158Q
+      subject_needed_name: GEOMETRIA Y ALGEBRA LINEAL 2
+      needs: exam
+  - type: logical
+    logical_operator: or
+    operands:
+    - type: subject
+      subject_needed_code: '1062'
+      subject_needed_name: CALCULO DIF. E INTEGRAL EN VARIAS VARIABLES
+      needs: course
+    - type: subject
+      subject_needed_code: '1022'
+      subject_needed_name: CALCULO 2
+      needs: course
+    - type: subject
+      subject_needed_code: '1072'
+      subject_needed_name: CALCULO 2
+      needs: exam
+    - type: subject
+      subject_needed_code: 108L
+      subject_needed_name: CALCULO 2
+      needs: exam
+    - type: subject
+      subject_needed_code: 172Q
+      subject_needed_name: CALCULO 2
+      needs: exam
+    - type: subject
+      subject_needed_code: 1022P
+      subject_needed_name: CREDITOS NO ACUM CALCULO 2
+      needs: exam
+    - type: subject
+      subject_needed_code: 1062P
+      subject_needed_name: CREDITOS NO ACUM CDIVV
+      needs: exam
+    - type: subject
+      subject_needed_code: 1022T
+      subject_needed_name: CREDITOS POR CALCULO 2
+      needs: exam
+  subject_code: '1886'
+  is_exam: false
+- type: logical
+  logical_operator: and
+  operands:
+  - type: logical
+    logical_operator: or
+    operands:
+    - type: subject
+      subject_needed_code: '1322'
+      subject_needed_name: PROGRAMACION 1
+      needs: exam
+    - type: subject
+      subject_needed_code: '1373'
+      subject_needed_name: PROGRAMACION 1
+      needs: exam
+  - type: logical
+    logical_operator: or
+    operands:
+    - type: subject
+      subject_needed_code: '1307'
+      subject_needed_name: PROGRAMACION PARA INGENIERIA ELECTRICA
+      needs: course
+    - type: subject
+      subject_needed_code: '1321'
+      subject_needed_name: PROGRAMACION 2
+      needs: exam
+  subject_code: '1892'
+  is_exam: false
+- type: logical
+  logical_operator: and
+  operands:
+  - type: subject
+    needs: course
+    subject_needed_code: '1892'
+    subject_needed_name: BASES DE DATOS PARA INGENIERÍA
+  subject_code: '1892'
+  is_exam: true
+- type: logical
+  logical_operator: and
+  operands:
+  - type: logical
+    logical_operator: not
+    operands:
+    - type: subject
+      needs: course
+      subject_needed_code: '1011'
+      subject_needed_name: TEORIA DE CODIGOS AVANZADO
+  - type: logical
+    logical_operator: or
+    operands:
+    - type: subject
+      subject_needed_code: '2415'
+      subject_needed_name: CODIGOS PARA CORRECCION DE ERRORES
+      needs: course
+    - type: subject
+      subject_needed_code: '1042'
+      subject_needed_name: TEORIA DE COD. ALGEB. PARA CORR. DE ERRORES
+      needs: course
+    - type: subject
+      subject_needed_code: '1065'
+      subject_needed_name: TEORIA DE COD. ALGEB. PARA CORR. DE ERRORES
+      needs: course
+    - type: subject
+      subject_needed_code: '1046'
+      subject_needed_name: TEORIA DE CODIGOS
+      needs: course
+  subject_code: '1899'
+  is_exam: false
+- type: logical
+  logical_operator: and
+  operands:
+  - type: subject
+    needs: exam
+    subject_needed_code: '1512'
+    subject_needed_name: DISEÑO LOGICO
+  - type: logical
+    logical_operator: or
+    operands:
+    - type: subject
+      subject_needed_code: '1061'
+      subject_needed_name: CALCULO DIF. E INTEGRAL EN UNA VARIABLE
+      needs: all
+    - type: subject
+      subject_needed_code: '1020'
+      subject_needed_name: CALCULO 1
+      needs: all
+    - type: subject
+      subject_needed_code: '1070'
+      subject_needed_name: CALCULO 1
+      needs: all
+    - type: subject
+      subject_needed_code: '1052'
+      subject_needed_name: CALCULO 1 (ANUAL)
+      needs: all
+    - type: subject
+      subject_needed_code: MAT33
+      subject_needed_name: CREDITOS ASIGNADOS POR REVALIDA
+      needs: all
+    - type: subject
+      subject_needed_code: 1020P
+      subject_needed_name: CREDITOS NO ACUM CALCULO 1
+      needs: all
+    - type: subject
+      subject_needed_code: 1061P
+      subject_needed_name: CREDITOS NO ACUM CDIV
+      needs: all
+  - type: logical
+    logical_operator: or
+    operands:
+    - type: subject
+      subject_needed_code: '1320'
+      subject_needed_name: PROGRAMACION 1
+      needs: exam
+    - type: subject
+      subject_needed_code: '1322'
+      subject_needed_name: PROGRAMACION 1
+      needs: exam
+    - type: subject
+      subject_needed_code: '1373'
+      subject_needed_name: PROGRAMACION 1
+      needs: exam
+  - type: logical
+    logical_operator: or
+    operands:
+    - type: subject
+      subject_needed_code: MAT33
+      subject_needed_name: CREDITOS ASIGNADOS POR REVALIDA
+      needs: all
+    - type: subject
+      subject_needed_code: 1030P
+      subject_needed_name: CREDITOS NO ACUM GAL1
+      needs: all
+    - type: subject
+      subject_needed_code: '1030'
+      subject_needed_name: GEOMETRIA Y ALGEBRA LINEAL 1
+      needs: all
+    - type: subject
+      subject_needed_code: '1071'
+      subject_needed_name: GEOMETRIA Y ALGEBRA LINEAL 1
+      needs: all
+    - type: subject
+      subject_needed_code: '1053'
+      subject_needed_name: GEOMETRIA Y ALGEBRA LINEAL 1 (ANUAL)
+      needs: all
+    - type: subject
+      subject_needed_code: GAL1P
+      subject_needed_name: GEOMETRIA Y ALGEBRA LINEAL 1 INTERACTIVA
+      needs: all
+  subject_code: '1911'
+  is_exam: false
+- type: logical
+  logical_operator: and
+  operands:
+  - type: subject
+    needs: course
+    subject_needed_code: '1911'
+    subject_needed_name: FUNDAMENTOS DE BASES DE DATOS
+  subject_code: '1911'
+  is_exam: true
+- type: logical
+  logical_operator: and
+  operands:
+  - type: logical
+    logical_operator: not
+    operands:
+    - type: subject
+      needs: all
+      subject_needed_code: '1902'
+      subject_needed_name: INT. A LA INGENIERIA INDUSTRIAL
+  - type: credits
+    credits: 120
+  subject_code: '1912'
+  is_exam: false
+- type: logical
+  logical_operator: and
+  operands:
+  - type: subject
+    needs: course
+    subject_needed_code: '1912'
+    subject_needed_name: INT. A LA INGENIERIA INDUSTRIAL
+  subject_code: '1912'
+  is_exam: true
+- type: logical
+  logical_operator: and
+  operands:
+  - type: logical
+    logical_operator: or
+    operands:
+    - type: subject
+      subject_needed_code: '1510'
+      subject_needed_name: CONTROL DE CALIDAD
+      needs: course
+    - type: subject
+      subject_needed_code: '1901'
+      subject_needed_name: CONTROL DE CALIDAD
+      needs: exam
+  subject_code: '1920'
+  is_exam: false
+- type: logical
+  logical_operator: and
+  operands:
+  - type: subject
+    needs: course
+    subject_needed_code: '1920'
+    subject_needed_name: GESTION DE MANTENIMIENTO
+  subject_code: '1920'
+  is_exam: true
+- type: logical
+  logical_operator: and
+  operands:
+  - type: logical
+    logical_operator: not
+    operands:
+    - type: subject
+      needs: all
+      subject_needed_code: '1903'
+      subject_needed_name: COSTOS PARA INGENIERIA
+  - type: credits
+    credits: 130
+  subject_code: '1922'
+  is_exam: false
+- type: logical
+  logical_operator: and
+  operands:
+  - type: logical
+    logical_operator: not
+    operands:
+    - type: subject
+      needs: exam
+      subject_needed_code: '1903'
+      subject_needed_name: COSTOS PARA INGENIERIA
+  - type: logical
+    logical_operator: or
+    operands:
+    - type: credits
+      credits: 130
+    - type: subject
+      needs: course
+      subject_needed_code: '1922'
+      subject_needed_name: COSTOS PARA INGENIERIA
+  subject_code: '1922'
+  is_exam: true
+- type: logical
+  logical_operator: and
+  operands:
+  - type: credits
+    credits: 150
+  subject_code: '1944'
+  is_exam: false
+- type: logical
+  logical_operator: and
+  operands:
+  - type: credits
+    credits: 150
+  subject_code: '1944'
+  is_exam: true
+- type: logical
+  logical_operator: and
+  operands:
+  - type: logical
+    logical_operator: not
+    operands:
+    - type: logical
+      logical_operator: or
+      operands:
+      - type: subject
+        subject_needed_code: '2241'
+        subject_needed_name: ADMINISTRACION DE EMPRESAS
+        needs: all
+      - type: subject
+        subject_needed_code: '1519'
+        subject_needed_name: INT. A LA ADMINISTRACION PARA INGENIEROS
+        needs: all
+      - type: subject
+        subject_needed_code: '1930'
+        subject_needed_name: ORGANIZACIONES PARA INGENIEROS
+        needs: all
+  - type: subject
+    needs: course
+    subject_needed_code: '1944'
+    subject_needed_name: ADMINISTRACION GENERAL PARA INGENIEROS
+  subject_code: '1945'
+  is_exam: false
+- type: logical
+  logical_operator: and
+  operands:
+  - type: logical
+    logical_operator: not
+    operands:
+    - type: logical
+      logical_operator: or
+      operands:
+      - type: subject
+        subject_needed_code: '2241'
+        subject_needed_name: ADMINISTRACION DE EMPRESAS
+        needs: all
+      - type: subject
+        subject_needed_code: '1519'
+        subject_needed_name: INT. A LA ADMINISTRACION PARA INGENIEROS
+        needs: all
+      - type: subject
+        subject_needed_code: '1930'
+        subject_needed_name: ORGANIZACIONES PARA INGENIEROS
+        needs: all
+  - type: subject
+    needs: exam
+    subject_needed_code: '1944'
+    subject_needed_name: ADMINISTRACION GENERAL PARA INGENIEROS
+  subject_code: '1945'
+  is_exam: true
+- type: logical
+  logical_operator: not
+  operands:
+  - type: subject
+    needs: all
+    subject_needed_code: 2011P
+    subject_needed_name: CREDITOS NO ACUM PASANTIA
+  subject_code: '2011'
+  is_exam: false
+- type: logical
+  logical_operator: and
+  operands:
+  - type: credits
+    credits: 280
+  - type: credits
+    credits: 60
+    group: 12
+  - type: credits
+    credits: 10
+    group: 26
+  - type: credits
+    credits: 30
+    group: 21
+  - type: credits
+    credits: 90
+    group: 11
+  - type: credits
+    credits: 10
+    group: 22
+  subject_code: '2013'
+  is_exam: false
+- type: logical
+  logical_operator: and
+  operands:
+  - type: subject
+    needs: course
+    subject_needed_code: '2013'
+    subject_needed_name: PROYECTO (ING.ELEC.)
+  subject_code: '2013'
+  is_exam: true
+- type: logical
+  logical_operator: and
+  operands:
+  - type: credits
+    credits: 60
+  subject_code: '2018'
+  is_exam: false
+- type: logical
+  logical_operator: and
+  operands:
+  - type: credits
+    credits: 60
+  subject_code: '2020'
+  is_exam: false
+- type: logical
+  logical_operator: and
+  operands:
+  - type: credits
+    credits: 60
+  subject_code: '2021'
+  is_exam: false
+- type: logical
+  logical_operator: and
+  operands:
+  - type: credits
+    credits: 60
+  subject_code: '2022'
+  is_exam: false
+- type: logical
+  logical_operator: and
+  operands:
+  - type: subject
+    needs: all
+    subject_needed_code: '2216'
+    subject_needed_name: TUTORIAS ENTRE PARES 1
+  subject_code: '2217'
+  is_exam: false
+- type: logical
+  logical_operator: and
+  operands:
+  - type: subject
+    needs: course
+    subject_needed_code: '5508'
+    subject_needed_name: REDES ELECTRICAS
+  - type: subject
+    needs: course
+    subject_needed_code: '1033'
+    subject_needed_name: METODOS NUMERICOS
+  - type: logical
+    logical_operator: or
+    operands:
+    - type: subject
+      subject_needed_code: '5850'
+      subject_needed_name: ELECTROTECNICA
+      needs: course
+    - type: subject
+      subject_needed_code: '5830'
+      subject_needed_name: INT. A LA ELECTROTECNICA
+      needs: exam
+  - type: logical
+    logical_operator: or
+    operands:
+    - type: subject
+      subject_needed_code: 1028P
+      subject_needed_name: CREDITOS NO ACUM EC. DIFERENCIALES
+      needs: exam
+    - type: subject
+      subject_needed_code: 1064P
+      subject_needed_name: CREDITOS NO ACUM INT. A LAS ECUACIONES DIFERENCIALES
+      needs: exam
+    - type: subject
+      subject_needed_code: '1028'
+      subject_needed_name: ECUACIONES DIFERENCIALES
+      needs: exam
+    - type: subject
+      subject_needed_code: '1074'
+      subject_needed_name: ECUACIONES DIFERENCIALES
+      needs: exam
+    - type: subject
+      subject_needed_code: '1064'
+      subject_needed_name: INT. A LAS ECUACIONES DIFERENCIALES
+      needs: course
+  subject_code: '2314'
+  is_exam: false
+- type: logical
+  logical_operator: and
+  operands:
+  - type: subject
+    needs: course
+    subject_needed_code: '1307'
+    subject_needed_name: PROGRAMACION PARA INGENIERIA ELECTRICA
+  - type: subject
+    needs: exam
+    subject_needed_code: '1373'
+    subject_needed_name: PROGRAMACION 1
+  subject_code: '2413'
+  is_exam: false
+- type: logical
+  logical_operator: and
+  operands:
+  - type: logical
+    logical_operator: not
+    operands:
+    - type: logical
+      logical_operator: or
+      operands:
+      - type: subject
+        subject_needed_code: '1042'
+        subject_needed_name: TEORIA DE COD. ALGEB. PARA CORR. DE ERRORES
+        needs: course
+      - type: subject
+        subject_needed_code: '1065'
+        subject_needed_name: TEORIA DE COD. ALGEB. PARA CORR. DE ERRORES
+        needs: course
+  - type: subject
+    needs: exam
+    subject_needed_code: '1512'
+    subject_needed_name: DISEÑO LOGICO
+  - type: logical
+    logical_operator: or
+    operands:
+    - type: subject
+      subject_needed_code: '1061'
+      subject_needed_name: CALCULO DIF. E INTEGRAL EN UNA VARIABLE
+      needs: exam
+    - type: subject
+      subject_needed_code: 1020P
+      subject_needed_name: CREDITOS NO ACUM CALCULO 1
+      needs: exam
+    - type: subject
+      subject_needed_code: 1061P
+      subject_needed_name: CREDITOS NO ACUM CDIV
+      needs: exam
+  - type: logical
+    logical_operator: or
+    operands:
+    - type: subject
+      subject_needed_code: 1025P
+      subject_needed_name: CREDITOS NO ACUM PROB Y EST.
+      needs: exam
+    - type: subject
+      subject_needed_code: '1025'
+      subject_needed_name: PROBABILIDAD Y ESTADISTICA
+      needs: course
+    - type: subject
+      subject_needed_code: '1075'
+      subject_needed_name: PROBABILIDAD Y ESTADISTICA
+      needs: exam
+  - type: logical
+    logical_operator: or
+    operands:
+    - type: subject
+      subject_needed_code: 1322P
+      subject_needed_name: CREDITOS NO ACUM PROGRAMACION 1
+      needs: exam
+    - type: subject
+      subject_needed_code: 1322T
+      subject_needed_name: PROGRAMACION 1
+      needs: exam
+    - type: subject
+      subject_needed_code: '1373'
+      subject_needed_name: PROGRAMACION 1
+      needs: course
+  - type: logical
+    logical_operator: or
+    operands:
+    - type: subject
+      subject_needed_code: 1030P
+      subject_needed_name: CREDITOS NO ACUM GAL1
+      needs: exam
+    - type: subject
+      subject_needed_code: '1030'
+      subject_needed_name: GEOMETRIA Y ALGEBRA LINEAL 1
+      needs: exam
+    - type: subject
+      subject_needed_code: GAL1P
+      subject_needed_name: GEOMETRIA Y ALGEBRA LINEAL 1 INTERACTIVA
+      needs: exam
+  - type: logical
+    logical_operator: or
+    operands:
+    - type: subject
+      subject_needed_code: '1307'
+      subject_needed_name: PROGRAMACION PARA INGENIERIA ELECTRICA
+      needs: course
+    - type: subject
+      subject_needed_code: '1321'
+      subject_needed_name: PROGRAMACION 2
+      needs: exam
+  - type: logical
+    logical_operator: or
+    operands:
+    - type: subject
+      subject_needed_code: '1062'
+      subject_needed_name: CALCULO DIF. E INTEGRAL EN VARIAS VARIABLES
+      needs: exam
+    - type: subject
+      subject_needed_code: '1022'
+      subject_needed_name: CALCULO 2
+      needs: exam
+    - type: subject
+      subject_needed_code: 1062P
+      subject_needed_name: CREDITOS NO ACUM CDIVV
+      needs: exam
+  subject_code: '2415'
+  is_exam: false
+- type: logical
+  logical_operator: and
+  operands:
+  - type: subject
+    needs: exam
+    subject_needed_code: '1373'
+    subject_needed_name: PROGRAMACION 1
+  - type: subject
+    needs: course
+    subject_needed_code: '1307'
+    subject_needed_name: PROGRAMACION PARA INGENIERIA ELECTRICA
+  subject_code: '2422'
+  is_exam: false
+- type: logical
+  logical_operator: and
+  operands:
+  - type: logical
+    logical_operator: not
+    operands:
+    - type: subject
+      needs: exam
+      subject_needed_code: '2704'
+      subject_needed_name: INSTRUMENTACION INDUSTRIAL
+  - type: logical
+    logical_operator: or
+    operands:
+    - type: logical
+      logical_operator: and
+      operands:
+      - type: credits
+        credits: 45
+        group: 12
+      - type: subject
+        needs: course
+        subject_needed_code: '5900'
+        subject_needed_name: INT. A LA TEORIA DE CONTROL
+      - type: logical
+        logical_operator: or
+        operands:
+        - type: subject
+          subject_needed_code: '1423'
+          subject_needed_name: SISTEMAS LINEALES 1
+          needs: exam
+        - type: subject
+          subject_needed_code: '1407'
+          subject_needed_name: SISTEMAS LINEALES 2
+          needs: exam
+    - type: logical
+      logical_operator: and
+      operands:
+      - type: credits
+        credits: 15
+        group: 21
+      - type: credits
+        credits: 45
+        group: 12
+      - type: subject
+        needs: exam
+        subject_needed_code: '1456'
+        subject_needed_name: TEORIA DE CIRCUITOS
+      - type: subject
+        needs: course
+        subject_needed_code: '5905'
+        subject_needed_name: SISTEMAS Y CONTROL
+  subject_code: '2706'
+  is_exam: false
+- type: logical
+  logical_operator: and
+  operands:
+  - type: logical
+    logical_operator: not
+    operands:
+    - type: subject
+      needs: exam
+      subject_needed_code: '2704'
+      subject_needed_name: INSTRUMENTACION INDUSTRIAL
+  - type: logical
+    logical_operator: or
+    operands:
+    - type: logical
+      logical_operator: and
+      operands:
+      - type: credits
+        credits: 45
+        group: 12
+      - type: credits
+        credits: 15
+        group: 21
+      - type: subject
+        needs: exam
+        subject_needed_code: '1456'
+        subject_needed_name: TEORIA DE CIRCUITOS
+      - type: subject
+        needs: course
+        subject_needed_code: '5905'
+        subject_needed_name: SISTEMAS Y CONTROL
+    - type: logical
+      logical_operator: and
+      operands:
+      - type: credits
+        credits: 45
+        group: 12
+      - type: subject
+        needs: course
+        subject_needed_code: '5900'
+        subject_needed_name: INT. A LA TEORIA DE CONTROL
+      - type: logical
+        logical_operator: or
+        operands:
+        - type: subject
+          subject_needed_code: '1423'
+          subject_needed_name: SISTEMAS LINEALES 1
+          needs: exam
+        - type: subject
+          subject_needed_code: '1407'
+          subject_needed_name: SISTEMAS LINEALES 2
+          needs: exam
+    - type: subject
+      needs: course
+      subject_needed_code: '2706'
+      subject_needed_name: INSTRUMENTACION INDUSTRIAL
+  subject_code: '2706'
+  is_exam: true
+- type: logical
+  logical_operator: and
+  operands:
+  - type: credits
+    credits: 250
+  subject_code: '2907'
+  is_exam: false
+- type: logical
+  logical_operator: and
+  operands:
+  - type: logical
+    logical_operator: not
+    operands:
+    - type: subject
+      needs: all
+      subject_needed_code: '3333'
+      subject_needed_name: FUNDAMENTOS DE ING. DE SOFT. PARA PROD. IND.
+  - type: credits
+    credits: 270
+  - type: logical
+    logical_operator: or
+    operands:
+    - type: subject
+      subject_needed_code: 1322P
+      subject_needed_name: CREDITOS NO ACUM PROGRAMACION 1
+      needs: all
+    - type: subject
+      subject_needed_code: '1322'
+      subject_needed_name: PROGRAMACION 1
+      needs: all
+    - type: subject
+      subject_needed_code: '1373'
+      subject_needed_name: PROGRAMACION 1
+      needs: all
+  subject_code: '3334'
+  is_exam: false
+- type: logical
+  logical_operator: and
+  operands:
+  - type: logical
+    logical_operator: not
+    operands:
+    - type: subject
+      needs: all
+      subject_needed_code: '2217'
+      subject_needed_name: TUTORIAS ENTRE PARES 2
+  - type: logical
+    logical_operator: not
+    operands:
+    - type: subject
+      needs: all
+      subject_needed_code: '2216'
+      subject_needed_name: TUTORIAS ENTRE PARES 1
+  - type: logical
+    logical_operator: or
+    operands:
+    - type: subject
+      needs: exam_activity
+      subject_needed_code: '1151'
+      subject_needed_name: FISICA 1
+    - type: logical
+      logical_operator: and
+      operands:
+      - type: subject
+        subject_needed_code: '1030'
+        subject_needed_name: GEOMETRIA Y ALGEBRA LINEAL 1
+        needs: exam
+      - type: subject
+        subject_needed_code: '1031'
+        subject_needed_name: GEOMETRIA Y ALGEBRA LINEAL 2
+        needs: course
+    - type: logical
+      logical_operator: and
+      operands:
+      - type: subject
+        subject_needed_code: '1061'
+        subject_needed_name: CALCULO DIF. E INTEGRAL EN UNA VARIABLE
+        needs: exam
+      - type: subject
+        subject_needed_code: '1062'
+        subject_needed_name: CALCULO DIF. E INTEGRAL EN VARIAS VARIABLES
+        needs: course
+  - type: credits
+    credits: 55
+  subject_code: '5005'
+  is_exam: false
+- type: logical
+  logical_operator: and
+  operands:
+  - type: logical
+    logical_operator: not
+    operands:
+    - type: subject
+      needs: course
+      subject_needed_code: '5511'
+      subject_needed_name: PROYECTO DE INSTALACIONES ELECTRICAS DE BAJA Y MEDIA TENSION
+  - type: logical
+    logical_operator: or
+    operands:
+    - type: subject
+      subject_needed_code: '5503'
+      subject_needed_name: INSTALACIONES ELECTRICAS
+      needs: exam
+    - type: subject
+      subject_needed_code: '5507'
+      subject_needed_name: INSTALACIONES ELECTRICAS
+      needs: exam
+  subject_code: '5504'
+  is_exam: false
+- type: logical
+  logical_operator: and
+  operands:
+  - type: logical
+    logical_operator: not
+    operands:
+    - type: logical
+      logical_operator: or
+      operands:
+      - type: subject
+        subject_needed_code: INS18
+        subject_needed_name: CREDITOS ASIGNADOS POR REVALIDA
+        needs: exam
+      - type: subject
+        subject_needed_code: CP148
+        subject_needed_name: INSTALACIONES ELECTRICAS
+        needs: exam
+      - type: subject
+        subject_needed_code: '5503'
+        subject_needed_name: INSTALACIONES ELECTRICAS
+        needs: exam
+  - type: logical
+    logical_operator: or
+    operands:
+    - type: subject
+      subject_needed_code: '5850'
+      subject_needed_name: ELECTROTECNICA
+      needs: course
+    - type: subject
+      subject_needed_code: '5601'
+      subject_needed_name: INT. A LA ELECTROTECNICA
+      needs: exam
+    - type: subject
+      subject_needed_code: '5608'
+      subject_needed_name: INT. A LA ELECTROTECNICA
+      needs: exam
+    - type: subject
+      subject_needed_code: '5830'
+      subject_needed_name: INT. A LA ELECTROTECNICA
+      needs: exam
+  subject_code: '5507'
+  is_exam: false
+- type: logical
+  logical_operator: and
+  operands:
+  - type: logical
+    logical_operator: not
+    operands:
+    - type: logical
+      logical_operator: or
+      operands:
+      - type: subject
+        subject_needed_code: INS18
+        subject_needed_name: CREDITOS ASIGNADOS POR REVALIDA
+        needs: exam
+      - type: subject
+        subject_needed_code: CP148
+        subject_needed_name: INSTALACIONES ELECTRICAS
+        needs: exam
+      - type: subject
+        subject_needed_code: '5503'
+        subject_needed_name: INSTALACIONES ELECTRICAS
+        needs: exam
+  - type: logical
+    logical_operator: or
+    operands:
+    - type: subject
+      needs: course
+      subject_needed_code: '5507'
+      subject_needed_name: INSTALACIONES ELECTRICAS
+    - type: logical
+      logical_operator: or
+      operands:
+      - type: subject
+        subject_needed_code: '5850'
+        subject_needed_name: ELECTROTECNICA
+        needs: course
+      - type: subject
+        subject_needed_code: '5601'
+        subject_needed_name: INT. A LA ELECTROTECNICA
+        needs: exam
+      - type: subject
+        subject_needed_code: '5608'
+        subject_needed_name: INT. A LA ELECTROTECNICA
+        needs: exam
+      - type: subject
+        subject_needed_code: '5830'
+        subject_needed_name: INT. A LA ELECTROTECNICA
+        needs: exam
+  subject_code: '5507'
+  is_exam: true
+- type: logical
+  logical_operator: and
+  operands:
+  - type: logical
+    logical_operator: not
+    operands:
+    - type: logical
+      logical_operator: or
+      operands:
+      - type: subject
+        subject_needed_code: INS18
+        subject_needed_name: CREDITOS ASIGNADOS POR REVALIDA
+        needs: exam
+      - type: subject
+        subject_needed_code: CP74
+        subject_needed_name: REDES ELECTRICAS I
+        needs: exam
+  - type: logical
+    logical_operator: or
+    operands:
+    - type: subject
+      needs: exam
+      subject_needed_code: '1456'
+      subject_needed_name: TEORIA DE CIRCUITOS
+    - type: logical
+      logical_operator: or
+      operands:
+      - type: subject
+        subject_needed_code: '1401'
+        subject_needed_name: SISTEMAS LINEALES 1
+        needs: exam
+      - type: subject
+        subject_needed_code: '1423'
+        subject_needed_name: SISTEMAS LINEALES 1
+        needs: exam
+      - type: subject
+        subject_needed_code: '1407'
+        subject_needed_name: SISTEMAS LINEALES 2
+        needs: exam
+  - type: logical
+    logical_operator: or
+    operands:
+    - type: subject
+      subject_needed_code: '5850'
+      subject_needed_name: ELECTROTECNICA
+      needs: course
+    - type: subject
+      subject_needed_code: '5830'
+      subject_needed_name: INT. A LA ELECTROTECNICA
+      needs: exam
+  subject_code: '5508'
+  is_exam: false
+- type: logical
+  logical_operator: and
+  operands:
+  - type: subject
+    needs: course
+    subject_needed_code: '5508'
+    subject_needed_name: REDES ELECTRICAS
+  subject_code: '5508'
+  is_exam: true
+- type: logical
+  logical_operator: and
+  operands:
+  - type: logical
+    logical_operator: or
+    operands:
+    - type: subject
+      subject_needed_code: '5508'
+      subject_needed_name: REDES ELECTRICAS
+      needs: course
+    - type: subject
+      subject_needed_code: '5502'
+      subject_needed_name: REDES ELECTRICAS 2
+      needs: exam
+  - type: logical
+    logical_operator: or
+    operands:
+    - type: subject
+      subject_needed_code: '5503'
+      subject_needed_name: INSTALACIONES ELECTRICAS
+      needs: exam
+    - type: subject
+      subject_needed_code: '5507'
+      subject_needed_name: INSTALACIONES ELECTRICAS
+      needs: course
+  - type: logical
+    logical_operator: or
+    operands:
+    - type: subject
+      subject_needed_code: '5508'
+      subject_needed_name: REDES ELECTRICAS
+      needs: course
+    - type: subject
+      subject_needed_code: '5501'
+      subject_needed_name: REDES ELECTRICAS 1
+      needs: exam
+  subject_code: '5510'
+  is_exam: false
+- type: logical
+  logical_operator: and
+  operands:
+  - type: logical
+    logical_operator: not
+    operands:
+    - type: subject
+      needs: all
+      subject_needed_code: '5504'
+      subject_needed_name: PROYECTO DE INSTALACIONES ELECTRICAS
+  - type: subject
+    needs: course
+    subject_needed_code: '5514'
+    subject_needed_name: SUBESTACIONES EN MEDIA TENSION
+  - type: subject
+    needs: exam
+    subject_needed_code: '5507'
+    subject_needed_name: INSTALACIONES ELECTRICAS
+  subject_code: '5511'
+  is_exam: false
+- type: logical
+  logical_operator: and
+  operands:
+  - type: subject
+    needs: exam
+    subject_needed_code: '5850'
+    subject_needed_name: ELECTROTECNICA
+  - type: subject
+    needs: course
+    subject_needed_code: '5508'
+    subject_needed_name: REDES ELECTRICAS
+  - type: subject
+    needs: course
+    subject_needed_code: '5507'
+    subject_needed_name: INSTALACIONES ELECTRICAS
+  subject_code: '5514'
+  is_exam: false
+- type: logical
+  logical_operator: or
+  operands:
+  - type: logical
+    logical_operator: and
+    operands:
+    - type: subject
+      needs: course
+      subject_needed_code: '5508'
+      subject_needed_name: REDES ELECTRICAS
+    - type: subject
+      needs: exam
+      subject_needed_code: '5850'
+      subject_needed_name: ELECTROTECNICA
+    - type: subject
+      needs: course
+      subject_needed_code: '5507'
+      subject_needed_name: INSTALACIONES ELECTRICAS
+  - type: subject
+    needs: course
+    subject_needed_code: '5514'
+    subject_needed_name: SUBESTACIONES EN MEDIA TENSION
+  subject_code: '5514'
+  is_exam: true
+- type: logical
+  logical_operator: and
+  operands:
+  - type: credits
+    credits: 18
+    group: 34
+  subject_code: '5517'
+  is_exam: false
+- type: logical
+  logical_operator: and
+  operands:
+  - type: logical
+    logical_operator: or
+    operands:
+    - type: subject
+      subject_needed_code: '5850'
+      subject_needed_name: ELECTROTECNICA
+      needs: exam
+    - type: subject
+      subject_needed_code: '5601'
+      subject_needed_name: INT. A LA ELECTROTECNICA
+      needs: exam
+    - type: subject
+      subject_needed_code: '5608'
+      subject_needed_name: INT. A LA ELECTROTECNICA
+      needs: exam
+    - type: subject
+      subject_needed_code: '5830'
+      subject_needed_name: INT. A LA ELECTROTECNICA
+      needs: exam
+  - type: logical
+    logical_operator: or
+    operands:
+    - type: subject
+      subject_needed_code: '5508'
+      subject_needed_name: REDES ELECTRICAS
+      needs: exam
+    - type: subject
+      subject_needed_code: '5502'
+      subject_needed_name: REDES ELECTRICAS 2
+      needs: exam
+  subject_code: '5518'
+  is_exam: false
+- type: logical
+  logical_operator: and
+  operands:
+  - type: subject
+    needs: course
+    subject_needed_code: '5518'
+    subject_needed_name: INT. A LOS SIST. DE PROT. DE SIST. ELECT. DE POT.
+  subject_code: '5518'
+  is_exam: true
+- type: logical
+  logical_operator: and
+  operands:
+  - type: logical
+    logical_operator: or
+    operands:
+    - type: logical
+      logical_operator: and
+      operands:
+      - type: subject
+        needs: course
+        subject_needed_code: '1457'
+        subject_needed_name: SEÑALES Y SISTEMAS
+      - type: subject
+        needs: exam
+        subject_needed_code: '1456'
+        subject_needed_name: TEORIA DE CIRCUITOS
+    - type: logical
+      logical_operator: or
+      operands:
+      - type: subject
+        subject_needed_code: '1423'
+        subject_needed_name: SISTEMAS LINEALES 1
+        needs: exam
+      - type: subject
+        subject_needed_code: '1407'
+        subject_needed_name: SISTEMAS LINEALES 2
+        needs: exam
+  - type: logical
+    logical_operator: or
+    operands:
+    - type: subject
+      subject_needed_code: 1128P
+      subject_needed_name: CREDITOS NO ACUM ELECTROMAGNETISMO
+      needs: exam
+    - type: subject
+      subject_needed_code: '1128'
+      subject_needed_name: ELECTROMAGNETISMO
+      needs: exam
+    - type: subject
+      subject_needed_code: '1178'
+      subject_needed_name: ELECTROMAGNETISMO
+      needs: exam
+  subject_code: '5519'
+  is_exam: false
+- type: logical
+  logical_operator: and
+  operands:
+  - type: subject
+    needs: course
+    subject_needed_code: '5519'
+    subject_needed_name: ENSAYOS ELECTRICOS Y EQUIPOS DE MEDIA TENSION
+  subject_code: '5519'
+  is_exam: true
+- type: logical
+  logical_operator: and
+  operands:
+  - type: logical
+    logical_operator: not
+    operands:
+    - type: subject
+      needs: all
+      subject_needed_code: '5513'
+      subject_needed_name: TRANSPORTE DE ENERGIA ELECTRICA
+  - type: subject
+    needs: course
+    subject_needed_code: '5508'
+    subject_needed_name: REDES ELECTRICAS
+  - type: logical
+    logical_operator: or
+    operands:
+    - type: subject
+      subject_needed_code: '1401'
+      subject_needed_name: SISTEMAS LINEALES 1
+      needs: exam
+    - type: subject
+      subject_needed_code: '1423'
+      subject_needed_name: SISTEMAS LINEALES 1
+      needs: exam
+    - type: subject
+      subject_needed_code: '1456'
+      subject_needed_name: TEORIA DE CIRCUITOS
+      needs: exam
+  subject_code: '5520'
+  is_exam: false
+- type: logical
+  logical_operator: and
+  operands:
+  - type: subject
+    needs: course
+    subject_needed_code: '5520'
+    subject_needed_name: TRANSPORTE DE ENERGIA ELECTRICA
+  subject_code: '5520'
+  is_exam: true
+- type: logical
+  logical_operator: and
+  operands:
+  - type: subject
+    needs: exam
+    subject_needed_code: '1456'
+    subject_needed_name: TEORIA DE CIRCUITOS
+  - type: subject
+    needs: course
+    subject_needed_code: '5850'
+    subject_needed_name: ELECTROTECNICA
+  - type: subject
+    needs: exam
+    subject_needed_code: '1128'
+    subject_needed_name: ELECTROMAGNETISMO
+  subject_code: '5602'
+  is_exam: false
+- type: logical
+  logical_operator: or
+  operands:
+  - type: logical
+    logical_operator: and
+    operands:
+    - type: subject
+      needs: exam
+      subject_needed_code: '1456'
+      subject_needed_name: TEORIA DE CIRCUITOS
+    - type: subject
+      needs: course
+      subject_needed_code: '5850'
+      subject_needed_name: ELECTROTECNICA
+    - type: subject
+      needs: exam
+      subject_needed_code: '1128'
+      subject_needed_name: ELECTROMAGNETISMO
+  - type: subject
+    needs: course
+    subject_needed_code: '5602'
+    subject_needed_name: MAQUINAS ELECTRICAS
+  subject_code: '5602'
+  is_exam: true
+- type: logical
+  logical_operator: and
+  operands:
+  - type: logical
+    logical_operator: or
+    operands:
+    - type: subject
+      needs: exam
+      subject_needed_code: '1456'
+      subject_needed_name: TEORIA DE CIRCUITOS
+    - type: logical
+      logical_operator: or
+      operands:
+      - type: subject
+        subject_needed_code: '1423'
+        subject_needed_name: SISTEMAS LINEALES 1
+        needs: exam
+      - type: subject
+        subject_needed_code: '1407'
+        subject_needed_name: SISTEMAS LINEALES 2
+        needs: exam
+  - type: subject
+    needs: course
+    subject_needed_code: '5602'
+    subject_needed_name: MAQUINAS ELECTRICAS
+  - type: logical
+    logical_operator: or
+    operands:
+    - type: subject
+      subject_needed_code: '5850'
+      subject_needed_name: ELECTROTECNICA
+      needs: exam
+    - type: subject
+      subject_needed_code: '5608'
+      subject_needed_name: INT. A LA ELECTROTECNICA
+      needs: exam
+    - type: subject
+      subject_needed_code: '5830'
+      subject_needed_name: INT. A LA ELECTROTECNICA
+      needs: exam
+  subject_code: '5603'
+  is_exam: false
+- type: logical
+  logical_operator: and
+  operands:
+  - type: logical
+    logical_operator: not
+    operands:
+    - type: subject
+      needs: all
+      subject_needed_code: '5607'
+      subject_needed_name: ELECTRONICA DE POTENCIA 1
+  - type: subject
+    needs: course
+    subject_needed_code: '5609'
+    subject_needed_name: ELECTRONICA DE POTENCIA
+  subject_code: '5604'
+  is_exam: false
+- type: logical
+  logical_operator: and
+  operands:
+  - type: logical
+    logical_operator: not
+    operands:
+    - type: logical
+      logical_operator: or
+      operands:
+      - type: subject
+        subject_needed_code: CON12
+        subject_needed_name: CREDITOS ASIGNADOS POR REVALIDA
+        needs: exam
+      - type: subject
+        subject_needed_code: CON20
+        subject_needed_name: CREDITOS ASIGNADOS POR REVALIDA
+        needs: exam
+      - type: subject
+        subject_needed_code: 5609P
+        subject_needed_name: CREDITOS NO ACUM ELECTRONICA DE POTENCIA
+        needs: exam
+  - type: logical
+    logical_operator: or
+    operands:
+    - type: logical
+      logical_operator: and
+      operands:
+      - type: subject
+        needs: exam
+        subject_needed_code: '1456'
+        subject_needed_name: TEORIA DE CIRCUITOS
+      - type: subject
+        needs: course
+        subject_needed_code: '5715'
+        subject_needed_name: ELECTRONICA FUNDAMENTAL
+      - type: subject
+        needs: course
+        subject_needed_code: '1457'
+        subject_needed_name: SEÑALES Y SISTEMAS
+      - type: logical
+        logical_operator: or
+        operands:
+        - type: subject
+          subject_needed_code: 1028R
+          subject_needed_name: CREDITOS ASIGNADOS POR REVALIDA
+          needs: exam
+        - type: subject
+          subject_needed_code: 1028P
+          subject_needed_name: CREDITOS NO ACUM EC. DIFERENCIALES
+          needs: exam
+        - type: subject
+          subject_needed_code: '1028'
+          subject_needed_name: ECUACIONES DIFERENCIALES
+          needs: exam
+        - type: subject
+          subject_needed_code: '1074'
+          subject_needed_name: ECUACIONES DIFERENCIALES
+          needs: exam
+        - type: subject
+          subject_needed_code: '1064'
+          subject_needed_name: INT. A LAS ECUACIONES DIFERENCIALES
+          needs: exam
+      - type: logical
+        logical_operator: or
+        operands:
+        - type: subject
+          subject_needed_code: '1029'
+          subject_needed_name: FUNCIONES DE VARIABLE COMPLEJA
+          needs: exam
+        - type: subject
+          subject_needed_code: '1036'
+          subject_needed_name: FUNCIONES DE VARIABLE COMPLEJA
+          needs: exam
+        - type: subject
+          subject_needed_code: '1066'
+          subject_needed_name: FUNCIONES DE VARIABLE COMPLEJA
+          needs: exam
+    - type: logical
+      logical_operator: at_least
+      amount_of_subjects_needed: 2
+      operands:
+      - type: subject
+        subject_needed_code: 1423P
+        subject_needed_name: CREDITOS NO ACUM SISTEMAS LINEALES 1
+        needs: course
+      - type: subject
+        subject_needed_code: '5715'
+        subject_needed_name: ELECTRONICA FUNDAMENTAL
+        needs: course
+      - type: subject
+        subject_needed_code: '5701'
+        subject_needed_name: ELECTRONICA 1
+        needs: exam
+      - type: subject
+        subject_needed_code: '1423'
+        subject_needed_name: SISTEMAS LINEALES 1
+        needs: exam
+  subject_code: '5609'
+  is_exam: false
+- type: logical
+  logical_operator: and
+  operands:
+  - type: logical
+    logical_operator: not
+    operands:
+    - type: logical
+      logical_operator: or
+      operands:
+      - type: subject
+        subject_needed_code: CON12
+        subject_needed_name: CREDITOS ASIGNADOS POR REVALIDA
+        needs: exam
+      - type: subject
+        subject_needed_code: CON20
+        subject_needed_name: CREDITOS ASIGNADOS POR REVALIDA
+        needs: exam
+      - type: subject
+        subject_needed_code: 5609P
+        subject_needed_name: CREDITOS NO ACUM ELECTRONICA DE POTENCIA
+        needs: exam
+  - type: logical
+    logical_operator: or
+    operands:
+    - type: logical
+      logical_operator: and
+      operands:
+      - type: subject
+        needs: exam
+        subject_needed_code: '1456'
+        subject_needed_name: TEORIA DE CIRCUITOS
+      - type: subject
+        needs: course
+        subject_needed_code: '1457'
+        subject_needed_name: SEÑALES Y SISTEMAS
+      - type: subject
+        needs: course
+        subject_needed_code: '5715'
+        subject_needed_name: ELECTRONICA FUNDAMENTAL
+      - type: logical
+        logical_operator: or
+        operands:
+        - type: subject
+          subject_needed_code: 1028R
+          subject_needed_name: CREDITOS ASIGNADOS POR REVALIDA
+          needs: exam
+        - type: subject
+          subject_needed_code: 1028P
+          subject_needed_name: CREDITOS NO ACUM EC. DIFERENCIALES
+          needs: exam
+        - type: subject
+          subject_needed_code: '1028'
+          subject_needed_name: ECUACIONES DIFERENCIALES
+          needs: exam
+        - type: subject
+          subject_needed_code: '1074'
+          subject_needed_name: ECUACIONES DIFERENCIALES
+          needs: exam
+        - type: subject
+          subject_needed_code: '1064'
+          subject_needed_name: INT. A LAS ECUACIONES DIFERENCIALES
+          needs: exam
+      - type: logical
+        logical_operator: or
+        operands:
+        - type: subject
+          subject_needed_code: '1029'
+          subject_needed_name: FUNCIONES DE VARIABLE COMPLEJA
+          needs: exam
+        - type: subject
+          subject_needed_code: '1036'
+          subject_needed_name: FUNCIONES DE VARIABLE COMPLEJA
+          needs: exam
+        - type: subject
+          subject_needed_code: '1066'
+          subject_needed_name: FUNCIONES DE VARIABLE COMPLEJA
+          needs: exam
+    - type: subject
+      needs: course
+      subject_needed_code: '5609'
+      subject_needed_name: ELECTRONICA DE POTENCIA
+    - type: logical
+      logical_operator: at_least
+      amount_of_subjects_needed: 2
+      operands:
+      - type: subject
+        subject_needed_code: '5715'
+        subject_needed_name: ELECTRONICA FUNDAMENTAL
+        needs: exam
+      - type: subject
+        subject_needed_code: '5701'
+        subject_needed_name: ELECTRONICA 1
+        needs: exam
+      - type: subject
+        subject_needed_code: '1423'
+        subject_needed_name: SISTEMAS LINEALES 1
+        needs: exam
+  subject_code: '5609'
+  is_exam: true
+- type: logical
+  logical_operator: and
+  operands:
+  - type: logical
+    logical_operator: not
+    operands:
+    - type: subject
+      needs: course
+      subject_needed_code: '5607'
+      subject_needed_name: ELECTRONICA DE POTENCIA 1
+  - type: logical
+    logical_operator: not
+    operands:
+    - type: subject
+      needs: course
+      subject_needed_code: 5610P
+      subject_needed_name: CREDITOS NO ACUM TALLER LAB. ELECT. DE POT.
+  - type: subject
+    needs: course
+    subject_needed_code: '5609'
+    subject_needed_name: ELECTRONICA DE POTENCIA
+  subject_code: '5610'
+  is_exam: false
+- type: logical
+  logical_operator: and
+  operands:
+  - type: subject
+    needs: course
+    subject_needed_code: '5520'
+    subject_needed_name: TRANSPORTE DE ENERGIA ELECTRICA
+  - type: subject
+    needs: exam
+    subject_needed_code: '5905'
+    subject_needed_name: SISTEMAS Y CONTROL
+  - type: subject
+    needs: course
+    subject_needed_code: '5609'
+    subject_needed_name: ELECTRONICA DE POTENCIA
+  - type: subject
+    needs: exam
+    subject_needed_code: '5602'
+    subject_needed_name: MAQUINAS ELECTRICAS
+  subject_code: '5630'
+  is_exam: false
+- type: logical
+  logical_operator: and
+  operands:
+  - type: subject
+    needs: course
+    subject_needed_code: '5630'
+    subject_needed_name: GENERACION DE ENERGIA ELECTRICA
+  subject_code: '5630'
+  is_exam: true
+- type: logical
+  logical_operator: and
+  operands:
+  - type: credits
+    credits: 160
+  subject_code: '5705'
+  is_exam: false
+- type: logical
+  logical_operator: and
+  operands:
+  - type: logical
+    logical_operator: or
+    operands:
+    - type: subject
+      subject_needed_code: '1409'
+      subject_needed_name: MUESTREO Y PROCESAMIENTO DIGITAL
+      needs: exam
+    - type: subject
+      subject_needed_code: '1457'
+      subject_needed_name: SEÑALES Y SISTEMAS
+      needs: exam
+  - type: logical
+    logical_operator: or
+    operands:
+    - type: subject
+      subject_needed_code: '1401'
+      subject_needed_name: SISTEMAS LINEALES 1
+      needs: exam
+    - type: subject
+      subject_needed_code: '1423'
+      subject_needed_name: SISTEMAS LINEALES 1
+      needs: exam
+    - type: subject
+      subject_needed_code: '1456'
+      subject_needed_name: TEORIA DE CIRCUITOS
+      needs: exam
+  - type: logical
+    logical_operator: or
+    operands:
+    - type: subject
+      subject_needed_code: 1322P
+      subject_needed_name: CREDITOS NO ACUM PROGRAMACION 1
+      needs: exam
+    - type: subject
+      subject_needed_code: '1320'
+      subject_needed_name: PROGRAMACION 1
+      needs: exam
+    - type: subject
+      subject_needed_code: '1322'
+      subject_needed_name: PROGRAMACION 1
+      needs: exam
+    - type: subject
+      subject_needed_code: '1373'
+      subject_needed_name: PROGRAMACION 1
+      needs: exam
+  subject_code: '5707'
+  is_exam: false
+- type: logical
+  logical_operator: or
+  operands:
+  - type: logical
+    logical_operator: and
+    operands:
+    - type: subject
+      needs: exam
+      subject_needed_code: '1512'
+      subject_needed_name: DISEÑO LOGICO
+    - type: logical
+      logical_operator: or
+      operands:
+      - type: subject
+        subject_needed_code: '5716'
+        subject_needed_name: ELECTRONICA AVANZADA 1
+        needs: exam
+      - type: subject
+        subject_needed_code: '5701'
+        subject_needed_name: ELECTRONICA 1
+        needs: exam
+    - type: logical
+      logical_operator: or
+      operands:
+      - type: subject
+        subject_needed_code: 1423P
+        subject_needed_name: CREDITOS NO ACUM SISTEMAS LINEALES 1
+        needs: course
+      - type: subject
+        subject_needed_code: '1401'
+        subject_needed_name: SISTEMAS LINEALES 1
+        needs: exam
+      - type: subject
+        subject_needed_code: '1423'
+        subject_needed_name: SISTEMAS LINEALES 1
+        needs: exam
+      - type: subject
+        subject_needed_code: '1407'
+        subject_needed_name: SISTEMAS LINEALES 2
+        needs: exam
+  - type: logical
+    logical_operator: and
+    operands:
+    - type: subject
+      needs: exam
+      subject_needed_code: '1457'
+      subject_needed_name: SEÑALES Y SISTEMAS
+    - type: subject
+      needs: exam
+      subject_needed_code: '5716'
+      subject_needed_name: ELECTRONICA AVANZADA 1
+    - type: subject
+      needs: exam
+      subject_needed_code: '1512'
+      subject_needed_name: DISEÑO LOGICO
+    - type: subject
+      needs: exam
+      subject_needed_code: '1456'
+      subject_needed_name: TEORIA DE CIRCUITOS
+    - type: subject
+      needs: course
+      subject_needed_code: '5717'
+      subject_needed_name: ELECTRONICA AVANZADA 2
+    - type: subject
+      needs: exam
+      subject_needed_code: '5715'
+      subject_needed_name: ELECTRONICA FUNDAMENTAL
+  subject_code: '5708'
+  is_exam: false
+- type: logical
+  logical_operator: and
+  operands:
+  - type: logical
+    logical_operator: or
+    operands:
+    - type: subject
+      subject_needed_code: '1409'
+      subject_needed_name: MUESTREO Y PROCESAMIENTO DIGITAL
+      needs: exam
+    - type: subject
+      subject_needed_code: '1457'
+      subject_needed_name: SEÑALES Y SISTEMAS
+      needs: course
+  - type: logical
+    logical_operator: or
+    operands:
+    - type: subject
+      subject_needed_code: '5715'
+      subject_needed_name: ELECTRONICA FUNDAMENTAL
+      needs: course
+    - type: subject
+      subject_needed_code: '5701'
+      subject_needed_name: ELECTRONICA 1
+      needs: exam
+  subject_code: '5710'
+  is_exam: false
+- type: logical
+  logical_operator: and
+  operands:
+  - type: logical
+    logical_operator: at_least
+    amount_of_subjects_needed: 3
+    operands:
+    - type: subject
+      subject_needed_code: '5707'
+      subject_needed_name: 'IMAGENES MEDICAS: ADQUISICION, INSTRUMENTACION Y GESTION'
+      needs: course
+    - type: subject
+      subject_needed_code: '5703'
+      subject_needed_name: INGENIERIA BIOMEDICA
+      needs: course
+    - type: subject
+      subject_needed_code: '5710'
+      subject_needed_name: INGENIERIA BIOMEDICA
+      needs: course
+    - type: subject
+      subject_needed_code: '5507'
+      subject_needed_name: INSTALACIONES ELECTRICAS
+      needs: exam
+    - type: subject
+      subject_needed_code: '1461'
+      subject_needed_name: MEDIDAS ELECTRICAS
+      needs: exam
+    - type: subject
+      subject_needed_code: '5705'
+      subject_needed_name: SEMINARIO DE INGENIERIA BIOMEDICA
+      needs: course
+  subject_code: '5712'
+  is_exam: false
+- type: logical
+  logical_operator: and
+  operands:
+  - type: credits
+    credits: 10
+    group: 23
+  - type: credits
+    credits: 25
+    group: 21
+  - type: logical
+    logical_operator: or
+    operands:
+    - type: subject
+      subject_needed_code: '1128'
+      subject_needed_name: ELECTROMAGNETISMO
+      needs: all
+    - type: subject
+      subject_needed_code: '1178'
+      subject_needed_name: ELECTROMAGNETISMO
+      needs: all
+  subject_code: '5713'
+  is_exam: false
+- type: logical
+  logical_operator: and
+  operands:
+  - type: credits
+    credits: 25
+    group: 12
+  - type: credits
+    credits: 50
+    group: 11
+  - type: logical
+    logical_operator: or
+    operands:
+    - type: subject
+      subject_needed_code: 1151P
+      subject_needed_name: CREDITOS NO ACUM FISICA 1
+      needs: all
+    - type: subject
+      subject_needed_code: '1120'
+      subject_needed_name: FISICA GENERAL 1
+      needs: all
+    - type: subject
+      subject_needed_code: '1170'
+      subject_needed_name: FISICA GENERAL 1
+      needs: all
+    - type: subject
+      subject_needed_code: '1151'
+      subject_needed_name: FISICA 1
+      needs: all
+    - type: subject
+      subject_needed_code: '1171'
+      subject_needed_name: FISICA 1
+      needs: all
+  - type: logical
+    logical_operator: or
+    operands:
+    - type: subject
+      subject_needed_code: '1061'
+      subject_needed_name: CALCULO DIF. E INTEGRAL EN UNA VARIABLE
+      needs: all
+    - type: subject
+      subject_needed_code: '1020'
+      subject_needed_name: CALCULO 1
+      needs: all
+    - type: subject
+      subject_needed_code: '1070'
+      subject_needed_name: CALCULO 1
+      needs: all
+    - type: subject
+      subject_needed_code: '1052'
+      subject_needed_name: CALCULO 1 (ANUAL)
+      needs: all
+    - type: subject
+      subject_needed_code: MAT33
+      subject_needed_name: CREDITOS ASIGNADOS POR REVALIDA
+      needs: all
+    - type: subject
+      subject_needed_code: 1020P
+      subject_needed_name: CREDITOS NO ACUM CALCULO 1
+      needs: all
+    - type: subject
+      subject_needed_code: 1061P
+      subject_needed_name: CREDITOS NO ACUM CDIV
+      needs: all
+  - type: logical
+    logical_operator: or
+    operands:
+    - type: subject
+      subject_needed_code: 1153P
+      subject_needed_name: CREDITOS NO ACUM FISICA 3
+      needs: all
+    - type: subject
+      subject_needed_code: '1121'
+      subject_needed_name: FISICA GENERAL 2
+      needs: all
+    - type: subject
+      subject_needed_code: '1172'
+      subject_needed_name: FISICA GENERAL 2
+      needs: all
+    - type: subject
+      subject_needed_code: '1153'
+      subject_needed_name: FISICA 3
+      needs: all
+    - type: subject
+      subject_needed_code: '1173'
+      subject_needed_name: FISICA 3
+      needs: all
+  - type: logical
+    logical_operator: or
+    operands:
+    - type: subject
+      subject_needed_code: 1154P
+      subject_needed_name: CREDITOS NO ACUM FISICA EXPERIMENTAL 1
+      needs: exam
+    - type: subject
+      subject_needed_code: '1154'
+      subject_needed_name: FISICA EXPERIMENTAL 1
+      needs: course
+    - type: subject
+      subject_needed_code: 1154I
+      subject_needed_name: FISICA EXPERIMENTAL 1
+      needs: exam
+    - type: subject
+      subject_needed_code: '1124'
+      subject_needed_name: LABORATORIO 1
+      needs: course
+  - type: logical
+    logical_operator: or
+    operands:
+    - type: subject
+      subject_needed_code: '1021'
+      subject_needed_name: ALGEBRA LINEAL
+      needs: all
+    - type: subject
+      subject_needed_code: MAT33
+      subject_needed_name: CREDITOS ASIGNADOS POR REVALIDA
+      needs: all
+    - type: subject
+      subject_needed_code: 1031P
+      subject_needed_name: CREDITOS NO ACUM GAL2
+      needs: all
+    - type: subject
+      subject_needed_code: '1031'
+      subject_needed_name: GEOMETRIA Y ALGEBRA LINEAL 2
+      needs: all
+    - type: subject
+      subject_needed_code: '1058'
+      subject_needed_name: GEOMETRIA Y ALGEBRA LINEAL 2
+      needs: all
+  - type: logical
+    logical_operator: or
+    operands:
+    - type: subject
+      subject_needed_code: 1128P
+      subject_needed_name: CREDITOS NO ACUM ELECTROMAGNETISMO
+      needs: exam
+    - type: subject
+      subject_needed_code: '1128'
+      subject_needed_name: ELECTROMAGNETISMO
+      needs: course
+    - type: subject
+      subject_needed_code: '1178'
+      subject_needed_name: ELECTROMAGNETISMO
+      needs: exam
+  - type: logical
+    logical_operator: or
+    operands:
+    - type: subject
+      subject_needed_code: 1456P
+      subject_needed_name: CREDITOS NO ACUM TEORIA DE CIRCUITOS
+      needs: course
+    - type: subject
+      subject_needed_code: 1456R
+      subject_needed_name: CREDITOS NO ACUM TEORIA DE CIRCUITOS
+      needs: course
+    - type: subject
+      subject_needed_code: '1456'
+      subject_needed_name: TEORIA DE CIRCUITOS
+      needs: course
+  - type: logical
+    logical_operator: or
+    operands:
+    - type: subject
+      subject_needed_code: '1062'
+      subject_needed_name: CALCULO DIF. E INTEGRAL EN VARIAS VARIABLES
+      needs: all
+    - type: subject
+      subject_needed_code: '1022'
+      subject_needed_name: CALCULO 2
+      needs: all
+    - type: subject
+      subject_needed_code: '1072'
+      subject_needed_name: CALCULO 2
+      needs: all
+    - type: subject
+      subject_needed_code: MAT33
+      subject_needed_name: CREDITOS ASIGNADOS POR REVALIDA
+      needs: all
+    - type: subject
+      subject_needed_code: 1022P
+      subject_needed_name: CREDITOS NO ACUM CALCULO 2
+      needs: all
+    - type: subject
+      subject_needed_code: 1062P
+      subject_needed_name: CREDITOS NO ACUM CDIVV
+      needs: all
+  - type: logical
+    logical_operator: or
+    operands:
+    - type: subject
+      subject_needed_code: '1021'
+      subject_needed_name: ALGEBRA LINEAL
+      needs: all
+    - type: subject
+      subject_needed_code: MAT33
+      subject_needed_name: CREDITOS ASIGNADOS POR REVALIDA
+      needs: all
+    - type: subject
+      subject_needed_code: 1030P
+      subject_needed_name: CREDITOS NO ACUM GAL1
+      needs: all
+    - type: subject
+      subject_needed_code: '1030'
+      subject_needed_name: GEOMETRIA Y ALGEBRA LINEAL 1
+      needs: all
+    - type: subject
+      subject_needed_code: '1071'
+      subject_needed_name: GEOMETRIA Y ALGEBRA LINEAL 1
+      needs: all
+    - type: subject
+      subject_needed_code: '1053'
+      subject_needed_name: GEOMETRIA Y ALGEBRA LINEAL 1 (ANUAL)
+      needs: all
+    - type: subject
+      subject_needed_code: GAL1P
+      subject_needed_name: GEOMETRIA Y ALGEBRA LINEAL 1 INTERACTIVA
+      needs: all
+  subject_code: '5715'
+  is_exam: false
+- type: logical
+  logical_operator: and
+  operands:
+  - type: subject
+    needs: course
+    subject_needed_code: '5715'
+    subject_needed_name: ELECTRONICA FUNDAMENTAL
+  subject_code: '5715'
+  is_exam: true
+- type: logical
+  logical_operator: or
+  operands:
+  - type: logical
+    logical_operator: and
+    operands:
+    - type: logical
+      logical_operator: or
+      operands:
+      - type: subject
+        subject_needed_code: '1401'
+        subject_needed_name: SISTEMAS LINEALES 1
+        needs: exam
+      - type: subject
+        subject_needed_code: '1423'
+        subject_needed_name: SISTEMAS LINEALES 1
+        needs: exam
+      - type: subject
+        subject_needed_code: '1407'
+        subject_needed_name: SISTEMAS LINEALES 2
+        needs: exam
+    - type: logical
+      logical_operator: or
+      operands:
+      - type: subject
+        subject_needed_code: '5715'
+        subject_needed_name: ELECTRONICA FUNDAMENTAL
+        needs: course
+      - type: subject
+        subject_needed_code: '5701'
+        subject_needed_name: ELECTRONICA 1
+        needs: exam
+  - type: logical
+    logical_operator: and
+    operands:
+    - type: credits
+      credits: 50
+      group: 11
+    - type: credits
+      credits: 40
+      group: 12
+    - type: subject
+      needs: course
+      subject_needed_code: '5715'
+      subject_needed_name: ELECTRONICA FUNDAMENTAL
+    - type: subject
+      needs: exam
+      subject_needed_code: '1456'
+      subject_needed_name: TEORIA DE CIRCUITOS
+    - type: logical
+      logical_operator: or
+      operands:
+      - type: subject
+        subject_needed_code: 1128P
+        subject_needed_name: CREDITOS NO ACUM ELECTROMAGNETISMO
+        needs: exam
+      - type: subject
+        subject_needed_code: '1128'
+        subject_needed_name: ELECTROMAGNETISMO
+        needs: exam
+      - type: subject
+        subject_needed_code: '1178'
+        subject_needed_name: ELECTROMAGNETISMO
+        needs: exam
+  subject_code: '5716'
+  is_exam: false
+- type: logical
+  logical_operator: and
+  operands:
+  - type: subject
+    needs: course
+    subject_needed_code: '5716'
+    subject_needed_name: ELECTRONICA AVANZADA 1
+  subject_code: '5716'
+  is_exam: true
+- type: logical
+  logical_operator: or
+  operands:
+  - type: logical
+    logical_operator: and
+    operands:
+    - type: subject
+      needs: exam
+      subject_needed_code: '1456'
+      subject_needed_name: TEORIA DE CIRCUITOS
+    - type: subject
+      needs: course
+      subject_needed_code: '5716'
+      subject_needed_name: ELECTRONICA AVANZADA 1
+    - type: subject
+      needs: course
+      subject_needed_code: '1457'
+      subject_needed_name: SEÑALES Y SISTEMAS
+    - type: logical
+      logical_operator: or
+      operands:
+      - type: subject
+        subject_needed_code: '5715'
+        subject_needed_name: ELECTRONICA FUNDAMENTAL
+        needs: exam
+      - type: subject
+        subject_needed_code: '5701'
+        subject_needed_name: ELECTRONICA 1
+        needs: exam
+    - type: logical
+      logical_operator: or
+      operands:
+      - type: subject
+        subject_needed_code: '5900'
+        subject_needed_name: INT. A LA TEORIA DE CONTROL
+        needs: exam
+      - type: subject
+        subject_needed_code: '5905'
+        subject_needed_name: SISTEMAS Y CONTROL
+        needs: course
+    - type: logical
+      logical_operator: or
+      operands:
+      - type: subject
+        subject_needed_code: '1128'
+        subject_needed_name: ELECTROMAGNETISMO
+        needs: exam
+      - type: subject
+        subject_needed_code: '1178'
+        subject_needed_name: ELECTROMAGNETISMO
+        needs: exam
+  - type: logical
+    logical_operator: and
+    operands:
+    - type: logical
+      logical_operator: or
+      operands:
+      - type: subject
+        subject_needed_code: '5715'
+        subject_needed_name: ELECTRONICA FUNDAMENTAL
+        needs: exam
+      - type: subject
+        subject_needed_code: '5701'
+        subject_needed_name: ELECTRONICA 1
+        needs: exam
+    - type: logical
+      logical_operator: or
+      operands:
+      - type: subject
+        subject_needed_code: 1423P
+        subject_needed_name: CREDITOS NO ACUM SISTEMAS LINEALES 1
+        needs: course
+      - type: subject
+        subject_needed_code: '1423'
+        subject_needed_name: SISTEMAS LINEALES 1
+        needs: exam
+      - type: subject
+        subject_needed_code: '1407'
+        subject_needed_name: SISTEMAS LINEALES 2
+        needs: exam
+    - type: logical
+      logical_operator: or
+      operands:
+      - type: subject
+        subject_needed_code: '1128'
+        subject_needed_name: ELECTROMAGNETISMO
+        needs: exam
+      - type: subject
+        subject_needed_code: '1178'
+        subject_needed_name: ELECTROMAGNETISMO
+        needs: exam
+  subject_code: '5717'
+  is_exam: false
+- type: logical
+  logical_operator: and
+  operands:
+  - type: subject
+    needs: course
+    subject_needed_code: '5717'
+    subject_needed_name: ELECTRONICA AVANZADA 2
+  subject_code: '5717'
+  is_exam: true
+- type: logical
+  logical_operator: and
+  operands:
+  - type: logical
+    logical_operator: or
+    operands:
+    - type: subject
+      subject_needed_code: '1423'
+      subject_needed_name: SISTEMAS LINEALES 1
+      needs: exam
+    - type: subject
+      subject_needed_code: '1456'
+      subject_needed_name: TEORIA DE CIRCUITOS
+      needs: exam
+  - type: logical
+    logical_operator: or
+    operands:
+    - type: subject
+      subject_needed_code: '1326'
+      subject_needed_name: DESARROLLO DE SOFTWARE PARA ING.ELECT.
+      needs: course
+    - type: subject
+      subject_needed_code: '1306'
+      subject_needed_name: PROGRAMACION ORIENTADA A OBJETOS
+      needs: course
+    - type: subject
+      subject_needed_code: '1307'
+      subject_needed_name: PROGRAMACION PARA INGENIERIA ELECTRICA
+      needs: course
+    - type: subject
+      subject_needed_code: '1321'
+      subject_needed_name: PROGRAMACION 2
+      needs: exam
+  - type: logical
+    logical_operator: or
+    operands:
+    - type: subject
+      subject_needed_code: '5715'
+      subject_needed_name: ELECTRONICA FUNDAMENTAL
+      needs: exam
+    - type: subject
+      subject_needed_code: '5701'
+      subject_needed_name: ELECTRONICA 1
+      needs: exam
+  subject_code: '5718'
+  is_exam: false
+- type: logical
+  logical_operator: and
+  operands:
+  - type: logical
+    logical_operator: or
+    operands:
+    - type: subject
+      subject_needed_code: '5852'
+      subject_needed_name: FUNDAMENTOS DE APRENDIZAJE AUTOMATICO Y RECONOCIMIENTO
+        DE PATRONES
+      needs: course
+    - type: subject
+      subject_needed_code: '5842'
+      subject_needed_name: RECONOCIMIENTO DE PATRONES
+      needs: course
+  subject_code: '5719'
+  is_exam: false
+- type: logical
+  logical_operator: and
+  operands:
+  - type: logical
+    logical_operator: not
+    operands:
+    - type: subject
+      needs: course
+      subject_needed_code: '5853'
+      subject_needed_name: TALLER DE APRENDIZAJE AUTOMATICO
+  - type: logical
+    logical_operator: or
+    operands:
+    - type: subject
+      subject_needed_code: '5852'
+      subject_needed_name: FUNDAMENTOS DE APRENDIZAJE AUTOMATICO Y RECONOCIMIENTO
+        DE PATRONES
+      needs: exam
+    - type: subject
+      subject_needed_code: '5842'
+      subject_needed_name: RECONOCIMIENTO DE PATRONES
+      needs: course
+  subject_code: '5720'
+  is_exam: false
+- type: logical
+  logical_operator: and
+  operands:
+  - type: logical
+    logical_operator: not
+    operands:
+    - type: subject
+      needs: all
+      subject_needed_code: '5714'
+      subject_needed_name: DISEÑO DE SISTEMAS MEDICOS IMPLANTABLES ACTIVOS
+  - type: subject
+    needs: exam
+    subject_needed_code: '1513'
+    subject_needed_name: INT. A LOS MICROPROCESADORES
+  - type: logical
+    logical_operator: or
+    operands:
+    - type: subject
+      subject_needed_code: '5715'
+      subject_needed_name: ELECTRONICA FUNDAMENTAL
+      needs: course
+    - type: subject
+      subject_needed_code: '5701'
+      subject_needed_name: ELECTRONICA 1
+      needs: exam
+  - type: logical
+    logical_operator: or
+    operands:
+    - type: subject
+      subject_needed_code: 1461P
+      subject_needed_name: CREDITOS NO ACUM MEDIDAS ELECTRICAS
+      needs: exam
+    - type: subject
+      subject_needed_code: '1410'
+      subject_needed_name: MEDIDAS ELECTRICAS
+      needs: exam
+    - type: subject
+      subject_needed_code: '1451'
+      subject_needed_name: MEDIDAS ELECTRICAS
+      needs: exam
+    - type: subject
+      subject_needed_code: '1461'
+      subject_needed_name: MEDIDAS ELECTRICAS
+      needs: course
+  - type: logical
+    logical_operator: or
+    operands:
+    - type: subject
+      subject_needed_code: '1307'
+      subject_needed_name: PROGRAMACION PARA INGENIERIA ELECTRICA
+      needs: course
+    - type: subject
+      subject_needed_code: '1321'
+      subject_needed_name: PROGRAMACION 2
+      needs: exam
+  subject_code: '5724'
+  is_exam: false
+- type: logical
+  logical_operator: and
+  operands:
+  - type: logical
+    logical_operator: not
+    operands:
+    - type: logical
+      logical_operator: or
+      operands:
+      - type: subject
+        subject_needed_code: '5803'
+        subject_needed_name: ANTENAS Y PROPAGACION
+        needs: all
+      - type: subject
+        subject_needed_code: TELE8
+        subject_needed_name: CREDITOS ASIGNADOS POR REVALIDA
+        needs: all
+      - type: subject
+        subject_needed_code: 5817P
+        subject_needed_name: CREDITOS NO ACUM ANTENAS Y PROPAGACION
+        needs: all
+  - type: logical
+    logical_operator: and
+    operands:
+    - type: subject
+      needs: course
+      subject_needed_code: '1456'
+      subject_needed_name: TEORIA DE CIRCUITOS
+    - type: subject
+      needs: course
+      subject_needed_code: '1460'
+      subject_needed_name: SEÑALES ALEATORIAS Y MODULACION
+    - type: logical
+      logical_operator: or
+      operands:
+      - type: subject
+        subject_needed_code: 1066P
+        subject_needed_name: CREDITOS NO ACUM FUNCIONES DE VAR. COMP.
+        needs: exam
+      - type: subject
+        subject_needed_code: '1029'
+        subject_needed_name: FUNCIONES DE VARIABLE COMPLEJA
+        needs: exam
+      - type: subject
+        subject_needed_code: '1036'
+        subject_needed_name: FUNCIONES DE VARIABLE COMPLEJA
+        needs: exam
+      - type: subject
+        subject_needed_code: '1066'
+        subject_needed_name: FUNCIONES DE VARIABLE COMPLEJA
+        needs: course
+    - type: logical
+      logical_operator: or
+      operands:
+      - type: subject
+        subject_needed_code: 1128P
+        subject_needed_name: CREDITOS NO ACUM ELECTROMAGNETISMO
+        needs: exam
+      - type: subject
+        subject_needed_code: '1128'
+        subject_needed_name: ELECTROMAGNETISMO
+        needs: exam
+      - type: subject
+        subject_needed_code: '1178'
+        subject_needed_name: ELECTROMAGNETISMO
+        needs: exam
+  subject_code: '5817'
+  is_exam: false
+- type: logical
+  logical_operator: and
+  operands:
+  - type: subject
+    needs: course
+    subject_needed_code: '5817'
+    subject_needed_name: ANTENAS Y PROPAGACION
+  subject_code: '5817'
+  is_exam: true
+- type: logical
+  logical_operator: and
+  operands:
+  - type: logical
+    logical_operator: or
+    operands:
+    - type: subject
+      subject_needed_code: '5803'
+      subject_needed_name: ANTENAS Y PROPAGACION
+      needs: exam
+    - type: subject
+      subject_needed_code: '5817'
+      subject_needed_name: ANTENAS Y PROPAGACION
+      needs: course
+  subject_code: '5821'
+  is_exam: false
+- type: logical
+  logical_operator: and
+  operands:
+  - type: logical
+    logical_operator: not
+    operands:
+    - type: logical
+      logical_operator: or
+      operands:
+      - type: subject
+        subject_needed_code: 5805P
+        subject_needed_name: CREDITOS NO ACUM REDES DE DATOS
+        needs: course
+      - type: subject
+        subject_needed_code: '5805'
+        subject_needed_name: REDES DE DATOS
+        needs: exam
+  - type: subject
+    needs: course
+    subject_needed_code: '1512'
+    subject_needed_name: DISEÑO LOGICO
+  subject_code: '5824'
+  is_exam: false
+- type: logical
+  logical_operator: and
+  operands:
+  - type: subject
+    needs: course
+    subject_needed_code: '5824'
+    subject_needed_name: REDES DE DATOS 1
+  subject_code: '5824'
+  is_exam: true
+- type: logical
+  logical_operator: and
+  operands:
+  - type: logical
+    logical_operator: not
+    operands:
+    - type: logical
+      logical_operator: or
+      operands:
+      - type: subject
+        subject_needed_code: 5828P
+        subject_needed_name: CREDITOS NO ACUM TRATAMIENTO DE IMAG POR COMP
+        needs: all
+      - type: subject
+        subject_needed_code: '5811'
+        subject_needed_name: TRATAMIENTO DE IMAGENES POR COMPUTADORA
+        needs: all
+  - type: credits
+    credits: 7
+    group: 26
+  - type: logical
+    logical_operator: or
+    operands:
+    - type: subject
+      subject_needed_code: '1409'
+      subject_needed_name: MUESTREO Y PROCESAMIENTO DIGITAL
+      needs: exam
+    - type: subject
+      subject_needed_code: '1457'
+      subject_needed_name: SEÑALES Y SISTEMAS
+      needs: exam
+  subject_code: '5828'
+  is_exam: false
+- type: logical
+  logical_operator: and
+  operands:
+  - type: logical
+    logical_operator: or
+    operands:
+    - type: subject
+      subject_needed_code: '1460'
+      subject_needed_name: SEÑALES ALEATORIAS Y MODULACION
+      needs: course
+    - type: subject
+      subject_needed_code: '5808'
+      subject_needed_name: SISTEMAS DE COMUNICACION
+      needs: exam
+  - type: logical
+    logical_operator: or
+    operands:
+    - type: subject
+      subject_needed_code: 5805P
+      subject_needed_name: CREDITOS NO ACUM REDES DE DATOS
+      needs: course
+    - type: subject
+      subject_needed_code: '5805'
+      subject_needed_name: REDES DE DATOS
+      needs: exam
+    - type: subject
+      subject_needed_code: '5824'
+      subject_needed_name: REDES DE DATOS 1
+      needs: course
+  subject_code: '5833'
+  is_exam: true
+- type: logical
+  logical_operator: and
+  operands:
+  - type: logical
+    logical_operator: or
+    operands:
+    - type: subject
+      subject_needed_code: 5805P
+      subject_needed_name: CREDITOS NO ACUM REDES DE DATOS
+      needs: all
+    - type: subject
+      subject_needed_code: '5805'
+      subject_needed_name: REDES DE DATOS
+      needs: all
+    - type: subject
+      subject_needed_code: '5824'
+      subject_needed_name: REDES DE DATOS 1
+      needs: all
+  - type: logical
+    logical_operator: or
+    operands:
+    - type: subject
+      subject_needed_code: 1025P
+      subject_needed_name: CREDITOS NO ACUM PROB Y EST.
+      needs: all
+    - type: subject
+      subject_needed_code: '1025'
+      subject_needed_name: PROBABILIDAD Y ESTADISTICA
+      needs: all
+    - type: subject
+      subject_needed_code: '1075'
+      subject_needed_name: PROBABILIDAD Y ESTADISTICA
+      needs: all
+  subject_code: '5835'
+  is_exam: false
+- type: logical
+  logical_operator: or
+  operands:
+  - type: logical
+    logical_operator: and
+    operands:
+    - type: credits
+      credits: 7
+      group: 26
+    - type: subject
+      needs: exam
+      subject_needed_code: '1457'
+      subject_needed_name: SEÑALES Y SISTEMAS
+  - type: logical
+    logical_operator: and
+    operands:
+    - type: logical
+      logical_operator: or
+      operands:
+      - type: subject
+        subject_needed_code: '1409'
+        subject_needed_name: MUESTREO Y PROCESAMIENTO DIGITAL
+        needs: exam
+      - type: subject
+        subject_needed_code: '1460'
+        subject_needed_name: SEÑALES ALEATORIAS Y MODULACION
+        needs: course
+    - type: logical
+      logical_operator: or
+      operands:
+      - type: subject
+        subject_needed_code: '1423'
+        subject_needed_name: SISTEMAS LINEALES 1
+        needs: exam
+      - type: subject
+        subject_needed_code: '1407'
+        subject_needed_name: SISTEMAS LINEALES 2
+        needs: exam
+  subject_code: '5839'
+  is_exam: false
+- type: logical
+  logical_operator: and
+  operands:
+  - type: logical
+    logical_operator: or
+    operands:
+    - type: subject
+      subject_needed_code: '1104'
+      subject_needed_name: INT. A LA MODULACION
+      needs: exam
+    - type: subject
+      subject_needed_code: '5801'
+      subject_needed_name: SISTEMAS DE COMUNICACION
+      needs: exam
+    - type: subject
+      subject_needed_code: '5808'
+      subject_needed_name: SISTEMAS DE COMUNICACION
+      needs: course
+  subject_code: '5844'
+  is_exam: false
+- type: logical
+  logical_operator: and
+  operands:
+  - type: logical
+    logical_operator: or
+    operands:
+    - type: subject
+      subject_needed_code: 5805P
+      subject_needed_name: CREDITOS NO ACUM REDES DE DATOS
+      needs: course
+    - type: subject
+      subject_needed_code: '5805'
+      subject_needed_name: REDES DE DATOS
+      needs: exam
+    - type: subject
+      subject_needed_code: '5824'
+      subject_needed_name: REDES DE DATOS 1
+      needs: course
+  subject_code: '5846'
+  is_exam: false
+- type: logical
+  logical_operator: and
+  operands:
+  - type: logical
+    logical_operator: or
+    operands:
+    - type: subject
+      subject_needed_code: 1025P
+      subject_needed_name: CREDITOS NO ACUM PROB Y EST.
+      needs: exam
+    - type: subject
+      subject_needed_code: '1025'
+      subject_needed_name: PROBABILIDAD Y ESTADISTICA
+      needs: exam
+    - type: subject
+      subject_needed_code: '1075'
+      subject_needed_name: PROBABILIDAD Y ESTADISTICA
+      needs: exam
+  - type: logical
+    logical_operator: or
+    operands:
+    - type: subject
+      subject_needed_code: 1322P
+      subject_needed_name: CREDITOS NO ACUM PROGRAMACION 1
+      needs: exam
+    - type: subject
+      subject_needed_code: '1320'
+      subject_needed_name: PROGRAMACION 1
+      needs: exam
+    - type: subject
+      subject_needed_code: '1322'
+      subject_needed_name: PROGRAMACION 1
+      needs: exam
+    - type: subject
+      subject_needed_code: '1373'
+      subject_needed_name: PROGRAMACION 1
+      needs: exam
+  subject_code: '5847'
+  is_exam: false
+- type: logical
+  logical_operator: and
+  operands:
+  - type: logical
+    logical_operator: or
+    operands:
+    - type: subject
+      subject_needed_code: '1326'
+      subject_needed_name: DESARROLLO DE SOFTWARE PARA ING.ELECT.
+      needs: course
+    - type: subject
+      subject_needed_code: '1306'
+      subject_needed_name: PROGRAMACION ORIENTADA A OBJETOS
+      needs: course
+    - type: subject
+      subject_needed_code: '1307'
+      subject_needed_name: PROGRAMACION PARA INGENIERIA ELECTRICA
+      needs: course
+    - type: subject
+      subject_needed_code: '1321'
+      subject_needed_name: PROGRAMACION 2
+      needs: exam
+  - type: logical
+    logical_operator: or
+    operands:
+    - type: subject
+      subject_needed_code: '1462'
+      subject_needed_name: COMUNICACIONES DIGITALES
+      needs: course
+    - type: subject
+      subject_needed_code: '5801'
+      subject_needed_name: SISTEMAS DE COMUNICACION
+      needs: exam
+    - type: subject
+      subject_needed_code: '5808'
+      subject_needed_name: SISTEMAS DE COMUNICACION
+      needs: exam
+  subject_code: '5848'
+  is_exam: false
+- type: logical
+  logical_operator: and
+  operands:
+  - type: logical
+    logical_operator: not
+    operands:
+    - type: subject
+      needs: all
+      subject_needed_code: '5840'
+      subject_needed_name: TRATAMIENTO ESTADISTICO DE SEÑALES
+  - type: logical
+    logical_operator: or
+    operands:
+    - type: logical
+      logical_operator: and
+      operands:
+      - type: subject
+        needs: course
+        subject_needed_code: '1460'
+        subject_needed_name: SEÑALES ALEATORIAS Y MODULACION
+      - type: subject
+        needs: exam
+        subject_needed_code: '1457'
+        subject_needed_name: SEÑALES Y SISTEMAS
+    - type: subject
+      needs: exam
+      subject_needed_code: '1409'
+      subject_needed_name: MUESTREO Y PROCESAMIENTO DIGITAL
+  subject_code: '5849'
+  is_exam: false
+- type: logical
+  logical_operator: and
+  operands:
+  - type: logical
+    logical_operator: not
+    operands:
+    - type: logical
+      logical_operator: or
+      operands:
+      - type: subject
+        subject_needed_code: 5850P
+        subject_needed_name: CREDITOS NO ACUM ELECTROTECNICA
+        needs: all
+      - type: subject
+        subject_needed_code: '5601'
+        subject_needed_name: INT. A LA ELECTROTECNICA
+        needs: all
+      - type: subject
+        subject_needed_code: '5608'
+        subject_needed_name: INT. A LA ELECTROTECNICA
+        needs: all
+      - type: subject
+        subject_needed_code: '5830'
+        subject_needed_name: INT. A LA ELECTROTECNICA
+        needs: all
+  - type: logical
+    logical_operator: or
+    operands:
+    - type: logical
+      logical_operator: and
+      operands:
+      - type: logical
+        logical_operator: or
+        operands:
+        - type: subject
+          subject_needed_code: 1128P
+          subject_needed_name: CREDITOS NO ACUM ELECTROMAGNETISMO
+          needs: exam
+        - type: subject
+          subject_needed_code: '1128'
+          subject_needed_name: ELECTROMAGNETISMO
+          needs: course
+        - type: subject
+          subject_needed_code: '1178'
+          subject_needed_name: ELECTROMAGNETISMO
+          needs: exam
+      - type: logical
+        logical_operator: or
+        operands:
+        - type: subject
+          subject_needed_code: 1423P
+          subject_needed_name: CREDITOS NO ACUM SISTEMAS LINEALES 1
+          needs: course
+        - type: subject
+          subject_needed_code: '1401'
+          subject_needed_name: SISTEMAS LINEALES 1
+          needs: exam
+        - type: subject
+          subject_needed_code: '1423'
+          subject_needed_name: SISTEMAS LINEALES 1
+          needs: exam
+        - type: subject
+          subject_needed_code: '1407'
+          subject_needed_name: SISTEMAS LINEALES 2
+          needs: exam
+      - type: logical
+        logical_operator: or
+        operands:
+        - type: subject
+          subject_needed_code: 1151P
+          subject_needed_name: CREDITOS NO ACUM FISICA 1
+          needs: exam
+        - type: subject
+          subject_needed_code: '1120'
+          subject_needed_name: FISICA GENERAL 1
+          needs: exam
+        - type: subject
+          subject_needed_code: '1170'
+          subject_needed_name: FISICA GENERAL 1
+          needs: exam
+        - type: subject
+          subject_needed_code: '1151'
+          subject_needed_name: FISICA 1
+          needs: exam
+        - type: subject
+          subject_needed_code: '1171'
+          subject_needed_name: FISICA 1
+          needs: exam
+    - type: logical
+      logical_operator: and
+      operands:
+      - type: credits
+        credits: 35
+        group: 12
+      - type: subject
+        needs: course
+        subject_needed_code: '1456'
+        subject_needed_name: TEORIA DE CIRCUITOS
+      - type: logical
+        logical_operator: or
+        operands:
+        - type: subject
+          subject_needed_code: 1153P
+          subject_needed_name: CREDITOS NO ACUM FISICA 3
+          needs: exam
+        - type: subject
+          subject_needed_code: '1121'
+          subject_needed_name: FISICA GENERAL 2
+          needs: exam
+        - type: subject
+          subject_needed_code: '1172'
+          subject_needed_name: FISICA GENERAL 2
+          needs: exam
+        - type: subject
+          subject_needed_code: '1153'
+          subject_needed_name: FISICA 3
+          needs: exam
+        - type: subject
+          subject_needed_code: '1173'
+          subject_needed_name: FISICA 3
+          needs: exam
+      - type: logical
+        logical_operator: or
+        operands:
+        - type: subject
+          subject_needed_code: '1021'
+          subject_needed_name: ALGEBRA LINEAL
+          needs: exam
+        - type: subject
+          subject_needed_code: MAT33
+          subject_needed_name: CREDITOS ASIGNADOS POR REVALIDA
+          needs: exam
+        - type: subject
+          subject_needed_code: 1030P
+          subject_needed_name: CREDITOS NO ACUM GAL1
+          needs: exam
+        - type: subject
+          subject_needed_code: '1030'
+          subject_needed_name: GEOMETRIA Y ALGEBRA LINEAL 1
+          needs: exam
+        - type: subject
+          subject_needed_code: '1071'
+          subject_needed_name: GEOMETRIA Y ALGEBRA LINEAL 1
+          needs: exam
+        - type: subject
+          subject_needed_code: '1053'
+          subject_needed_name: GEOMETRIA Y ALGEBRA LINEAL 1 (ANUAL)
+          needs: exam
+        - type: subject
+          subject_needed_code: GAL1P
+          subject_needed_name: GEOMETRIA Y ALGEBRA LINEAL 1 INTERACTIVA
+          needs: exam
+      - type: logical
+        logical_operator: or
+        operands:
+        - type: subject
+          subject_needed_code: '1128'
+          subject_needed_name: ELECTROMAGNETISMO
+          needs: course
+        - type: subject
+          subject_needed_code: '1178'
+          subject_needed_name: ELECTROMAGNETISMO
+          needs: exam
+      - type: logical
+        logical_operator: or
+        operands:
+        - type: subject
+          subject_needed_code: 1151P
+          subject_needed_name: CREDITOS NO ACUM FISICA 1
+          needs: exam
+        - type: subject
+          subject_needed_code: '1120'
+          subject_needed_name: FISICA GENERAL 1
+          needs: exam
+        - type: subject
+          subject_needed_code: '1170'
+          subject_needed_name: FISICA GENERAL 1
+          needs: exam
+        - type: subject
+          subject_needed_code: '1151'
+          subject_needed_name: FISICA 1
+          needs: exam
+        - type: subject
+          subject_needed_code: '1171'
+          subject_needed_name: FISICA 1
+          needs: exam
+      - type: logical
+        logical_operator: or
+        operands:
+        - type: subject
+          subject_needed_code: '1021'
+          subject_needed_name: ALGEBRA LINEAL
+          needs: exam
+        - type: subject
+          subject_needed_code: MAT33
+          subject_needed_name: CREDITOS ASIGNADOS POR REVALIDA
+          needs: exam
+        - type: subject
+          subject_needed_code: 1031P
+          subject_needed_name: CREDITOS NO ACUM GAL2
+          needs: exam
+        - type: subject
+          subject_needed_code: '1031'
+          subject_needed_name: GEOMETRIA Y ALGEBRA LINEAL 2
+          needs: exam
+        - type: subject
+          subject_needed_code: '1058'
+          subject_needed_name: GEOMETRIA Y ALGEBRA LINEAL 2
+          needs: exam
+      - type: logical
+        logical_operator: or
+        operands:
+        - type: subject
+          subject_needed_code: 1122P
+          subject_needed_name: CREDITOS NO ACUM MEC NEWTONIANA
+          needs: exam
+        - type: subject
+          subject_needed_code: '1078'
+          subject_needed_name: MECANICA NEWTONIANA
+          needs: exam
+        - type: subject
+          subject_needed_code: '1122'
+          subject_needed_name: MECANICA NEWTONIANA
+          needs: course
+      - type: logical
+        logical_operator: or
+        operands:
+        - type: subject
+          subject_needed_code: '1062'
+          subject_needed_name: CALCULO DIF. E INTEGRAL EN VARIAS VARIABLES
+          needs: exam
+        - type: subject
+          subject_needed_code: '1022'
+          subject_needed_name: CALCULO 2
+          needs: exam
+        - type: subject
+          subject_needed_code: '1072'
+          subject_needed_name: CALCULO 2
+          needs: exam
+        - type: subject
+          subject_needed_code: MAT33
+          subject_needed_name: CREDITOS ASIGNADOS POR REVALIDA
+          needs: exam
+        - type: subject
+          subject_needed_code: 1022P
+          subject_needed_name: CREDITOS NO ACUM CALCULO 2
+          needs: exam
+        - type: subject
+          subject_needed_code: 1062P
+          subject_needed_name: CREDITOS NO ACUM CDIVV
+          needs: exam
+      - type: logical
+        logical_operator: or
+        operands:
+        - type: subject
+          subject_needed_code: '1061'
+          subject_needed_name: CALCULO DIF. E INTEGRAL EN UNA VARIABLE
+          needs: exam
+        - type: subject
+          subject_needed_code: '1020'
+          subject_needed_name: CALCULO 1
+          needs: exam
+        - type: subject
+          subject_needed_code: '1070'
+          subject_needed_name: CALCULO 1
+          needs: exam
+        - type: subject
+          subject_needed_code: '1052'
+          subject_needed_name: CALCULO 1 (ANUAL)
+          needs: exam
+        - type: subject
+          subject_needed_code: MAT33
+          subject_needed_name: CREDITOS ASIGNADOS POR REVALIDA
+          needs: exam
+        - type: subject
+          subject_needed_code: 1020P
+          subject_needed_name: CREDITOS NO ACUM CALCULO 1
+          needs: exam
+        - type: subject
+          subject_needed_code: 1061P
+          subject_needed_name: CREDITOS NO ACUM CDIV
+          needs: exam
+  subject_code: '5850'
+  is_exam: false
+- type: logical
+  logical_operator: and
+  operands:
+  - type: logical
+    logical_operator: not
+    operands:
+    - type: logical
+      logical_operator: or
+      operands:
+      - type: subject
+        subject_needed_code: 5850P
+        subject_needed_name: CREDITOS NO ACUM ELECTROTECNICA
+        needs: all
+      - type: subject
+        subject_needed_code: '5601'
+        subject_needed_name: INT. A LA ELECTROTECNICA
+        needs: all
+      - type: subject
+        subject_needed_code: '5608'
+        subject_needed_name: INT. A LA ELECTROTECNICA
+        needs: all
+      - type: subject
+        subject_needed_code: '5830'
+        subject_needed_name: INT. A LA ELECTROTECNICA
+        needs: all
+  - type: logical
+    logical_operator: or
+    operands:
+    - type: logical
+      logical_operator: and
+      operands:
+      - type: logical
+        logical_operator: or
+        operands:
+        - type: subject
+          subject_needed_code: 1151P
+          subject_needed_name: CREDITOS NO ACUM FISICA 1
+          needs: exam
+        - type: subject
+          subject_needed_code: '1120'
+          subject_needed_name: FISICA GENERAL 1
+          needs: exam
+        - type: subject
+          subject_needed_code: '1170'
+          subject_needed_name: FISICA GENERAL 1
+          needs: exam
+        - type: subject
+          subject_needed_code: '1151'
+          subject_needed_name: FISICA 1
+          needs: exam
+        - type: subject
+          subject_needed_code: '1171'
+          subject_needed_name: FISICA 1
+          needs: exam
+      - type: logical
+        logical_operator: or
+        operands:
+        - type: subject
+          subject_needed_code: 1423P
+          subject_needed_name: CREDITOS NO ACUM SISTEMAS LINEALES 1
+          needs: course
+        - type: subject
+          subject_needed_code: '1401'
+          subject_needed_name: SISTEMAS LINEALES 1
+          needs: exam
+        - type: subject
+          subject_needed_code: '1423'
+          subject_needed_name: SISTEMAS LINEALES 1
+          needs: exam
+        - type: subject
+          subject_needed_code: '1407'
+          subject_needed_name: SISTEMAS LINEALES 2
+          needs: exam
+      - type: logical
+        logical_operator: or
+        operands:
+        - type: subject
+          subject_needed_code: 1128P
+          subject_needed_name: CREDITOS NO ACUM ELECTROMAGNETISMO
+          needs: exam
+        - type: subject
+          subject_needed_code: '1128'
+          subject_needed_name: ELECTROMAGNETISMO
+          needs: course
+        - type: subject
+          subject_needed_code: '1178'
+          subject_needed_name: ELECTROMAGNETISMO
+          needs: exam
+    - type: logical
+      logical_operator: and
+      operands:
+      - type: credits
+        credits: 35
+        group: 12
+      - type: subject
+        needs: course
+        subject_needed_code: '1456'
+        subject_needed_name: TEORIA DE CIRCUITOS
+      - type: logical
+        logical_operator: or
+        operands:
+        - type: subject
+          subject_needed_code: 1153P
+          subject_needed_name: CREDITOS NO ACUM FISICA 3
+          needs: exam
+        - type: subject
+          subject_needed_code: '1121'
+          subject_needed_name: FISICA GENERAL 2
+          needs: exam
+        - type: subject
+          subject_needed_code: '1172'
+          subject_needed_name: FISICA GENERAL 2
+          needs: exam
+        - type: subject
+          subject_needed_code: '1153'
+          subject_needed_name: FISICA 3
+          needs: exam
+        - type: subject
+          subject_needed_code: '1173'
+          subject_needed_name: FISICA 3
+          needs: exam
+      - type: logical
+        logical_operator: or
+        operands:
+        - type: subject
+          subject_needed_code: '1021'
+          subject_needed_name: ALGEBRA LINEAL
+          needs: exam
+        - type: subject
+          subject_needed_code: MAT33
+          subject_needed_name: CREDITOS ASIGNADOS POR REVALIDA
+          needs: exam
+        - type: subject
+          subject_needed_code: 1031P
+          subject_needed_name: CREDITOS NO ACUM GAL2
+          needs: exam
+        - type: subject
+          subject_needed_code: '1031'
+          subject_needed_name: GEOMETRIA Y ALGEBRA LINEAL 2
+          needs: exam
+        - type: subject
+          subject_needed_code: '1058'
+          subject_needed_name: GEOMETRIA Y ALGEBRA LINEAL 2
+          needs: exam
+      - type: logical
+        logical_operator: or
+        operands:
+        - type: subject
+          subject_needed_code: '1021'
+          subject_needed_name: ALGEBRA LINEAL
+          needs: exam
+        - type: subject
+          subject_needed_code: MAT33
+          subject_needed_name: CREDITOS ASIGNADOS POR REVALIDA
+          needs: exam
+        - type: subject
+          subject_needed_code: 1030P
+          subject_needed_name: CREDITOS NO ACUM GAL1
+          needs: exam
+        - type: subject
+          subject_needed_code: '1030'
+          subject_needed_name: GEOMETRIA Y ALGEBRA LINEAL 1
+          needs: exam
+        - type: subject
+          subject_needed_code: '1071'
+          subject_needed_name: GEOMETRIA Y ALGEBRA LINEAL 1
+          needs: exam
+        - type: subject
+          subject_needed_code: '1053'
+          subject_needed_name: GEOMETRIA Y ALGEBRA LINEAL 1 (ANUAL)
+          needs: exam
+        - type: subject
+          subject_needed_code: GAL1P
+          subject_needed_name: GEOMETRIA Y ALGEBRA LINEAL 1 INTERACTIVA
+          needs: exam
+      - type: logical
+        logical_operator: or
+        operands:
+        - type: subject
+          subject_needed_code: 1128P
+          subject_needed_name: CREDITOS NO ACUM ELECTROMAGNETISMO
+          needs: exam
+        - type: subject
+          subject_needed_code: '1128'
+          subject_needed_name: ELECTROMAGNETISMO
+          needs: course
+        - type: subject
+          subject_needed_code: '1178'
+          subject_needed_name: ELECTROMAGNETISMO
+          needs: exam
+      - type: logical
+        logical_operator: or
+        operands:
+        - type: subject
+          subject_needed_code: '1061'
+          subject_needed_name: CALCULO DIF. E INTEGRAL EN UNA VARIABLE
+          needs: exam
+        - type: subject
+          subject_needed_code: '1020'
+          subject_needed_name: CALCULO 1
+          needs: exam
+        - type: subject
+          subject_needed_code: '1070'
+          subject_needed_name: CALCULO 1
+          needs: exam
+        - type: subject
+          subject_needed_code: '1052'
+          subject_needed_name: CALCULO 1 (ANUAL)
+          needs: exam
+        - type: subject
+          subject_needed_code: MAT33
+          subject_needed_name: CREDITOS ASIGNADOS POR REVALIDA
+          needs: exam
+        - type: subject
+          subject_needed_code: 1020P
+          subject_needed_name: CREDITOS NO ACUM CALCULO 1
+          needs: exam
+        - type: subject
+          subject_needed_code: 1061P
+          subject_needed_name: CREDITOS NO ACUM CDIV
+          needs: exam
+      - type: logical
+        logical_operator: or
+        operands:
+        - type: subject
+          subject_needed_code: '1062'
+          subject_needed_name: CALCULO DIF. E INTEGRAL EN VARIAS VARIABLES
+          needs: exam
+        - type: subject
+          subject_needed_code: '1022'
+          subject_needed_name: CALCULO 2
+          needs: exam
+        - type: subject
+          subject_needed_code: '1072'
+          subject_needed_name: CALCULO 2
+          needs: exam
+        - type: subject
+          subject_needed_code: MAT33
+          subject_needed_name: CREDITOS ASIGNADOS POR REVALIDA
+          needs: exam
+        - type: subject
+          subject_needed_code: 1062P
+          subject_needed_name: CREDITOS NO ACUM CDIVV
+          needs: exam
+      - type: logical
+        logical_operator: or
+        operands:
+        - type: subject
+          subject_needed_code: 1151P
+          subject_needed_name: CREDITOS NO ACUM FISICA 1
+          needs: exam
+        - type: subject
+          subject_needed_code: '1120'
+          subject_needed_name: FISICA GENERAL 1
+          needs: exam
+        - type: subject
+          subject_needed_code: '1170'
+          subject_needed_name: FISICA GENERAL 1
+          needs: exam
+        - type: subject
+          subject_needed_code: '1151'
+          subject_needed_name: FISICA 1
+          needs: exam
+        - type: subject
+          subject_needed_code: '1171'
+          subject_needed_name: FISICA 1
+          needs: exam
+      - type: logical
+        logical_operator: or
+        operands:
+        - type: subject
+          subject_needed_code: 1122P
+          subject_needed_name: CREDITOS NO ACUM MEC NEWTONIANA
+          needs: exam
+        - type: subject
+          subject_needed_code: '1078'
+          subject_needed_name: MECANICA NEWTONIANA
+          needs: exam
+        - type: subject
+          subject_needed_code: '1122'
+          subject_needed_name: MECANICA NEWTONIANA
+          needs: course
+    - type: subject
+      needs: course
+      subject_needed_code: '5850'
+      subject_needed_name: ELECTROTECNICA
+  subject_code: '5850'
+  is_exam: true
+- type: logical
+  logical_operator: and
+  operands:
+  - type: logical
+    logical_operator: not
+    operands:
+    - type: subject
+      needs: course
+      subject_needed_code: '5842'
+      subject_needed_name: RECONOCIMIENTO DE PATRONES
+  - type: logical
+    logical_operator: or
+    operands:
+    - type: logical
+      logical_operator: and
+      operands:
+      - type: credits
+        credits: 50
+        group: 11
+      - type: subject
+        needs: course
+        subject_needed_code: '1457'
+        subject_needed_name: SEÑALES Y SISTEMAS
+      - type: logical
+        logical_operator: or
+        operands:
+        - type: subject
+          subject_needed_code: 1025P
+          subject_needed_name: CREDITOS NO ACUM PROB Y EST.
+          needs: exam
+        - type: subject
+          subject_needed_code: '1025'
+          subject_needed_name: PROBABILIDAD Y ESTADISTICA
+          needs: exam
+        - type: subject
+          subject_needed_code: '1075'
+          subject_needed_name: PROBABILIDAD Y ESTADISTICA
+          needs: exam
+    - type: subject
+      needs: exam
+      subject_needed_code: '1409'
+      subject_needed_name: MUESTREO Y PROCESAMIENTO DIGITAL
+  - type: logical
+    logical_operator: or
+    operands:
+    - type: subject
+      subject_needed_code: 1025P
+      subject_needed_name: CREDITOS NO ACUM PROB Y EST.
+      needs: exam
+    - type: subject
+      subject_needed_code: '1025'
+      subject_needed_name: PROBABILIDAD Y ESTADISTICA
+      needs: exam
+    - type: subject
+      subject_needed_code: '1075'
+      subject_needed_name: PROBABILIDAD Y ESTADISTICA
+      needs: exam
+  - type: logical
+    logical_operator: or
+    operands:
+    - type: subject
+      subject_needed_code: 1322P
+      subject_needed_name: CREDITOS NO ACUM PROGRAMACION 1
+      needs: exam
+    - type: subject
+      subject_needed_code: '1320'
+      subject_needed_name: PROGRAMACION 1
+      needs: exam
+    - type: subject
+      subject_needed_code: '1322'
+      subject_needed_name: PROGRAMACION 1
+      needs: exam
+    - type: subject
+      subject_needed_code: '1373'
+      subject_needed_name: PROGRAMACION 1
+      needs: exam
+  subject_code: '5852'
+  is_exam: false
+- type: logical
+  logical_operator: and
+  operands:
+  - type: logical
+    logical_operator: or
+    operands:
+    - type: subject
+      subject_needed_code: 5805P
+      subject_needed_name: CREDITOS NO ACUM REDES DE DATOS
+      needs: course
+    - type: subject
+      subject_needed_code: '5805'
+      subject_needed_name: REDES DE DATOS
+      needs: exam
+    - type: subject
+      subject_needed_code: '5824'
+      subject_needed_name: REDES DE DATOS 1
+      needs: course
+  subject_code: '5855'
+  is_exam: false
+- type: logical
+  logical_operator: and
+  operands:
+  - type: subject
+    needs: course
+    subject_needed_code: '5855'
+    subject_needed_name: REDES DE DATOS 2
+  subject_code: '5855'
+  is_exam: true
+- type: logical
+  logical_operator: and
+  operands:
+  - type: logical
+    logical_operator: or
+    operands:
+    - type: subject
+      needs: course
+      subject_needed_code: '5808'
+      subject_needed_name: SISTEMAS DE COMUNICACION
+    - type: subject
+      needs: course
+      subject_needed_code: '1462'
+      subject_needed_name: COMUNICACIONES DIGITALES
+  - type: subject
+    needs: exam
+    subject_needed_code: '5817'
+    subject_needed_name: ANTENAS Y PROPAGACION
+  subject_code: '5860'
+  is_exam: false
+- type: logical
+  logical_operator: and
+  operands:
+  - type: credits
+    credits: 70
+    group: 11
+  - type: subject
+    needs: exam
+    subject_needed_code: '1460'
+    subject_needed_name: SEÑALES ALEATORIAS Y MODULACION
+  - type: subject
+    needs: exam
+    subject_needed_code: '1025'
+    subject_needed_name: PROBABILIDAD Y ESTADISTICA
+  - type: subject
+    needs: exam
+    subject_needed_code: '1457'
+    subject_needed_name: SEÑALES Y SISTEMAS
+  - type: subject
+    needs: exam
+    subject_needed_code: '5824'
+    subject_needed_name: REDES DE DATOS 1
+  - type: subject
+    needs: exam
+    subject_needed_code: '1373'
+    subject_needed_name: PROGRAMACION 1
+  - type: subject
+    needs: course
+    subject_needed_code: '1462'
+    subject_needed_name: COMUNICACIONES DIGITALES
+  subject_code: '5863'
+  is_exam: false
+- type: logical
+  logical_operator: and
+  operands:
+  - type: credits
+    credits: 70
+    group: 11
+  - type: subject
+    needs: exam
+    subject_needed_code: '1460'
+    subject_needed_name: SEÑALES ALEATORIAS Y MODULACION
+  - type: subject
+    needs: exam
+    subject_needed_code: '1025'
+    subject_needed_name: PROBABILIDAD Y ESTADISTICA
+  - type: subject
+    needs: exam
+    subject_needed_code: '1457'
+    subject_needed_name: SEÑALES Y SISTEMAS
+  - type: subject
+    needs: exam
+    subject_needed_code: '1373'
+    subject_needed_name: PROGRAMACION 1
+  subject_code: '5864'
+  is_exam: false
+- type: logical
+  logical_operator: and
+  operands:
+  - type: logical
+    logical_operator: not
+    operands:
+    - type: logical
+      logical_operator: or
+      operands:
+      - type: subject
+        subject_needed_code: '5834'
+        subject_needed_name: NUCLEO DE RED EN TELECOMUNICACIONES
+        needs: exam
+      - type: subject
+        subject_needed_code: '5856'
+        subject_needed_name: TECNOLOGIAS DE REDES Y SERVICIOS DE TELECOMUNICACIONES
+        needs: exam
+  - type: logical
+    logical_operator: or
+    operands:
+    - type: logical
+      logical_operator: at_least
+      amount_of_subjects_needed: 2
+      operands:
+      - type: subject
+        subject_needed_code: 5824P
+        subject_needed_name: CREDITOS NO ACUM REDES DE DATOS 1
+        needs: course
+      - type: subject
+        subject_needed_code: '5805'
+        subject_needed_name: REDES DE DATOS
+        needs: exam
+      - type: subject
+        subject_needed_code: '5824'
+        subject_needed_name: REDES DE DATOS 1
+        needs: course
+      - type: subject
+        subject_needed_code: '1457'
+        subject_needed_name: SEÑALES Y SISTEMAS
+        needs: exam
+    - type: logical
+      logical_operator: at_least
+      amount_of_subjects_needed: 2
+      operands:
+      - type: subject
+        subject_needed_code: '1103'
+        subject_needed_name: MUESTREO Y PROCESAMIENTO DIGITAL
+        needs: exam
+      - type: subject
+        subject_needed_code: '1409'
+        subject_needed_name: MUESTREO Y PROCESAMIENTO DIGITAL
+        needs: exam
+      - type: subject
+        subject_needed_code: '5801'
+        subject_needed_name: SISTEMAS DE COMUNICACION
+        needs: exam
+      - type: subject
+        subject_needed_code: '5808'
+        subject_needed_name: SISTEMAS DE COMUNICACION
+        needs: course
+  subject_code: '5866'
+  is_exam: false
+- type: logical
+  logical_operator: and
+  operands:
+  - type: subject
+    needs: course
+    subject_needed_code: '5866'
+    subject_needed_name: TECNOLOGIAS DE REDES Y SERVICIOS DE TELECOMUNICACIONES
+  subject_code: '5866'
+  is_exam: true
+- type: logical
+  logical_operator: and
+  operands:
+  - type: logical
+    logical_operator: not
+    operands:
+    - type: credits
+      credits: 70
+  - type: logical
+    logical_operator: not
+    operands:
+    - type: subject
+      needs: all
+      subject_needed_code: '1220'
+      subject_needed_name: TALLER DE DISEÑO, COM. Y REPRES. GRAFICA
+  - type: logical
+    logical_operator: not
+    operands:
+    - type: subject
+      needs: all
+      subject_needed_code: '1266'
+      subject_needed_name: TALLER DE REPRESENTACION Y COMUNICACION GRAFICA_MODULO
+        A
+  subject_code: '5904'
+  is_exam: false
+- type: logical
+  logical_operator: and
+  operands:
+  - type: credits
+    credits: 45
+    group: 12
+  - type: credits
+    credits: 59
+    group: 11
+  - type: credits
+    credits: 5
+    group: 21
+  - type: subject
+    needs: course
+    subject_needed_code: '1456'
+    subject_needed_name: TEORIA DE CIRCUITOS
+  - type: subject
+    needs: course
+    subject_needed_code: '1457'
+    subject_needed_name: SEÑALES Y SISTEMAS
+  - type: logical
+    logical_operator: or
+    operands:
+    - type: subject
+      subject_needed_code: 1028P
+      subject_needed_name: CREDITOS NO ACUM EC. DIFERENCIALES
+      needs: exam
+    - type: subject
+      subject_needed_code: '1028'
+      subject_needed_name: ECUACIONES DIFERENCIALES
+      needs: exam
+    - type: subject
+      subject_needed_code: '1074'
+      subject_needed_name: ECUACIONES DIFERENCIALES
+      needs: exam
+    - type: subject
+      subject_needed_code: '1064'
+      subject_needed_name: INT. A LAS ECUACIONES DIFERENCIALES
+      needs: course
+  - type: logical
+    logical_operator: or
+    operands:
+    - type: subject
+      subject_needed_code: '1036'
+      subject_needed_name: FUNCIONES DE VARIABLE COMPLEJA
+      needs: exam
+    - type: subject
+      subject_needed_code: '1066'
+      subject_needed_name: FUNCIONES DE VARIABLE COMPLEJA
+      needs: course
+  - type: logical
+    logical_operator: or
+    operands:
+    - type: subject
+      subject_needed_code: 1154P
+      subject_needed_name: CREDITOS NO ACUM FISICA EXPERIMENTAL 1
+      needs: exam
+    - type: subject
+      subject_needed_code: '1154'
+      subject_needed_name: FISICA EXPERIMENTAL 1
+      needs: course
+    - type: subject
+      subject_needed_code: '1124'
+      subject_needed_name: LABORATORIO 1
+      needs: course
+  subject_code: '5905'
+  is_exam: false
+- type: logical
+  logical_operator: and
+  operands:
+  - type: subject
+    needs: course
+    subject_needed_code: '5905'
+    subject_needed_name: SISTEMAS Y CONTROL
+  subject_code: '5905'
+  is_exam: true
+- type: logical
+  logical_operator: and
+  operands:
+  - type: logical
+    logical_operator: or
+    operands:
+    - type: subject
+      subject_needed_code: '5900'
+      subject_needed_name: INT. A LA TEORIA DE CONTROL
+      needs: all
+    - type: subject
+      subject_needed_code: '5905'
+      subject_needed_name: SISTEMAS Y CONTROL
+      needs: all
+  subject_code: '5906'
+  is_exam: false
+- type: logical
+  logical_operator: and
+  operands:
+  - type: subject
+    needs: course
+    subject_needed_code: '1462'
+    subject_needed_name: COMUNICACIONES DIGITALES
+  - type: subject
+    needs: exam
+    subject_needed_code: '1460'
+    subject_needed_name: SEÑALES ALEATORIAS Y MODULACION
+  - type: logical
+    logical_operator: or
+    operands:
+    - type: subject
+      subject_needed_code: '5805'
+      subject_needed_name: REDES DE DATOS
+      needs: exam
+    - type: subject
+      subject_needed_code: '5824'
+      subject_needed_name: REDES DE DATOS 1
+      needs: exam
+  subject_code: '5907'
+  is_exam: false
+- type: logical
+  logical_operator: and
+  operands:
+  - type: credits
+    credits: 60
+    group: 11
+  - type: subject
+    needs: course
+    subject_needed_code: '1307'
+    subject_needed_name: PROGRAMACION PARA INGENIERIA ELECTRICA
+  - type: subject
+    needs: exam
+    subject_needed_code: '1025'
+    subject_needed_name: PROBABILIDAD Y ESTADISTICA
+  - type: subject
+    needs: exam
+    subject_needed_code: '1457'
+    subject_needed_name: SEÑALES Y SISTEMAS
+  subject_code: '5908'
+  is_exam: false
+- type: logical
+  logical_operator: and
+  operands:
+  - type: logical
+    logical_operator: or
+    operands:
+    - type: subject
+      subject_needed_code: '1028'
+      subject_needed_name: ECUACIONES DIFERENCIALES
+      needs: all
+    - type: subject
+      subject_needed_code: '1074'
+      subject_needed_name: ECUACIONES DIFERENCIALES
+      needs: all
+    - type: subject
+      subject_needed_code: '1064'
+      subject_needed_name: INT. A LAS ECUACIONES DIFERENCIALES
+      needs: all
+  subject_code: '5913'
+  is_exam: false
+- type: logical
+  logical_operator: and
+  operands:
+  - type: logical
+    logical_operator: not
+    operands:
+    - type: subject
+      needs: course
+      subject_needed_code: '5910'
+      subject_needed_name: INT. A LOS PLC
+  - type: subject
+    needs: course
+    subject_needed_code: '5905'
+    subject_needed_name: SISTEMAS Y CONTROL
+  - type: subject
+    needs: exam
+    subject_needed_code: '1373'
+    subject_needed_name: PROGRAMACION 1
+  subject_code: '5920'
+  is_exam: false
+- type: logical
+  logical_operator: and
+  operands:
+  - type: logical
+    logical_operator: or
+    operands:
+    - type: subject
+      subject_needed_code: '1061'
+      subject_needed_name: CALCULO DIF. E INTEGRAL EN UNA VARIABLE
+      needs: exam
+    - type: subject
+      subject_needed_code: '1020'
+      subject_needed_name: CALCULO 1
+      needs: exam
+    - type: subject
+      subject_needed_code: '1070'
+      subject_needed_name: CALCULO 1
+      needs: exam
+  - type: logical
+    logical_operator: or
+    operands:
+    - type: subject
+      subject_needed_code: '1031'
+      subject_needed_name: GEOMETRIA Y ALGEBRA LINEAL 2
+      needs: course
+    - type: subject
+      subject_needed_code: '1058'
+      subject_needed_name: GEOMETRIA Y ALGEBRA LINEAL 2
+      needs: exam
+  - type: logical
+    logical_operator: or
+    operands:
+    - type: subject
+      subject_needed_code: '1062'
+      subject_needed_name: CALCULO DIF. E INTEGRAL EN VARIAS VARIABLES
+      needs: course
+    - type: subject
+      subject_needed_code: '1022'
+      subject_needed_name: CALCULO 2
+      needs: exam
+    - type: subject
+      subject_needed_code: '1072'
+      subject_needed_name: CALCULO 2
+      needs: exam
+  - type: logical
+    logical_operator: or
+    operands:
+    - type: subject
+      subject_needed_code: '1151'
+      subject_needed_name: FISICA 1
+      needs: exam
+    - type: subject
+      subject_needed_code: '1171'
+      subject_needed_name: FISICA 1
+      needs: exam
+  - type: logical
+    logical_operator: or
+    operands:
+    - type: subject
+      subject_needed_code: '1030'
+      subject_needed_name: GEOMETRIA Y ALGEBRA LINEAL 1
+      needs: exam
+    - type: subject
+      subject_needed_code: '1071'
+      subject_needed_name: GEOMETRIA Y ALGEBRA LINEAL 1
+      needs: exam
+    - type: subject
+      subject_needed_code: GAL1P
+      subject_needed_name: GEOMETRIA Y ALGEBRA LINEAL 1 INTERACTIVA
+      needs: exam
+  subject_code: BG827
+  is_exam: false
+- type: logical
+  logical_operator: and
+  operands:
+  - type: subject
+    needs: course
+    subject_needed_code: BG827
+    subject_needed_name: BIOFÍSICA (2020-
+  subject_code: BG827
+  is_exam: true
+- type: logical
+  logical_operator: and
+  operands:
+  - type: credits
+    credits: 10
+    group: 21
+  - type: subject
+    needs: course
+    subject_needed_code: '5839'
+    subject_needed_name: PROCESAMIENTO DIGITAL DE SEÑALES DE AUDIO
+  subject_code: ETSON
+  is_exam: false
+- type: logical
+  logical_operator: and
+  operands:
+  - type: credits
+    credits: 10
+    group: 21
+  - type: subject
+    needs: course
+    subject_needed_code: '5839'
+    subject_needed_name: PROCESAMIENTO DIGITAL DE SEÑALES DE AUDIO
+  subject_code: ETSON
+  is_exam: true
+- type: logical
+  logical_operator: and
+  operands:
+  - type: logical
+    logical_operator: not
+    operands:
+    - type: subject
+      needs: course_enrollment
+      subject_needed_code: '1030'
+      subject_needed_name: GEOMETRIA Y ALGEBRA LINEAL 1
+  - type: logical
+    logical_operator: not
+    operands:
+    - type: logical
+      logical_operator: or
+      operands:
+      - type: subject
+        subject_needed_code: CM14
+        subject_needed_name: CREDITOS ASIGNADOS POR REVALIDA
+        needs: exam
+      - type: subject
+        subject_needed_code: GAL7
+        subject_needed_name: CREDITOS ASIGNADOS POR REVALIDA
+        needs: exam
+      - type: subject
+        subject_needed_code: MAT33
+        subject_needed_name: CREDITOS ASIGNADOS POR REVALIDA
+        needs: exam
+      - type: subject
+        subject_needed_code: MA51
+        subject_needed_name: CREDITOS ASIGNADOS POR REVALIDA
+        needs: exam
+      - type: subject
+        subject_needed_code: MA7
+        subject_needed_name: CREDITOS ASIGNADOS POR REVALIDA
+        needs: exam
+      - type: subject
+        subject_needed_code: MC3
+        subject_needed_name: CREDITOS ASIGNADOS POR REVALIDA
+        needs: exam
+      - type: subject
+        subject_needed_code: M24
+        subject_needed_name: CREDITOS ASIGNADOS POR REVALIDA
+        needs: exam
+      - type: subject
+        subject_needed_code: M9
+        subject_needed_name: CREDITOS ASIGNADOS POR REVALIDA
+        needs: exam
+      - type: subject
+        subject_needed_code: 1030P
+        subject_needed_name: CREDITOS NO ACUM GAL1
+        needs: exam
+      - type: subject
+        subject_needed_code: CP2
+        subject_needed_name: GEOMETRIA Y ALGEBRA LINEAL
+        needs: exam
+      - type: subject
+        subject_needed_code: CP23
+        subject_needed_name: GEOMETRIA Y ALGEBRA LINEAL (P. 74)
+        needs: exam
+      - type: subject
+        subject_needed_code: CP46
+        subject_needed_name: GEOMETRIA Y ALGEBRA LINEAL (1ER.SEM.)
+        needs: exam
+      - type: subject
+        subject_needed_code: '1030'
+        subject_needed_name: GEOMETRIA Y ALGEBRA LINEAL 1
+        needs: exam
+      - type: subject
+        subject_needed_code: '1071'
+        subject_needed_name: GEOMETRIA Y ALGEBRA LINEAL 1
+        needs: exam
+      - type: subject
+        subject_needed_code: 171L
+        subject_needed_name: GEOMETRIA Y ALGEBRA LINEAL 1
+        needs: exam
+      - type: subject
+        subject_needed_code: 171Q
+        subject_needed_name: GEOMETRIA Y ALGEBRA LINEAL 1
+        needs: exam
+      - type: subject
+        subject_needed_code: '1053'
+        subject_needed_name: GEOMETRIA Y ALGEBRA LINEAL 1 (ANUAL)
+        needs: exam
+  subject_code: GAL1P
+  is_exam: false
+- type: logical
+  logical_operator: and
+  operands:
+  - type: logical
+    logical_operator: not
+    operands:
+    - type: subject
+      needs: exam_enrollment
+      subject_needed_code: '1030'
+      subject_needed_name: GEOMETRIA Y ALGEBRA LINEAL 1
+  - type: logical
+    logical_operator: not
+    operands:
+    - type: logical
+      logical_operator: or
+      operands:
+      - type: subject
+        subject_needed_code: CM14
+        subject_needed_name: CREDITOS ASIGNADOS POR REVALIDA
+        needs: exam
+      - type: subject
+        subject_needed_code: GAL7
+        subject_needed_name: CREDITOS ASIGNADOS POR REVALIDA
+        needs: exam
+      - type: subject
+        subject_needed_code: MAT33
+        subject_needed_name: CREDITOS ASIGNADOS POR REVALIDA
+        needs: exam
+      - type: subject
+        subject_needed_code: MA51
+        subject_needed_name: CREDITOS ASIGNADOS POR REVALIDA
+        needs: exam
+      - type: subject
+        subject_needed_code: MA7
+        subject_needed_name: CREDITOS ASIGNADOS POR REVALIDA
+        needs: exam
+      - type: subject
+        subject_needed_code: MC3
+        subject_needed_name: CREDITOS ASIGNADOS POR REVALIDA
+        needs: exam
+      - type: subject
+        subject_needed_code: M24
+        subject_needed_name: CREDITOS ASIGNADOS POR REVALIDA
+        needs: exam
+      - type: subject
+        subject_needed_code: M9
+        subject_needed_name: CREDITOS ASIGNADOS POR REVALIDA
+        needs: exam
+      - type: subject
+        subject_needed_code: 1030P
+        subject_needed_name: CREDITOS NO ACUM GAL1
+        needs: exam
+      - type: subject
+        subject_needed_code: CP2
+        subject_needed_name: GEOMETRIA Y ALGEBRA LINEAL
+        needs: exam
+      - type: subject
+        subject_needed_code: CP23
+        subject_needed_name: GEOMETRIA Y ALGEBRA LINEAL (P. 74)
+        needs: exam
+      - type: subject
+        subject_needed_code: CP46
+        subject_needed_name: GEOMETRIA Y ALGEBRA LINEAL (1ER.SEM.)
+        needs: exam
+      - type: subject
+        subject_needed_code: '1030'
+        subject_needed_name: GEOMETRIA Y ALGEBRA LINEAL 1
+        needs: exam
+      - type: subject
+        subject_needed_code: '1071'
+        subject_needed_name: GEOMETRIA Y ALGEBRA LINEAL 1
+        needs: exam
+      - type: subject
+        subject_needed_code: 171L
+        subject_needed_name: GEOMETRIA Y ALGEBRA LINEAL 1
+        needs: exam
+      - type: subject
+        subject_needed_code: 171Q
+        subject_needed_name: GEOMETRIA Y ALGEBRA LINEAL 1
+        needs: exam
+      - type: subject
+        subject_needed_code: '1053'
+        subject_needed_name: GEOMETRIA Y ALGEBRA LINEAL 1 (ANUAL)
+        needs: exam
+  subject_code: GAL1P
+  is_exam: true
+- type: logical
+  logical_operator: and
+  operands:
+  - type: subject
+    needs: exam
+    subject_needed_code: '1456'
+    subject_needed_name: TEORIA DE CIRCUITOS
+  - type: subject
+    needs: course
+    subject_needed_code: '5715'
+    subject_needed_name: ELECTRONICA FUNDAMENTAL
+  subject_code: LIB10
+  is_exam: false
+- type: logical
+  logical_operator: and
+  operands:
+  - type: subject
+    needs: course
+    subject_needed_code: LIB10
+    subject_needed_name: TALLER DE INGENIERÍA BIOLÓGICA II
+  subject_code: LIB10
+  is_exam: true
+- type: logical
+  logical_operator: and
+  operands:
+  - type: subject
+    needs: exam
+    subject_needed_code: '1513'
+    subject_needed_name: INT. A LOS MICROPROCESADORES
+  - type: subject
+    needs: exam
+    subject_needed_code: '1512'
+    subject_needed_name: DISEÑO LOGICO
+  - type: logical
+    logical_operator: or
+    operands:
+    - type: subject
+      subject_needed_code: '1307'
+      subject_needed_name: PROGRAMACION PARA INGENIERIA ELECTRICA
+      needs: all
+    - type: subject
+      subject_needed_code: '1321'
+      subject_needed_name: PROGRAMACION 2
+      needs: all
+  subject_code: LIB36
+  is_exam: false
+- type: logical
+  logical_operator: and
+  operands:
+  - type: subject
+    needs: course
+    subject_needed_code: LIB36
+    subject_needed_name: INFORMÁTICA EN BIOLOGÍA Y MEDICINA
+  subject_code: LIB36
+  is_exam: true
+- type: logical
+  logical_operator: and
+  operands:
+  - type: subject
+    needs: exam
+    subject_needed_code: '1457'
+    subject_needed_name: SEÑALES Y SISTEMAS
+  - type: subject
+    needs: course
+    subject_needed_code: '1033'
+    subject_needed_name: METODOS NUMERICOS
+  - type: logical
+    logical_operator: or
+    operands:
+    - type: subject
+      subject_needed_code: '1028'
+      subject_needed_name: ECUACIONES DIFERENCIALES
+      needs: all
+    - type: subject
+      subject_needed_code: '1074'
+      subject_needed_name: ECUACIONES DIFERENCIALES
+      needs: all
+    - type: subject
+      subject_needed_code: '1064'
+      subject_needed_name: INT. A LAS ECUACIONES DIFERENCIALES
+      needs: all
+  - type: logical
+    logical_operator: or
+    operands:
+    - type: subject
+      subject_needed_code: '1307'
+      subject_needed_name: PROGRAMACION PARA INGENIERIA ELECTRICA
+      needs: all
+    - type: subject
+      subject_needed_code: '1321'
+      subject_needed_name: PROGRAMACION 2
+      needs: all
+  subject_code: LIB38
+  is_exam: false
+- type: logical
+  logical_operator: and
+  operands:
+  - type: subject
+    needs: course
+    subject_needed_code: LIB38
+    subject_needed_name: FISIOLOGÍA CUANTITATIVA
+  subject_code: LIB38
+  is_exam: true
+- type: logical
+  logical_operator: and
+  operands:
+  - type: logical
+    logical_operator: not
+    operands:
+    - type: subject
+      needs: course_enrollment
+      subject_needed_code: '01'
+      subject_needed_name: MAT. 01 (ANÁLISIS I)
+  - type: logical
+    logical_operator: not
+    operands:
+    - type: logical
+      logical_operator: or
+      operands:
+      - type: subject
+        subject_needed_code: CP1
+        subject_needed_name: ANALISIS MATEMATICO I
+        needs: exam
+      - type: subject
+        subject_needed_code: CP22
+        subject_needed_name: ANALISIS MATEMATICO I (P. 74)
+        needs: exam
+      - type: subject
+        subject_needed_code: CP44
+        subject_needed_name: ANALISIS MATEMATICO I (1ER.SEM.)
+        needs: exam
+      - type: subject
+        subject_needed_code: '1061'
+        subject_needed_name: CALCULO DIF. E INTEGRAL EN UNA VARIABLE
+        needs: exam
+      - type: subject
+        subject_needed_code: '1020'
+        subject_needed_name: CALCULO 1
+        needs: exam
+      - type: subject
+        subject_needed_code: 107L
+        subject_needed_name: CALCULO 1
+        needs: exam
+      - type: subject
+        subject_needed_code: '1070'
+        subject_needed_name: CALCULO 1
+        needs: exam
+      - type: subject
+        subject_needed_code: 170Q
+        subject_needed_name: CALCULO 1
+        needs: exam
+      - type: subject
+        subject_needed_code: '1052'
+        subject_needed_name: CALCULO 1 (ANUAL)
+        needs: exam
+      - type: subject
+        subject_needed_code: CAL10
+        subject_needed_name: CREDITOS ASIGNADOS POR REVALIDA
+        needs: exam
+      - type: subject
+        subject_needed_code: CAL12
+        subject_needed_name: CREDITOS ASIGNADOS POR REVALIDA
+        needs: exam
+      - type: subject
+        subject_needed_code: MAT14
+        subject_needed_name: CREDITOS ASIGNADOS POR REVALIDA
+        needs: exam
+      - type: subject
+        subject_needed_code: MAT33
+        subject_needed_name: CREDITOS ASIGNADOS POR REVALIDA
+        needs: exam
+      - type: subject
+        subject_needed_code: MA11
+        subject_needed_name: CREDITOS ASIGNADOS POR REVALIDA
+        needs: exam
+      - type: subject
+        subject_needed_code: MA25
+        subject_needed_name: CREDITOS ASIGNADOS POR REVALIDA
+        needs: exam
+      - type: subject
+        subject_needed_code: MA47
+        subject_needed_name: CREDITOS ASIGNADOS POR REVALIDA
+        needs: exam
+      - type: subject
+        subject_needed_code: MA51
+        subject_needed_name: CREDITOS ASIGNADOS POR REVALIDA
+        needs: exam
+      - type: subject
+        subject_needed_code: MC13
+        subject_needed_name: CREDITOS ASIGNADOS POR REVALIDA
+        needs: exam
+      - type: subject
+        subject_needed_code: M12
+        subject_needed_name: CREDITOS ASIGNADOS POR REVALIDA
+        needs: exam
+      - type: subject
+        subject_needed_code: M13
+        subject_needed_name: CREDITOS ASIGNADOS POR REVALIDA
+        needs: exam
+      - type: subject
+        subject_needed_code: 1020R
+        subject_needed_name: CREDITOS ASIGNADOS POR REVALIDA
+        needs: exam
+      - type: subject
+        subject_needed_code: 1061P
+        subject_needed_name: CREDITOS NO ACUM CDIV
+        needs: exam
+      - type: subject
+        subject_needed_code: '01'
+        subject_needed_name: MAT. 01 (ANÁLISIS I)
+        needs: exam
+      - type: subject
+        subject_needed_code: '101'
+        subject_needed_name: MATEMÁTICA 101 (ANÁLISIS I)
+        needs: exam
+  - type: logical
+    logical_operator: not
+    operands:
+    - type: logical
+      logical_operator: or
+      operands:
+      - type: subject
+        subject_needed_code: '1061'
+        subject_needed_name: CALCULO DIF. E INTEGRAL EN UNA VARIABLE
+        needs: course
+      - type: subject
+        subject_needed_code: '1020'
+        subject_needed_name: CALCULO 1
+        needs: course
+      - type: subject
+        subject_needed_code: '01'
+        subject_needed_name: MAT. 01 (ANÁLISIS I)
+        needs: course
+      - type: subject
+        subject_needed_code: '101'
+        subject_needed_name: MATEMÁTICA 101 (ANÁLISIS I)
+        needs: course
+  subject_code: MI2
+  is_exam: false
+- type: logical
+  logical_operator: and
+  operands:
+  - type: logical
+    logical_operator: not
+    operands:
+    - type: subject
+      needs: course_enrollment
+      subject_needed_code: '01'
+      subject_needed_name: MAT. 01 (ANÁLISIS I)
+  - type: logical
+    logical_operator: not
+    operands:
+    - type: logical
+      logical_operator: or
+      operands:
+      - type: subject
+        subject_needed_code: CP1
+        subject_needed_name: ANALISIS MATEMATICO I
+        needs: exam
+      - type: subject
+        subject_needed_code: CP22
+        subject_needed_name: ANALISIS MATEMATICO I (P. 74)
+        needs: exam
+      - type: subject
+        subject_needed_code: CP44
+        subject_needed_name: ANALISIS MATEMATICO I (1ER.SEM.)
+        needs: exam
+      - type: subject
+        subject_needed_code: '1061'
+        subject_needed_name: CALCULO DIF. E INTEGRAL EN UNA VARIABLE
+        needs: exam
+      - type: subject
+        subject_needed_code: '1020'
+        subject_needed_name: CALCULO 1
+        needs: exam
+      - type: subject
+        subject_needed_code: 107L
+        subject_needed_name: CALCULO 1
+        needs: exam
+      - type: subject
+        subject_needed_code: '1070'
+        subject_needed_name: CALCULO 1
+        needs: exam
+      - type: subject
+        subject_needed_code: 170Q
+        subject_needed_name: CALCULO 1
+        needs: exam
+      - type: subject
+        subject_needed_code: '1052'
+        subject_needed_name: CALCULO 1 (ANUAL)
+        needs: exam
+      - type: subject
+        subject_needed_code: CAL10
+        subject_needed_name: CREDITOS ASIGNADOS POR REVALIDA
+        needs: exam
+      - type: subject
+        subject_needed_code: CAL12
+        subject_needed_name: CREDITOS ASIGNADOS POR REVALIDA
+        needs: exam
+      - type: subject
+        subject_needed_code: MAT14
+        subject_needed_name: CREDITOS ASIGNADOS POR REVALIDA
+        needs: exam
+      - type: subject
+        subject_needed_code: MAT33
+        subject_needed_name: CREDITOS ASIGNADOS POR REVALIDA
+        needs: exam
+      - type: subject
+        subject_needed_code: MA11
+        subject_needed_name: CREDITOS ASIGNADOS POR REVALIDA
+        needs: exam
+      - type: subject
+        subject_needed_code: MA25
+        subject_needed_name: CREDITOS ASIGNADOS POR REVALIDA
+        needs: exam
+      - type: subject
+        subject_needed_code: MA47
+        subject_needed_name: CREDITOS ASIGNADOS POR REVALIDA
+        needs: exam
+      - type: subject
+        subject_needed_code: MA51
+        subject_needed_name: CREDITOS ASIGNADOS POR REVALIDA
+        needs: exam
+      - type: subject
+        subject_needed_code: MC13
+        subject_needed_name: CREDITOS ASIGNADOS POR REVALIDA
+        needs: exam
+      - type: subject
+        subject_needed_code: M12
+        subject_needed_name: CREDITOS ASIGNADOS POR REVALIDA
+        needs: exam
+      - type: subject
+        subject_needed_code: M13
+        subject_needed_name: CREDITOS ASIGNADOS POR REVALIDA
+        needs: exam
+      - type: subject
+        subject_needed_code: 1020R
+        subject_needed_name: CREDITOS ASIGNADOS POR REVALIDA
+        needs: exam
+      - type: subject
+        subject_needed_code: 1061P
+        subject_needed_name: CREDITOS NO ACUM CDIV
+        needs: exam
+      - type: subject
+        subject_needed_code: '01'
+        subject_needed_name: MAT. 01 (ANÁLISIS I)
+        needs: exam
+      - type: subject
+        subject_needed_code: '101'
+        subject_needed_name: MATEMÁTICA 101 (ANÁLISIS I)
+        needs: exam
+  - type: logical
+    logical_operator: not
+    operands:
+    - type: logical
+      logical_operator: or
+      operands:
+      - type: subject
+        subject_needed_code: '1061'
+        subject_needed_name: CALCULO DIF. E INTEGRAL EN UNA VARIABLE
+        needs: course
+      - type: subject
+        subject_needed_code: '1020'
+        subject_needed_name: CALCULO 1
+        needs: course
+      - type: subject
+        subject_needed_code: '01'
+        subject_needed_name: MAT. 01 (ANÁLISIS I)
+        needs: course
+      - type: subject
+        subject_needed_code: '101'
+        subject_needed_name: MATEMÁTICA 101 (ANÁLISIS I)
+        needs: course
+  subject_code: MI2
+  is_exam: true
+- type: logical
+  logical_operator: and
+  operands:
+  - type: logical
+    logical_operator: not
+    operands:
+    - type: subject
+      needs: all
+      subject_needed_code: Q58
+      subject_needed_name: INT. A LA PREVENCION DE RIESGOS LABORALES
+  - type: credits
+    credits: 270
+  subject_code: Q16
+  is_exam: false
+- type: logical
+  logical_operator: and
+  operands:
+  - type: subject
+    needs: course
+    subject_needed_code: Q16
+    subject_needed_name: INT. A LA PREVENCION DE RIESGOS LABORALES
+  subject_code: Q16
+  is_exam: true
+- type: logical
+  logical_operator: and
+  operands:
+  - type: credits
+    credits: 50
+    group: 12
+  - type: credits
+    credits: 50
+    group: 11
+  - type: subject
+    needs: exam
+    subject_needed_code: '1456'
+    subject_needed_name: TEORIA DE CIRCUITOS
+  - type: subject
+    needs: exam
+    subject_needed_code: '5850'
+    subject_needed_name: ELECTROTECNICA
+  - type: subject
+    needs: exam
+    subject_needed_code: '1620'
+    subject_needed_name: PRINCIPIOS DE QUIMICA GENERAL
+  - type: logical
+    logical_operator: or
+    operands:
+    - type: subject
+      subject_needed_code: '1128'
+      subject_needed_name: ELECTROMAGNETISMO
+      needs: exam
+    - type: subject
+      subject_needed_code: '1178'
+      subject_needed_name: ELECTROMAGNETISMO
+      needs: exam
+  subject_code: Q47
+  is_exam: false
+- type: logical
+  logical_operator: and
+  operands:
+  - type: logical
+    logical_operator: or
+    operands:
+    - type: subject
+      subject_needed_code: '5805'
+      subject_needed_name: REDES DE DATOS
+      needs: exam
+    - type: subject
+      subject_needed_code: '5824'
+      subject_needed_name: REDES DE DATOS 1
+      needs: course
+  subject_code: TTR13
+  is_exam: false

--- a/db/data/electrica/scraped_subject_groups.yml
+++ b/db/data/electrica/scraped_subject_groups.yml
@@ -1,0 +1,89 @@
+---
+'011':
+  code: '011'
+  name: MATEMATICA
+  min_credits: 75
+'012':
+  code: '012'
+  name: FISICA
+  min_credits: 50
+'013':
+  code: '013'
+  name: OTRAS AREAS DE FORMACION BASICA
+  min_credits: 0
+'021':
+  code: '021'
+  name: FUNDAMENTOS DE INGENIERIA ELECTRICA
+  min_credits: 20
+'022':
+  code: '022'
+  name: FUNDAMENTOS DE SISTEMAS DIGITALES
+  min_credits: 5
+'023':
+  code: '023'
+  name: FUNDAMENTOS DE ELECTRONICA
+  min_credits: 5
+'024':
+  code: '024'
+  name: FUNDAMENTOS DE COMUNICACION Y SEÑALES
+  min_credits: 5
+'025':
+  code: '025'
+  name: FUNDAMENTOS DE CONVERTIDORES ELECTROMAGNETICOS DE ENERGIA
+  min_credits: 5
+'026':
+  code: '026'
+  name: FUNDAMENTOS DE COMPUTACION
+  min_credits: 5
+'030':
+  code: '030'
+  name: PROCESAMIENTO DE LA INFORMACION
+  min_credits: 0
+'031':
+  code: '031'
+  name: CONTROL
+  min_credits: 5
+'032':
+  code: '032'
+  name: CONVERTIDORES ELECTROMAGNETICOS DE ENERGIA
+  min_credits: 0
+'033':
+  code: '033'
+  name: COMPUTACION
+  min_credits: 5
+'034':
+  code: '034'
+  name: INSTALACIONES Y SISTEMAS ELECTRICOS DE POTENCIA
+  min_credits: 5
+'035':
+  code: '035'
+  name: ELECTRONICA
+  min_credits: 0
+'036':
+  code: '036'
+  name: SISTEMAS DIGITALES
+  min_credits: 5
+'037':
+  code: '037'
+  name: TRANSMISION DE LA INFORMACION
+  min_credits: 5
+'038':
+  code: '038'
+  name: INGENIERIA EN MEDICINA Y BIOLOGIA
+  min_credits: 0
+'039':
+  code: '039'
+  name: PRACTICA DE INGENIERIA ELECTRICA
+  min_credits: 35
+'041':
+  code: '041'
+  name: INGENIERIA INDUSTRIAL
+  min_credits: 5
+'042':
+  code: '042'
+  name: INGENIERIA Y SOCIEDAD
+  min_credits: 5
+'043':
+  code: '043'
+  name: OTRAS AREAS DE FORMACION COMPLEMENTARIA
+  min_credits: 5

--- a/db/data/electrica/scraped_subjects.yml
+++ b/db/data/electrica/scraped_subjects.yml
@@ -1,0 +1,2996 @@
+---
+'01':
+  code: '01'
+  name: MAT. 01 (ANÁLISIS I)
+  credits: 0
+  has_exam: true
+  subject_group:
+'1001':
+  code: '1001'
+  name: ELECTRONICA II
+  credits: 0
+  has_exam: true
+  subject_group:
+'101':
+  code: '101'
+  name: MATEMÁTICA 101 (ANÁLISIS I)
+  credits: 0
+  has_exam: true
+  subject_group:
+'1011':
+  code: '1011'
+  name: TEORIA DE CODIGOS AVANZADO
+  credits: 0
+  has_exam: false
+  subject_group:
+'102':
+  code: '102'
+  name: QUÍMICA GENERAL I
+  credits: 7
+  has_exam: true
+  subject_group: '013'
+'1020':
+  code: '1020'
+  name: CALCULO 1
+  credits: 0
+  has_exam: true
+  subject_group:
+1020P:
+  code: 1020P
+  name: CREDITOS NO ACUM CALCULO 1
+  credits: 0
+  has_exam: true
+  subject_group:
+1020R:
+  code: 1020R
+  name: CREDITOS ASIGNADOS POR REVALIDA
+  credits: 0
+  has_exam: true
+  subject_group:
+'1021':
+  code: '1021'
+  name: ALGEBRA LINEAL
+  credits: 0
+  has_exam: true
+  subject_group:
+'1022':
+  code: '1022'
+  name: CALCULO 2
+  credits: 0
+  has_exam: true
+  subject_group:
+1022P:
+  code: 1022P
+  name: CREDITOS NO ACUM CALCULO 2
+  credits: 0
+  has_exam: true
+  subject_group:
+1022T:
+  code: 1022T
+  name: CREDITOS POR CALCULO 2
+  credits: 0
+  has_exam: true
+  subject_group:
+'1023':
+  code: '1023'
+  name: MATEMATICA DISCRETA 1
+  credits: 9
+  has_exam: true
+  subject_group: '011'
+1023P:
+  code: 1023P
+  name: CREDITOS NO ACUM MATEMATICA DISCRETA 1
+  credits: 0
+  has_exam: true
+  subject_group:
+'1024':
+  code: '1024'
+  name: CALCULO 3
+  credits: 0
+  has_exam: true
+  subject_group:
+1024P:
+  code: 1024P
+  name: CREDITOS NO ACUM CALCULO 3
+  credits: 0
+  has_exam: true
+  subject_group:
+'1025':
+  code: '1025'
+  name: PROBABILIDAD Y ESTADISTICA
+  credits: 10
+  has_exam: true
+  subject_group: '011'
+1025P:
+  code: 1025P
+  name: CREDITOS NO ACUM PROB Y EST.
+  credits: 0
+  has_exam: true
+  subject_group:
+1025T:
+  code: 1025T
+  name: CREDITOS NO ACUM PROBABILIDAD Y ESTADISTICA
+  credits: 0
+  has_exam: true
+  subject_group:
+'1027':
+  code: '1027'
+  name: LOGICA
+  credits: 12
+  has_exam: true
+  subject_group: '033'
+'1028':
+  code: '1028'
+  name: ECUACIONES DIFERENCIALES
+  credits: 0
+  has_exam: true
+  subject_group:
+1028M:
+  code: 1028M
+  name: CREDITOS ASIGNADOS POR REVALIDA
+  credits: 0
+  has_exam: true
+  subject_group:
+1028P:
+  code: 1028P
+  name: CREDITOS NO ACUM EC. DIFERENCIALES
+  credits: 0
+  has_exam: true
+  subject_group:
+1028R:
+  code: 1028R
+  name: CREDITOS ASIGNADOS POR REVALIDA
+  credits: 0
+  has_exam: true
+  subject_group:
+'1029':
+  code: '1029'
+  name: FUNCIONES DE VARIABLE COMPLEJA
+  credits: 0
+  has_exam: true
+  subject_group:
+102R:
+  code: 102R
+  name: QCA. GENERAL I (PLAN 2000)
+  credits: 0
+  has_exam: true
+  subject_group:
+'1030':
+  code: '1030'
+  name: GEOMETRIA Y ALGEBRA LINEAL 1
+  credits: 9
+  has_exam: true
+  subject_group: '011'
+1030P:
+  code: 1030P
+  name: CREDITOS NO ACUM GAL1
+  credits: 0
+  has_exam: true
+  subject_group:
+'1031':
+  code: '1031'
+  name: GEOMETRIA Y ALGEBRA LINEAL 2
+  credits: 9
+  has_exam: true
+  subject_group: '011'
+1031P:
+  code: 1031P
+  name: CREDITOS NO ACUM GAL2
+  credits: 0
+  has_exam: true
+  subject_group:
+'1033':
+  code: '1033'
+  name: METODOS NUMERICOS
+  credits: 8
+  has_exam: true
+  subject_group: '011'
+'1036':
+  code: '1036'
+  name: FUNCIONES DE VARIABLE COMPLEJA
+  credits: 0
+  has_exam: true
+  subject_group:
+1036R:
+  code: 1036R
+  name: CREDITOS ASIGNADOS POR REVALIDA
+  credits: 0
+  has_exam: true
+  subject_group:
+'1042':
+  code: '1042'
+  name: TEORIA DE COD. ALGEB. PARA CORR. DE ERRORES
+  credits: 0
+  has_exam: false
+  subject_group:
+'1046':
+  code: '1046'
+  name: TEORIA DE CODIGOS
+  credits: 0
+  has_exam: false
+  subject_group:
+'1052':
+  code: '1052'
+  name: CALCULO 1 (ANUAL)
+  credits: 0
+  has_exam: true
+  subject_group:
+'1053':
+  code: '1053'
+  name: GEOMETRIA Y ALGEBRA LINEAL 1 (ANUAL)
+  credits: 0
+  has_exam: true
+  subject_group:
+'1058':
+  code: '1058'
+  name: GEOMETRIA Y ALGEBRA LINEAL 2
+  credits: 0
+  has_exam: true
+  subject_group:
+'1061':
+  code: '1061'
+  name: CALCULO DIF. E INTEGRAL EN UNA VARIABLE
+  credits: 13
+  has_exam: true
+  subject_group: '011'
+1061I:
+  code: 1061I
+  name: CALCULO DIF. E INTEGRAL EN UNA VARIABLE
+  credits: 0
+  has_exam: true
+  subject_group:
+1061P:
+  code: 1061P
+  name: CREDITOS NO ACUM CDIV
+  credits: 0
+  has_exam: true
+  subject_group:
+1061R:
+  code: 1061R
+  name: CALCULO DIF. E INTEGRAL EN UNA VARIABLE
+  credits: 0
+  has_exam: true
+  subject_group:
+'1062':
+  code: '1062'
+  name: CALCULO DIF. E INTEGRAL EN VARIAS VARIABLES
+  credits: 13
+  has_exam: true
+  subject_group: '011'
+1062P:
+  code: 1062P
+  name: CREDITOS NO ACUM CDIVV
+  credits: 0
+  has_exam: true
+  subject_group:
+'1063':
+  code: '1063'
+  name: CALCULO VECTORIAL
+  credits: 10
+  has_exam: true
+  subject_group: '011'
+1063P:
+  code: 1063P
+  name: CREDITOS NO ACUM CAL. VECTORIAL
+  credits: 0
+  has_exam: true
+  subject_group:
+'1064':
+  code: '1064'
+  name: INT. A LAS ECUACIONES DIFERENCIALES
+  credits: 10
+  has_exam: true
+  subject_group: '011'
+1064P:
+  code: 1064P
+  name: CREDITOS NO ACUM INT. A LAS ECUACIONES DIFERENCIALES
+  credits: 0
+  has_exam: true
+  subject_group:
+'1065':
+  code: '1065'
+  name: TEORIA DE COD. ALGEB. PARA CORR. DE ERRORES
+  credits: 0
+  has_exam: false
+  subject_group:
+'1066':
+  code: '1066'
+  name: FUNCIONES DE VARIABLE COMPLEJA
+  credits: 5
+  has_exam: true
+  subject_group: '011'
+1066P:
+  code: 1066P
+  name: CREDITOS NO ACUM FUNCIONES DE VAR. COMP.
+  credits: 0
+  has_exam: true
+  subject_group:
+'1070':
+  code: '1070'
+  name: CALCULO 1
+  credits: 0
+  has_exam: true
+  subject_group:
+'1071':
+  code: '1071'
+  name: GEOMETRIA Y ALGEBRA LINEAL 1
+  credits: 0
+  has_exam: true
+  subject_group:
+'1072':
+  code: '1072'
+  name: CALCULO 2
+  credits: 0
+  has_exam: true
+  subject_group:
+'1073':
+  code: '1073'
+  name: FISICA TERMICA
+  credits: 0
+  has_exam: true
+  subject_group:
+'1074':
+  code: '1074'
+  name: ECUACIONES DIFERENCIALES
+  credits: 0
+  has_exam: true
+  subject_group:
+'1075':
+  code: '1075'
+  name: PROBABILIDAD Y ESTADISTICA
+  credits: 0
+  has_exam: true
+  subject_group:
+'1076':
+  code: '1076'
+  name: CALCULO 3
+  credits: 0
+  has_exam: true
+  subject_group:
+'1077':
+  code: '1077'
+  name: FISICA 2
+  credits: 0
+  has_exam: true
+  subject_group:
+'1078':
+  code: '1078'
+  name: MECANICA NEWTONIANA
+  credits: 0
+  has_exam: true
+  subject_group:
+'1079':
+  code: '1079'
+  name: METODOS NUMERICOS
+  credits: 0
+  has_exam: false
+  subject_group:
+107L:
+  code: 107L
+  name: CALCULO 1
+  credits: 0
+  has_exam: true
+  subject_group:
+108L:
+  code: 108L
+  name: CALCULO 2
+  credits: 0
+  has_exam: true
+  subject_group:
+'1103':
+  code: '1103'
+  name: MUESTREO Y PROCESAMIENTO DIGITAL
+  credits: 0
+  has_exam: true
+  subject_group:
+'1104':
+  code: '1104'
+  name: INT. A LA MODULACION
+  credits: 0
+  has_exam: true
+  subject_group:
+'1120':
+  code: '1120'
+  name: FISICA GENERAL 1
+  credits: 0
+  has_exam: true
+  subject_group:
+1120P:
+  code: 1120P
+  name: CREDITOS NO ACUM. FISICA GENERAL 1
+  credits: 0
+  has_exam: true
+  subject_group:
+'1121':
+  code: '1121'
+  name: FISICA GENERAL 2
+  credits: 0
+  has_exam: true
+  subject_group:
+1121P:
+  code: 1121P
+  name: CREDITOS NO ACUM FISICA GRAL. 2
+  credits: 0
+  has_exam: true
+  subject_group:
+'1122':
+  code: '1122'
+  name: MECANICA NEWTONIANA
+  credits: 10
+  has_exam: true
+  subject_group: '012'
+1122P:
+  code: 1122P
+  name: CREDITOS NO ACUM MEC NEWTONIANA
+  credits: 0
+  has_exam: true
+  subject_group:
+'1123':
+  code: '1123'
+  name: FISICA TERMICA
+  credits: 10
+  has_exam: true
+  subject_group: '012'
+1123P:
+  code: 1123P
+  name: CREDITOS NO ACUM FIS TERMICA
+  credits: 0
+  has_exam: true
+  subject_group:
+'1124':
+  code: '1124'
+  name: LABORATORIO 1
+  credits: 0
+  has_exam: false
+  subject_group:
+'1126':
+  code: '1126'
+  name: MEC.DE SIST.Y FENOMENOS ONDULATORIOS
+  credits: 0
+  has_exam: true
+  subject_group:
+'1127':
+  code: '1127'
+  name: LABORATORIO 2
+  credits: 0
+  has_exam: false
+  subject_group:
+'1128':
+  code: '1128'
+  name: ELECTROMAGNETISMO
+  credits: 10
+  has_exam: true
+  subject_group: '012'
+1128P:
+  code: 1128P
+  name: CREDITOS NO ACUM ELECTROMAGNETISMO
+  credits: 0
+  has_exam: true
+  subject_group:
+'1129':
+  code: '1129'
+  name: OPTICA
+  credits: 10
+  has_exam: true
+  subject_group: '012'
+'1131':
+  code: '1131'
+  name: INT. A LA FISICA MODERNA
+  credits: 10
+  has_exam: true
+  subject_group: '012'
+1131I:
+  code: 1131I
+  name: INT. A LA FISICA MODERNA
+  credits: 0
+  has_exam: true
+  subject_group:
+1131P:
+  code: 1131P
+  name: CREDITOS NO ACUM INT. A LA FISICA MODERNA
+  credits: 0
+  has_exam: true
+  subject_group:
+'1138':
+  code: '1138'
+  name: INT. A LA FISICA MODERNA
+  credits: 0
+  has_exam: true
+  subject_group:
+'1139':
+  code: '1139'
+  name: MODULO DE ACUSTICA
+  credits: 4
+  has_exam: false
+  subject_group: '012'
+'1140':
+  code: '1140'
+  name: LABORATORIO 3
+  credits: 0
+  has_exam: false
+  subject_group:
+'1144':
+  code: '1144'
+  name: VIBRACIONES Y ONDAS
+  credits: 10
+  has_exam: true
+  subject_group: '012'
+1144P:
+  code: 1144P
+  name: CREDITOS NO ACUM VIBRACIONES Y ONDAS
+  credits: 0
+  has_exam: true
+  subject_group:
+'1151':
+  code: '1151'
+  name: FISICA 1
+  credits: 10
+  has_exam: true
+  subject_group: '012'
+1151P:
+  code: 1151P
+  name: CREDITOS NO ACUM FISICA 1
+  credits: 0
+  has_exam: true
+  subject_group:
+'1152':
+  code: '1152'
+  name: FISICA 2
+  credits: 10
+  has_exam: true
+  subject_group: '012'
+1152P:
+  code: 1152P
+  name: CREDITOS NO ACUM FISICA 2
+  credits: 0
+  has_exam: true
+  subject_group:
+'1153':
+  code: '1153'
+  name: FISICA 3
+  credits: 10
+  has_exam: true
+  subject_group: '012'
+1153P:
+  code: 1153P
+  name: CREDITOS NO ACUM FISICA 3
+  credits: 0
+  has_exam: true
+  subject_group:
+'1154':
+  code: '1154'
+  name: FISICA EXPERIMENTAL 1
+  credits: 5
+  has_exam: false
+  subject_group: '012'
+1154I:
+  code: 1154I
+  name: FISICA EXPERIMENTAL 1
+  credits: 0
+  has_exam: true
+  subject_group:
+1154P:
+  code: 1154P
+  name: CREDITOS NO ACUM FISICA EXPERIMENTAL 1
+  credits: 0
+  has_exam: true
+  subject_group:
+1154R:
+  code: 1154R
+  name: CREDITOS ASIGNADOS POR REVALIDA
+  credits: 0
+  has_exam: true
+  subject_group:
+'1155':
+  code: '1155'
+  name: FISICA EXPERIMENTAL 2
+  credits: 5
+  has_exam: false
+  subject_group: '012'
+1155I:
+  code: 1155I
+  name: FISICA EXPERIMENTAL 2
+  credits: 0
+  has_exam: false
+  subject_group:
+1155P:
+  code: 1155P
+  name: CREDITOS NO ACUM FISICA EXPERIMENTAL 2
+  credits: 0
+  has_exam: false
+  subject_group:
+'1156':
+  code: '1156'
+  name: FISICA EXPERIMENTAL 3
+  credits: 6
+  has_exam: false
+  subject_group: '012'
+'1158':
+  code: '1158'
+  name: PROCESAMIENTO CUÁNTICO DE LA INFORMACIÓN
+  credits: 10
+  has_exam: true
+  subject_group: '012'
+'1170':
+  code: '1170'
+  name: FISICA GENERAL 1
+  credits: 0
+  has_exam: true
+  subject_group:
+'1171':
+  code: '1171'
+  name: FISICA 1
+  credits: 0
+  has_exam: true
+  subject_group:
+'1172':
+  code: '1172'
+  name: FISICA GENERAL 2
+  credits: 0
+  has_exam: true
+  subject_group:
+'1173':
+  code: '1173'
+  name: FISICA 3
+  credits: 0
+  has_exam: true
+  subject_group:
+'1178':
+  code: '1178'
+  name: ELECTROMAGNETISMO
+  credits: 0
+  has_exam: true
+  subject_group:
+117Q:
+  code: 117Q
+  name: FISICA GENERAL 1
+  credits: 0
+  has_exam: false
+  subject_group:
+119Q:
+  code: 119Q
+  name: FISICA 3
+  credits: 0
+  has_exam: true
+  subject_group:
+'1208':
+  code: '1208'
+  name: MODULO DE EXTENSION 2
+  credits: 2
+  has_exam: false
+  subject_group: '042'
+'1209':
+  code: '1209'
+  name: MODULO DE EXTENSION 4
+  credits: 4
+  has_exam: false
+  subject_group: '042'
+'1220':
+  code: '1220'
+  name: TALLER DE DISEÑO, COM. Y REPRES. GRAFICA
+  credits: 0
+  has_exam: false
+  subject_group:
+1220P:
+  code: 1220P
+  name: CREDITOS NO ACUM TALLER DE DISEÑO, COM. Y REP. GRAFICA
+  credits: 0
+  has_exam: false
+  subject_group:
+'1221':
+  code: '1221'
+  name: ECONOMIA
+  credits: 0
+  has_exam: false
+  subject_group:
+'1223':
+  code: '1223'
+  name: CIENCIA, TECNOLOGIA Y SOCIEDAD
+  credits: 8
+  has_exam: true
+  subject_group: '042'
+'1224':
+  code: '1224'
+  name: ECONOMIA
+  credits: 7
+  has_exam: true
+  subject_group: '042'
+1224P:
+  code: 1224P
+  name: CREDITOS NO ACUM ECONOMIA
+  credits: 0
+  has_exam: false
+  subject_group:
+'1233':
+  code: '1233'
+  name: TUTORIA EN MATEMATICA
+  credits: 4
+  has_exam: false
+  subject_group: '043'
+'1235':
+  code: '1235'
+  name: FUNDAMENTOS CELULARES DE CIRCUITOS NEURALES
+  credits: 10
+  has_exam: false
+  subject_group: '013'
+'1236':
+  code: '1236'
+  name: SEMINARIO SOBRE ENCUENTROS ENTRE ARTE Y TECNOLOGIAS
+  credits: 4
+  has_exam: false
+  subject_group: '043'
+125L:
+  code: 125L
+  name: PROBABILIDAD Y ESTADISTICA
+  credits: 0
+  has_exam: true
+  subject_group:
+'1266':
+  code: '1266'
+  name: TALLER DE REPRESENTACION Y COMUNICACION GRAFICA_MODULO A
+  credits: 4
+  has_exam: false
+  subject_group: '043'
+'1275':
+  code: '1275'
+  name: TALLER BASICO DE ESTRATEGIAS Y ORIENTACION (TBEO)
+  credits: 3
+  has_exam: false
+  subject_group: '043'
+'1306':
+  code: '1306'
+  name: PROGRAMACION ORIENTADA A OBJETOS
+  credits: 0
+  has_exam: false
+  subject_group:
+'1307':
+  code: '1307'
+  name: PROGRAMACION PARA INGENIERIA ELECTRICA
+  credits: 7
+  has_exam: false
+  subject_group: '033'
+'1320':
+  code: '1320'
+  name: PROGRAMACION 1
+  credits: 0
+  has_exam: true
+  subject_group:
+'1321':
+  code: '1321'
+  name: PROGRAMACION 2
+  credits: 12
+  has_exam: true
+  subject_group: '033'
+1321P:
+  code: 1321P
+  name: CREDITOS NO ACUM PROGRAMACION 2
+  credits: 0
+  has_exam: true
+  subject_group:
+'1322':
+  code: '1322'
+  name: PROGRAMACION 1
+  credits: 0
+  has_exam: true
+  subject_group:
+1322P:
+  code: 1322P
+  name: CREDITOS NO ACUM PROGRAMACION 1
+  credits: 0
+  has_exam: true
+  subject_group:
+1322T:
+  code: 1322T
+  name: PROGRAMACION 1
+  credits: 0
+  has_exam: true
+  subject_group:
+'1323':
+  code: '1323'
+  name: PROGRAMACION 3
+  credits: 15
+  has_exam: true
+  subject_group: '033'
+'1324':
+  code: '1324'
+  name: PROGRAMACION 4
+  credits: 15
+  has_exam: true
+  subject_group: '033'
+'1326':
+  code: '1326'
+  name: DESARROLLO DE SOFTWARE PARA ING.ELECT.
+  credits: 0
+  has_exam: false
+  subject_group:
+'1373':
+  code: '1373'
+  name: PROGRAMACION 1
+  credits: 10
+  has_exam: true
+  subject_group: '026'
+'1401':
+  code: '1401'
+  name: SISTEMAS LINEALES 1
+  credits: 0
+  has_exam: true
+  subject_group:
+'1407':
+  code: '1407'
+  name: SISTEMAS LINEALES 2
+  credits: 0
+  has_exam: true
+  subject_group:
+'1409':
+  code: '1409'
+  name: MUESTREO Y PROCESAMIENTO DIGITAL
+  credits: 0
+  has_exam: true
+  subject_group:
+'1410':
+  code: '1410'
+  name: MEDIDAS ELECTRICAS
+  credits: 0
+  has_exam: true
+  subject_group:
+'1413':
+  code: '1413'
+  name: MONOGRAFIA EN MEDIDAS ELECTRICAS
+  credits: 2
+  has_exam: false
+  subject_group: '021'
+'1423':
+  code: '1423'
+  name: SISTEMAS LINEALES 1
+  credits: 0
+  has_exam: true
+  subject_group:
+1423P:
+  code: 1423P
+  name: CREDITOS NO ACUM SISTEMAS LINEALES 1
+  credits: 0
+  has_exam: false
+  subject_group:
+'1438':
+  code: '1438'
+  name: APLICACIONES DE TEORIA DE LA INFORMACION AL PROC. DE IMAG.
+  credits: 6
+  has_exam: false
+  subject_group: '030'
+'1442':
+  code: '1442'
+  name: ROBOTICA EMBEBIDA
+  credits: 0
+  has_exam: false
+  subject_group:
+'1450':
+  code: '1450'
+  name: INT. A LA TEORIA DE LA INFORMACION
+  credits: 4
+  has_exam: false
+  subject_group: '037'
+'1451':
+  code: '1451'
+  name: MEDIDAS ELECTRICAS
+  credits: 0
+  has_exam: true
+  subject_group:
+'1456':
+  code: '1456'
+  name: TEORIA DE CIRCUITOS
+  credits: 8
+  has_exam: true
+  subject_group: '021'
+1456P:
+  code: 1456P
+  name: CREDITOS NO ACUM TEORIA DE CIRCUITOS
+  credits: 0
+  has_exam: false
+  subject_group:
+1456R:
+  code: 1456R
+  name: CREDITOS NO ACUM TEORIA DE CIRCUITOS
+  credits: 0
+  has_exam: false
+  subject_group:
+'1457':
+  code: '1457'
+  name: SEÑALES Y SISTEMAS
+  credits: 7
+  has_exam: true
+  subject_group: '021'
+1457P:
+  code: 1457P
+  name: CREDITOS NO ACUM SEÑALES Y SISTEMAS
+  credits: 0
+  has_exam: true
+  subject_group:
+'1459':
+  code: '1459'
+  name: TALLER FOURIER
+  credits: 8
+  has_exam: false
+  subject_group: '021'
+'1460':
+  code: '1460'
+  name: SEÑALES ALEATORIAS Y MODULACION
+  credits: 3
+  has_exam: true
+  subject_group: '030'
+'1461':
+  code: '1461'
+  name: MEDIDAS ELECTRICAS
+  credits: 10
+  has_exam: true
+  subject_group: '021'
+1461P:
+  code: 1461P
+  name: CREDITOS NO ACUM MEDIDAS ELECTRICAS
+  credits: 0
+  has_exam: true
+  subject_group:
+'1462':
+  code: '1462'
+  name: COMUNICACIONES DIGITALES
+  credits: 11
+  has_exam: true
+  subject_group: '037'
+'1463':
+  code: '1463'
+  name: APRENDIZAJE PROFUNDO PARA VISION ARTIFICIAL
+  credits: 6
+  has_exam: false
+  subject_group: '030'
+'1510':
+  code: '1510'
+  name: CONTROL DE CALIDAD
+  credits: 8
+  has_exam: true
+  subject_group: '041'
+1510P:
+  code: 1510P
+  name: CREDITOS NO ACUM CONTROL DE CALIDAD
+  credits: 0
+  has_exam: true
+  subject_group:
+1510R:
+  code: 1510R
+  name: CREDITOS ASIGNADOS POR REVALIDA
+  credits: 0
+  has_exam: true
+  subject_group:
+'1511':
+  code: '1511'
+  name: SISTEMAS OPERATIVOS
+  credits: 0
+  has_exam: true
+  subject_group:
+'1512':
+  code: '1512'
+  name: DISEÑO LOGICO
+  credits: 12
+  has_exam: true
+  subject_group: '022'
+1512P:
+  code: 1512P
+  name: CREDITOS NO ACUM DISEÑO LOGICO
+  credits: 0
+  has_exam: false
+  subject_group:
+'1513':
+  code: '1513'
+  name: INT. A LOS MICROPROCESADORES
+  credits: 11
+  has_exam: true
+  subject_group: '036'
+'1516':
+  code: '1516'
+  name: DISEÑO LOGICO 2
+  credits: 0
+  has_exam: false
+  subject_group:
+'1518':
+  code: '1518'
+  name: SISTEMAS OPERATIVOS
+  credits: 0
+  has_exam: true
+  subject_group:
+'1519':
+  code: '1519'
+  name: INT. A LA ADMINISTRACION PARA INGENIEROS
+  credits: 0
+  has_exam: false
+  subject_group:
+'1532':
+  code: '1532'
+  name: SISTEMAS OPERATIVOS
+  credits: 0
+  has_exam: true
+  subject_group:
+'1534':
+  code: '1534'
+  name: DISEÑO LOGICO 2
+  credits: 8
+  has_exam: false
+  subject_group: '036'
+1534P:
+  code: 1534P
+  name: CREDITOS NO ACUM DISEÑO LOGICO 2
+  credits: 0
+  has_exam: false
+  subject_group:
+'1536':
+  code: '1536'
+  name: SISTEMAS EMBEBIDOS PARA TIEMPO REAL
+  credits: 0
+  has_exam: false
+  subject_group:
+'1537':
+  code: '1537'
+  name: SISTEMAS OPERATIVOS
+  credits: 12
+  has_exam: true
+  subject_group: '033'
+'1538':
+  code: '1538'
+  name: REDES DE SENSORES INALAMBRICOS
+  credits: 8
+  has_exam: false
+  subject_group: '036'
+'1544':
+  code: '1544'
+  name: INT. A LA COMPUTACION CIENTIFICA
+  credits: 4
+  has_exam: false
+  subject_group: '033'
+'1556':
+  code: '1556'
+  name: SISTEMAS EMBEBIDOS PARA TIEMPO REAL
+  credits: 10
+  has_exam: false
+  subject_group: '036'
+158Q:
+  code: 158Q
+  name: GEOMETRIA Y ALGEBRA LINEAL 2
+  credits: 0
+  has_exam: true
+  subject_group:
+'1610':
+  code: '1610'
+  name: INT. A LA INVESTIGACION DE OPERACIONES
+  credits: 0
+  has_exam: true
+  subject_group:
+1610P:
+  code: 1610P
+  name: CREDITOS NO ACUM INT. A LA INVESTIGACION DE OPERACIONES
+  credits: 0
+  has_exam: true
+  subject_group:
+'1620':
+  code: '1620'
+  name: PRINCIPIOS DE QUIMICA GENERAL
+  credits: 8
+  has_exam: true
+  subject_group: '013'
+'1650':
+  code: '1650'
+  name: INT. A LA INVESTIGACIÓN DE OPERACIONES
+  credits: 5
+  has_exam: true
+  subject_group: '041'
+'1701':
+  code: '1701'
+  name: INT. A LA CIENCIA DE MATERIALES
+  credits: 0
+  has_exam: true
+  subject_group:
+170Q:
+  code: 170Q
+  name: CALCULO 1
+  credits: 0
+  has_exam: true
+  subject_group:
+171L:
+  code: 171L
+  name: GEOMETRIA Y ALGEBRA LINEAL 1
+  credits: 0
+  has_exam: true
+  subject_group:
+171Q:
+  code: 171Q
+  name: GEOMETRIA Y ALGEBRA LINEAL 1
+  credits: 0
+  has_exam: true
+  subject_group:
+'1723':
+  code: '1723'
+  name: INT. A LA CIENCIA DE MATERIALES
+  credits: 4
+  has_exam: true
+  subject_group: '013'
+1723R:
+  code: 1723R
+  name: CREDITOS ASIGNADOS POR REVALIDA
+  credits: 0
+  has_exam: true
+  subject_group:
+172Q:
+  code: 172Q
+  name: CALCULO 2
+  credits: 0
+  has_exam: true
+  subject_group:
+174Q:
+  code: 174Q
+  name: ECUACIONES DIFERENCIALES
+  credits: 0
+  has_exam: true
+  subject_group:
+175Q:
+  code: 175Q
+  name: PROBABILIDAD Y ESTADISTICA
+  credits: 0
+  has_exam: false
+  subject_group:
+176Q:
+  code: 176Q
+  name: CALCULO 3
+  credits: 0
+  has_exam: true
+  subject_group:
+'1788':
+  code: '1788'
+  name: FUNDAMENTOS DE ROBOTICA INDUSTRIAL
+  credits: 8
+  has_exam: false
+  subject_group: '031'
+'181':
+  code: '181'
+  name: QCA. GENERAL I (SEMESTRAL 1980)
+  credits: 0
+  has_exam: false
+  subject_group:
+'183':
+  code: '183'
+  name: QCA. ANALÍTICA CUALITATIVA I (SEM. 1980)
+  credits: 0
+  has_exam: false
+  subject_group:
+'1848':
+  code: '1848'
+  name: ROBOTICA BASADA EN COMPORTAMIENTOS
+  credits: 15
+  has_exam: false
+  subject_group: '031'
+'1849':
+  code: '1849'
+  name: 'BUTIA: ROBOTICA EDUCATIVA'
+  credits: 8
+  has_exam: false
+  subject_group: '036'
+'1857':
+  code: '1857'
+  name: FUNDAMENTOS DE LA ROBOTICA AUTONOMA
+  credits: 7
+  has_exam: false
+  subject_group: '036'
+'186':
+  code: '186'
+  name: QCA. GENERAL II (SEMESTRAL 1980)
+  credits: 0
+  has_exam: false
+  subject_group:
+'1868':
+  code: '1868'
+  name: MODELOS ESTADISTICOS PARA CLASIF. Y REGRESION
+  credits: 6
+  has_exam: false
+  subject_group: '011'
+'1869':
+  code: '1869'
+  name: MODELOS PROBABILISTICOS EN INGENIERIA
+  credits: 6
+  has_exam: false
+  subject_group: '011'
+'1871':
+  code: '1871'
+  name: FUNDAMENTOS DE OPTIMIZACION
+  credits: 6
+  has_exam: false
+  subject_group: '011'
+'1872':
+  code: '1872'
+  name: APLICACIONES DEL ALGEBRA LINEAL
+  credits: 9
+  has_exam: true
+  subject_group: '011'
+'188':
+  code: '188'
+  name: QCA. GENERAL (ANUAL 1986)
+  credits: 0
+  has_exam: false
+  subject_group:
+'1886':
+  code: '1886'
+  name: TOPOLOGIA Y ANALISIS REAL
+  credits: 10
+  has_exam: false
+  subject_group: '011'
+188R:
+  code: 188R
+  name: QCA. GENERAL (ANUAL 1986)
+  credits: 0
+  has_exam: true
+  subject_group:
+'189':
+  code: '189'
+  name: QCA. ANALÍTICA CUALITATIVA (ANUAL 1986)
+  credits: 0
+  has_exam: false
+  subject_group:
+'1892':
+  code: '1892'
+  name: BASES DE DATOS PARA INGENIERÍA
+  credits: 10
+  has_exam: true
+  subject_group: '033'
+'1899':
+  code: '1899'
+  name: TEMAS AVANZADOS EN CÓDIGOS PARA CORRECCIÓN DE ERRORES
+  credits: 7
+  has_exam: false
+  subject_group: '030'
+189R:
+  code: 189R
+  name: QCA. ANALÍTICA CUALITATIVA (ANUAL 1986)
+  credits: 0
+  has_exam: true
+  subject_group:
+'1901':
+  code: '1901'
+  name: CONTROL DE CALIDAD
+  credits: 0
+  has_exam: true
+  subject_group:
+'1902':
+  code: '1902'
+  name: INT. A LA INGENIERIA INDUSTRIAL
+  credits: 0
+  has_exam: false
+  subject_group:
+'1903':
+  code: '1903'
+  name: COSTOS PARA INGENIERIA
+  credits: 0
+  has_exam: true
+  subject_group:
+'1911':
+  code: '1911'
+  name: FUNDAMENTOS DE BASES DE DATOS
+  credits: 15
+  has_exam: true
+  subject_group: '033'
+'1912':
+  code: '1912'
+  name: INT. A LA INGENIERIA INDUSTRIAL
+  credits: 8
+  has_exam: true
+  subject_group: '041'
+'1920':
+  code: '1920'
+  name: GESTION DE MANTENIMIENTO
+  credits: 8
+  has_exam: true
+  subject_group: '041'
+'1922':
+  code: '1922'
+  name: COSTOS PARA INGENIERIA
+  credits: 8
+  has_exam: true
+  subject_group: '041'
+'1930':
+  code: '1930'
+  name: ORGANIZACIONES PARA INGENIEROS
+  credits: 0
+  has_exam: false
+  subject_group:
+'1944':
+  code: '1944'
+  name: ADMINISTRACION GENERAL PARA INGENIEROS
+  credits: 5
+  has_exam: true
+  subject_group: '041'
+'1945':
+  code: '1945'
+  name: PRACTICA DE ADMINISTRACION PARA INGENIEROS
+  credits: 5
+  has_exam: true
+  subject_group: '041'
+'1951':
+  code: '1951'
+  name: 'TALLER: HERRAMIENTAS PARA LA INNOVACION'
+  credits: 4
+  has_exam: false
+  subject_group: '043'
+'2011':
+  code: '2011'
+  name: PASANTIA (ELECTRICA)
+  credits: 10
+  has_exam: false
+  subject_group: '039'
+2011P:
+  code: 2011P
+  name: CREDITOS NO ACUM PASANTIA
+  credits: 0
+  has_exam: false
+  subject_group:
+'2013':
+  code: '2013'
+  name: PROYECTO (ING.ELEC.)
+  credits: 35
+  has_exam: true
+  subject_group: '039'
+'2018':
+  code: '2018'
+  name: MODULO DE TALLER 1
+  credits: 4
+  has_exam: false
+  subject_group: '043'
+'2020':
+  code: '2020'
+  name: MODULO DE TALLER 2
+  credits: 4
+  has_exam: false
+  subject_group: '043'
+'2021':
+  code: '2021'
+  name: MODULO DE TALLER 3
+  credits: 4
+  has_exam: false
+  subject_group: '043'
+'2022':
+  code: '2022'
+  name: MODULO DE TALLER 4
+  credits: 2
+  has_exam: false
+  subject_group: '043'
+'2040':
+  code: '2040'
+  name: INICIACION A LA PROD. AUDIOVIS. Y MULTIMEDIA
+  credits: 6
+  has_exam: false
+  subject_group: '043'
+'2216':
+  code: '2216'
+  name: TUTORIAS ENTRE PARES 1
+  credits: 4
+  has_exam: false
+  subject_group: '043'
+'2217':
+  code: '2217'
+  name: TUTORIAS ENTRE PARES 2
+  credits: 4
+  has_exam: false
+  subject_group: '043'
+'2241':
+  code: '2241'
+  name: ADMINISTRACION DE EMPRESAS
+  credits: 0
+  has_exam: false
+  subject_group:
+'2243':
+  code: '2243'
+  name: HIGIENE Y SEGURIDAD INDUSTRIAL
+  credits: 8
+  has_exam: false
+  subject_group: '041'
+'2314':
+  code: '2314'
+  name: ESTABILIDAD DE LOS SIST.ELEC.DE POTENCIA
+  credits: 10
+  has_exam: false
+  subject_group: '034'
+'2401':
+  code: '2401'
+  name: LEGISLACION Y RELACIONES INDUSTRIALES
+  credits: 6
+  has_exam: false
+  subject_group: '041'
+'2413':
+  code: '2413'
+  name: INT. A BASES DE DATOS
+  credits: 8
+  has_exam: false
+  subject_group: '033'
+'2415':
+  code: '2415'
+  name: CODIGOS PARA CORRECCION DE ERRORES
+  credits: 8
+  has_exam: false
+  subject_group: '030'
+'2422':
+  code: '2422'
+  name: INT. A BASES DE DATOS
+  credits: 8
+  has_exam: false
+  subject_group: '033'
+24CIA:
+  code: 24CIA
+  name: COMUNICACIÓN E INTELIGENCIA ARTIFICIAL (PPP)
+  credits: 9
+  has_exam: false
+  subject_group: '042'
+'2704':
+  code: '2704'
+  name: INSTRUMENTACION INDUSTRIAL
+  credits: 0
+  has_exam: true
+  subject_group:
+'2706':
+  code: '2706'
+  name: INSTRUMENTACION INDUSTRIAL
+  credits: 8
+  has_exam: true
+  subject_group: '031'
+'284':
+  code: '284'
+  name: QCA. ANALÍTICA CUALITATIVA II (SEM.1980)
+  credits: 0
+  has_exam: false
+  subject_group:
+'2907':
+  code: '2907'
+  name: SEMINARIO DE INICIACION A LA INVESTIGACION
+  credits: 4
+  has_exam: false
+  subject_group: '043'
+'3333':
+  code: '3333'
+  name: FUNDAMENTOS DE ING. DE SOFT. PARA PROD. IND.
+  credits: 0
+  has_exam: false
+  subject_group:
+'3334':
+  code: '3334'
+  name: FUNDAMENTOS DE INGENIERIA DE SOFTWARE
+  credits: 8
+  has_exam: false
+  subject_group: '033'
+'5005':
+  code: '5005'
+  name: TUTORIAS ENTRE PARES ACADEMICAS PROGRESA/FING
+  credits: 8
+  has_exam: false
+  subject_group: '043'
+'5501':
+  code: '5501'
+  name: REDES ELECTRICAS 1
+  credits: 0
+  has_exam: true
+  subject_group:
+'5502':
+  code: '5502'
+  name: REDES ELECTRICAS 2
+  credits: 0
+  has_exam: true
+  subject_group:
+'5503':
+  code: '5503'
+  name: INSTALACIONES ELECTRICAS
+  credits: 0
+  has_exam: true
+  subject_group:
+'5504':
+  code: '5504'
+  name: PROYECTO DE INSTALACIONES ELECTRICAS
+  credits: 8
+  has_exam: false
+  subject_group: '034'
+'5507':
+  code: '5507'
+  name: INSTALACIONES ELECTRICAS
+  credits: 8
+  has_exam: true
+  subject_group: '034'
+'5508':
+  code: '5508'
+  name: REDES ELECTRICAS
+  credits: 10
+  has_exam: true
+  subject_group: '034'
+'5510':
+  code: '5510'
+  name: TEMAS DE SUBESTACIONES DE MEDIA TENSION
+  credits: 4
+  has_exam: false
+  subject_group: '034'
+'5511':
+  code: '5511'
+  name: PROYECTO DE INSTALACIONES ELECTRICAS DE BAJA Y MEDIA TENSION
+  credits: 10
+  has_exam: false
+  subject_group: '034'
+'5513':
+  code: '5513'
+  name: TRANSPORTE DE ENERGIA ELECTRICA
+  credits: 0
+  has_exam: false
+  subject_group:
+'5514':
+  code: '5514'
+  name: SUBESTACIONES EN MEDIA TENSION
+  credits: 8
+  has_exam: true
+  subject_group: '034'
+'5515':
+  code: '5515'
+  name: COMPLEM. TEMAS DE SUBEST.EN MEDIA TENS.
+  credits: 4
+  has_exam: false
+  subject_group: '034'
+'5517':
+  code: '5517'
+  name: SIMULACION DE SIST.DE ENERGIA ELECTRICA
+  credits: 8
+  has_exam: false
+  subject_group: '034'
+'5518':
+  code: '5518'
+  name: INT. A LOS SIST. DE PROT. DE SIST. ELECT. DE POT.
+  credits: 9
+  has_exam: true
+  subject_group: '034'
+'5519':
+  code: '5519'
+  name: ENSAYOS ELECTRICOS Y EQUIPOS DE MEDIA TENSION
+  credits: 9
+  has_exam: true
+  subject_group: '034'
+'5520':
+  code: '5520'
+  name: TRANSPORTE DE ENERGIA ELECTRICA
+  credits: 8
+  has_exam: true
+  subject_group: '034'
+'5601':
+  code: '5601'
+  name: INT. A LA ELECTROTECNICA
+  credits: 0
+  has_exam: true
+  subject_group:
+'5602':
+  code: '5602'
+  name: MAQUINAS ELECTRICAS
+  credits: 10
+  has_exam: true
+  subject_group: '032'
+'5603':
+  code: '5603'
+  name: TALLER DE MAQUINAS ELECTRICAS
+  credits: 4
+  has_exam: false
+  subject_group: '032'
+'5604':
+  code: '5604'
+  name: 'TALLER LAB. ELECT. DE POTENCIA: RECT. E INVER.'
+  credits: 2
+  has_exam: false
+  subject_group: '032'
+'5607':
+  code: '5607'
+  name: ELECTRONICA DE POTENCIA 1
+  credits: 0
+  has_exam: false
+  subject_group:
+'5608':
+  code: '5608'
+  name: INT. A LA ELECTROTECNICA
+  credits: 0
+  has_exam: true
+  subject_group:
+'5609':
+  code: '5609'
+  name: ELECTRONICA DE POTENCIA
+  credits: 10
+  has_exam: true
+  subject_group: '032'
+5609P:
+  code: 5609P
+  name: CREDITOS NO ACUM ELECTRONICA DE POTENCIA
+  credits: 0
+  has_exam: true
+  subject_group:
+'5610':
+  code: '5610'
+  name: TALLER LAB. ELECT. DE POTENCIA
+  credits: 4
+  has_exam: false
+  subject_group: '032'
+5610P:
+  code: 5610P
+  name: CREDITOS NO ACUM TALLER LAB. ELECT. DE POT.
+  credits: 0
+  has_exam: false
+  subject_group:
+'5630':
+  code: '5630'
+  name: GENERACION DE ENERGIA ELECTRICA
+  credits: 6
+  has_exam: true
+  subject_group: '032'
+'5701':
+  code: '5701'
+  name: ELECTRONICA 1
+  credits: 0
+  has_exam: true
+  subject_group:
+'5703':
+  code: '5703'
+  name: INGENIERIA BIOMEDICA
+  credits: 0
+  has_exam: false
+  subject_group:
+'5705':
+  code: '5705'
+  name: SEMINARIO DE INGENIERIA BIOMEDICA
+  credits: 4
+  has_exam: false
+  subject_group: '038'
+'5707':
+  code: '5707'
+  name: 'IMAGENES MEDICAS: ADQUISICION, INSTRUMENTACION Y GESTION'
+  credits: 8
+  has_exam: false
+  subject_group: '038'
+'5708':
+  code: '5708'
+  name: DISEÑO DE CIRCUITOS INTEGRADOS
+  credits: 9
+  has_exam: false
+  subject_group: '035'
+'5710':
+  code: '5710'
+  name: INGENIERIA BIOMEDICA
+  credits: 8
+  has_exam: false
+  subject_group: '038'
+'5712':
+  code: '5712'
+  name: INTERNADO DE INGENIERIA BIOMEDICA
+  credits: 18
+  has_exam: false
+  subject_group: '039'
+'5713':
+  code: '5713'
+  name: CIRCUITOS DE RADIOFRECUENCIA
+  credits: 8
+  has_exam: false
+  subject_group: '035'
+'5714':
+  code: '5714'
+  name: DISEÑO DE SISTEMAS MEDICOS IMPLANTABLES ACTIVOS
+  credits: 0
+  has_exam: false
+  subject_group:
+'5715':
+  code: '5715'
+  name: ELECTRONICA FUNDAMENTAL
+  credits: 11
+  has_exam: true
+  subject_group: '023'
+'5716':
+  code: '5716'
+  name: ELECTRONICA AVANZADA 1
+  credits: 10
+  has_exam: true
+  subject_group: '035'
+'5717':
+  code: '5717'
+  name: ELECTRONICA AVANZADA 2
+  credits: 8
+  has_exam: true
+  subject_group: '035'
+'5718':
+  code: '5718'
+  name: INGENIERIA CLINICA
+  credits: 8
+  has_exam: false
+  subject_group: '038'
+'5719':
+  code: '5719'
+  name: APRENDIZAJE PROFUNDO PARA EL ANALISIS DE IMAGENES BIOMEDICAS
+  credits: 7
+  has_exam: false
+  subject_group: '030'
+'5720':
+  code: '5720'
+  name: TALLER DE APRENDIZAJE AUTOMATICO
+  credits: 10
+  has_exam: false
+  subject_group: '030'
+'5724':
+  code: '5724'
+  name: DISEÑO DE SISTEMAS MEDICOS IMPLANTABLES ACTIVOS
+  credits: 8
+  has_exam: false
+  subject_group: '035'
+'5801':
+  code: '5801'
+  name: SISTEMAS DE COMUNICACION
+  credits: 0
+  has_exam: true
+  subject_group:
+'5803':
+  code: '5803'
+  name: ANTENAS Y PROPAGACION
+  credits: 0
+  has_exam: true
+  subject_group:
+'5805':
+  code: '5805'
+  name: REDES DE DATOS
+  credits: 0
+  has_exam: true
+  subject_group:
+5805P:
+  code: 5805P
+  name: CREDITOS NO ACUM REDES DE DATOS
+  credits: 0
+  has_exam: false
+  subject_group:
+'5808':
+  code: '5808'
+  name: SISTEMAS DE COMUNICACION
+  credits: 0
+  has_exam: true
+  subject_group:
+'5811':
+  code: '5811'
+  name: TRATAMIENTO DE IMAGENES POR COMPUTADORA
+  credits: 0
+  has_exam: false
+  subject_group:
+'5817':
+  code: '5817'
+  name: ANTENAS Y PROPAGACION
+  credits: 10
+  has_exam: true
+  subject_group: '037'
+5817P:
+  code: 5817P
+  name: CREDITOS NO ACUM ANTENAS Y PROPAGACION
+  credits: 0
+  has_exam: false
+  subject_group:
+'5821':
+  code: '5821'
+  name: PROPAGACION EN ENTORNOS URBANOS
+  credits: 4
+  has_exam: false
+  subject_group: '037'
+'5824':
+  code: '5824'
+  name: REDES DE DATOS 1
+  credits: 8
+  has_exam: true
+  subject_group: '037'
+5824P:
+  code: 5824P
+  name: CREDITOS NO ACUM REDES DE DATOS 1
+  credits: 0
+  has_exam: false
+  subject_group:
+'5828':
+  code: '5828'
+  name: TRATAMIENTO DE IMAGENES POR COMPUTADORA
+  credits: 10
+  has_exam: false
+  subject_group: '030'
+5828P:
+  code: 5828P
+  name: CREDITOS NO ACUM TRATAMIENTO DE IMAG POR COMP
+  credits: 0
+  has_exam: false
+  subject_group:
+'5830':
+  code: '5830'
+  name: INT. A LA ELECTROTECNICA
+  credits: 0
+  has_exam: true
+  subject_group:
+'5833':
+  code: '5833'
+  name: REDES DE ACCESO
+  credits: 6
+  has_exam: true
+  subject_group: '037'
+'5834':
+  code: '5834'
+  name: NUCLEO DE RED EN TELECOMUNICACIONES
+  credits: 0
+  has_exam: true
+  subject_group:
+'5835':
+  code: '5835'
+  name: MODELADO Y ANALISIS DE REDES DE TELECOM.
+  credits: 12
+  has_exam: false
+  subject_group: '037'
+'5839':
+  code: '5839'
+  name: PROCESAMIENTO DIGITAL DE SEÑALES DE AUDIO
+  credits: 8
+  has_exam: false
+  subject_group: '030'
+'5840':
+  code: '5840'
+  name: TRATAMIENTO ESTADISTICO DE SEÑALES
+  credits: 0
+  has_exam: false
+  subject_group:
+'5842':
+  code: '5842'
+  name: RECONOCIMIENTO DE PATRONES
+  credits: 0
+  has_exam: false
+  subject_group:
+'5844':
+  code: '5844'
+  name: TALLER DE TELECOMUNICACIONES
+  credits: 4
+  has_exam: false
+  subject_group: '037'
+'5846':
+  code: '5846'
+  name: TECNOLOGIAS DE RED EN INTERNET
+  credits: 7
+  has_exam: false
+  subject_group: '037'
+'5847':
+  code: '5847'
+  name: PROCESAMIENTO DE IMAGENES PARA BIOLOGIA Y MEDICINA
+  credits: 10
+  has_exam: false
+  subject_group: '038'
+'5848':
+  code: '5848'
+  name: COMUNICACIONES INALAMBRICAS
+  credits: 8
+  has_exam: false
+  subject_group: '037'
+'5849':
+  code: '5849'
+  name: ESTIMACION Y PREDICCION EN SERIES TEMPORALES
+  credits: 10
+  has_exam: false
+  subject_group: '030'
+'5850':
+  code: '5850'
+  name: ELECTROTECNICA
+  credits: 10
+  has_exam: true
+  subject_group: '025'
+5850P:
+  code: 5850P
+  name: CREDITOS NO ACUM ELECTROTECNICA
+  credits: 0
+  has_exam: false
+  subject_group:
+'5852':
+  code: '5852'
+  name: FUNDAMENTOS DE APRENDIZAJE AUTOMATICO Y RECONOCIMIENTO DE PATRONES
+  credits: 8
+  has_exam: true
+  subject_group: '030'
+'5853':
+  code: '5853'
+  name: TALLER DE APRENDIZAJE AUTOMATICO
+  credits: 0
+  has_exam: false
+  subject_group:
+'5855':
+  code: '5855'
+  name: REDES DE DATOS 2
+  credits: 10
+  has_exam: true
+  subject_group: '037'
+'5856':
+  code: '5856'
+  name: TECNOLOGIAS DE REDES Y SERVICIOS DE TELECOMUNICACIONES
+  credits: 0
+  has_exam: true
+  subject_group:
+'5860':
+  code: '5860'
+  name: TEMAS AVANZADOS EN SISTEMAS INALAMBRICOS
+  credits: 6
+  has_exam: false
+  subject_group: '037'
+'5863':
+  code: '5863'
+  name: DISTRIBUCION Y APLICACIONES MULTIMEDIA
+  credits: 8
+  has_exam: false
+  subject_group: '037'
+'5864':
+  code: '5864'
+  name: DIGITALIZACION Y CODIFICACION MULTIMEDIA
+  credits: 8
+  has_exam: false
+  subject_group: '030'
+'5866':
+  code: '5866'
+  name: TECNOLOGIAS DE REDES Y SERVICIOS DE TELECOMUNICACIONES
+  credits: 8
+  has_exam: true
+  subject_group: '037'
+'5900':
+  code: '5900'
+  name: INT. A LA TEORIA DE CONTROL
+  credits: 0
+  has_exam: true
+  subject_group:
+'5904':
+  code: '5904'
+  name: TALLER DE INTRODUCCION A LA ING. ELECTRICA
+  credits: 10
+  has_exam: false
+  subject_group: '043'
+'5905':
+  code: '5905'
+  name: SISTEMAS Y CONTROL
+  credits: 8
+  has_exam: true
+  subject_group: '031'
+'5906':
+  code: '5906'
+  name: SISTEMAS DE CONTROL EN TIEMPO DISCRETO
+  credits: 8
+  has_exam: false
+  subject_group: '031'
+'5907':
+  code: '5907'
+  name: REDES OPTICAS
+  credits: 10
+  has_exam: false
+  subject_group: '037'
+'5908':
+  code: '5908'
+  name: HERRAMIENTAS DE REPRESENTACION TIEMPO-FRECUENCIA
+  credits: 7
+  has_exam: false
+  subject_group: '030'
+'5910':
+  code: '5910'
+  name: INT. A LOS PLC
+  credits: 0
+  has_exam: false
+  subject_group:
+'5913':
+  code: '5913'
+  name: ANALISIS Y CONTROL DE SISTEMAS NO LINEALES
+  credits: 10
+  has_exam: false
+  subject_group: '031'
+'5920':
+  code: '5920'
+  name: CONTROLADORES LOGICOS PROGRAMABLES
+  credits: 5
+  has_exam: false
+  subject_group: '031'
+'600':
+  code: '600'
+  name: QCA. GENERAL E INORGÁNICA (PLAN 1992)
+  credits: 0
+  has_exam: false
+  subject_group:
+'601':
+  code: '601'
+  name: LABORATORIO GENERAL (PLAN 1992)
+  credits: 0
+  has_exam: false
+  subject_group:
+ACT5:
+  code: ACT5
+  name: CREDITOS ASIGNADOS POR REVALIDA
+  credits: 0
+  has_exam: false
+  subject_group:
+AL:
+  code: AL
+  name: GEOMETRÍA Y ÁLGEBRA LINEAL
+  credits: 9
+  has_exam: false
+  subject_group: '011'
+AT001:
+  code: AT001
+  name: SENSIBILIZACIÓN E INTERCAMBIO PARA LA EQUIDAD
+  credits: 2
+  has_exam: false
+  subject_group: '042'
+BG827:
+  code: BG827
+  name: BIOFÍSICA (2020-
+  credits: 14
+  has_exam: true
+  subject_group: '013'
+C50:
+  code: C50
+  name: HISTORIA DEL URUGUAY CONTEMPORÁNEO
+  credits: 8
+  has_exam: false
+  subject_group: '042'
+CAL10:
+  code: CAL10
+  name: CREDITOS ASIGNADOS POR REVALIDA
+  credits: 0
+  has_exam: true
+  subject_group:
+CAL12:
+  code: CAL12
+  name: CREDITOS ASIGNADOS POR REVALIDA
+  credits: 0
+  has_exam: true
+  subject_group:
+CAL2:
+  code: CAL2
+  name: CÁLCULO 2
+  credits: 10
+  has_exam: false
+  subject_group: '011'
+CCT10:
+  code: CCT10
+  name: FÍSICA I
+  credits: 14
+  has_exam: false
+  subject_group: '012'
+CCT20:
+  code: CCT20
+  name: FÍSICA II
+  credits: 14
+  has_exam: true
+  subject_group: '012'
+CH201:
+  code: CH201
+  name: PROBABILIDAD Y ESTADÍSTICA
+  credits: 10
+  has_exam: false
+  subject_group: '011'
+CIM10:
+  code: CIM10
+  name: CÁLCULO VECTORIAL
+  credits: 12
+  has_exam: false
+  subject_group: '011'
+CIM18:
+  code: CIM18
+  name: FÍSICA EXPERIMENTAL 1 (FE1)
+  credits: 5
+  has_exam: false
+  subject_group: '012'
+CIM24:
+  code: CIM24
+  name: ECUACIONES DIFERENCIALES
+  credits: 10
+  has_exam: false
+  subject_group: '011'
+CIM26:
+  code: CIM26
+  name: FÍSICA TÉRMICA
+  credits: 10
+  has_exam: false
+  subject_group: '012'
+CIM28:
+  code: CIM28
+  name: MECÁNICA CLÁSICA
+  credits: 10
+  has_exam: false
+  subject_group: '012'
+CIM29:
+  code: CIM29
+  name: FÍSICA EXPERIMENTAL 2 (FE2)
+  credits: 5
+  has_exam: false
+  subject_group: '012'
+CIM40:
+  code: CIM40
+  name: ELECTROMAGNETÍSMO CIM
+  credits: 10
+  has_exam: false
+  subject_group: '012'
+CM:
+  code: CM
+  name: COMPLEMENTO DE MATEMÁTICA
+  credits: 6
+  has_exam: false
+  subject_group: '011'
+CM14:
+  code: CM14
+  name: CREDITOS ASIGNADOS POR REVALIDA
+  credits: 0
+  has_exam: true
+  subject_group:
+CON12:
+  code: CON12
+  name: CREDITOS ASIGNADOS POR REVALIDA
+  credits: 0
+  has_exam: true
+  subject_group:
+CON20:
+  code: CON20
+  name: CREDITOS ASIGNADOS POR REVALIDA
+  credits: 0
+  has_exam: true
+  subject_group:
+CP02:
+  code: CP02
+  name: CRÉDITOS POR QUÍMICA GENERAL
+  credits: 0
+  has_exam: true
+  subject_group:
+CP03:
+  code: CP03
+  name: CRÉDITOS POR QCA. ANAL. CUALITATIVA
+  credits: 0
+  has_exam: true
+  subject_group:
+CP04:
+  code: CP04
+  name: CRÉDITOS POR FÍSICA I
+  credits: 0
+  has_exam: false
+  subject_group:
+CP1:
+  code: CP1
+  name: ANALISIS MATEMATICO I
+  credits: 0
+  has_exam: true
+  subject_group:
+CP10:
+  code: CP10
+  name: TALLER II
+  credits: 0
+  has_exam: false
+  subject_group:
+CP102:
+  code: CP102
+  name: CONTROL DE CALIDAD
+  credits: 0
+  has_exam: true
+  subject_group:
+CP119:
+  code: CP119
+  name: QUIMICA TECNICA
+  credits: 0
+  has_exam: false
+  subject_group:
+CP12:
+  code: CP12
+  name: TERMODINAMICA
+  credits: 0
+  has_exam: true
+  subject_group:
+CP120:
+  code: CP120
+  name: QUIMICA
+  credits: 0
+  has_exam: false
+  subject_group:
+CP13:
+  code: CP13
+  name: ELECTROMAGNETISMO
+  credits: 0
+  has_exam: true
+  subject_group:
+CP14:
+  code: CP14
+  name: TALLER LABORATORIO II (MODULO DE FISICA)
+  credits: 0
+  has_exam: false
+  subject_group:
+CP148:
+  code: CP148
+  name: INSTALACIONES ELECTRICAS
+  credits: 0
+  has_exam: true
+  subject_group:
+CP16:
+  code: CP16
+  name: CALCULO NUMERICO
+  credits: 0
+  has_exam: false
+  subject_group:
+CP17:
+  code: CP17
+  name: MECANICA I (TRANSICION)
+  credits: 0
+  has_exam: false
+  subject_group:
+CP18:
+  code: CP18
+  name: TECNOLOGIA Y SOCIEDAD
+  credits: 0
+  has_exam: false
+  subject_group:
+CP2:
+  code: CP2
+  name: GEOMETRIA Y ALGEBRA LINEAL
+  credits: 0
+  has_exam: true
+  subject_group:
+CP20:
+  code: CP20
+  name: ECONOMIA POLITICA
+  credits: 0
+  has_exam: false
+  subject_group:
+CP22:
+  code: CP22
+  name: ANALISIS MATEMATICO I (P. 74)
+  credits: 0
+  has_exam: true
+  subject_group:
+CP23:
+  code: CP23
+  name: GEOMETRIA Y ALGEBRA LINEAL (P. 74)
+  credits: 0
+  has_exam: true
+  subject_group:
+CP24:
+  code: CP24
+  name: COMPUTACION (P. 74)
+  credits: 0
+  has_exam: true
+  subject_group:
+CP25:
+  code: CP25
+  name: ANALISIS MATEMATICO II (P. 74)
+  credits: 0
+  has_exam: true
+  subject_group:
+CP26:
+  code: CP26
+  name: MECANICA GENERAL I (P. 74)
+  credits: 0
+  has_exam: true
+  subject_group:
+CP27:
+  code: CP27
+  name: INVESTIGACION OPERATIVA
+  credits: 0
+  has_exam: true
+  subject_group:
+CP29:
+  code: CP29
+  name: PROGRAMACION III
+  credits: 0
+  has_exam: true
+  subject_group:
+CP3:
+  code: CP3
+  name: MECANICA I
+  credits: 0
+  has_exam: false
+  subject_group:
+CP38:
+  code: CP38
+  name: PROGRAMACION II (P. 74)
+  credits: 0
+  has_exam: false
+  subject_group:
+CP4:
+  code: CP4
+  name: LOGICA
+  credits: 0
+  has_exam: false
+  subject_group:
+CP41:
+  code: CP41
+  name: FISICA I (P. 74)
+  credits: 0
+  has_exam: false
+  subject_group:
+CP42:
+  code: CP42
+  name: FISICA II (P. 74)
+  credits: 0
+  has_exam: true
+  subject_group:
+CP43:
+  code: CP43
+  name: FISICA III (P. 74)
+  credits: 0
+  has_exam: true
+  subject_group:
+CP44:
+  code: CP44
+  name: ANALISIS MATEMATICO I (1ER.SEM.)
+  credits: 0
+  has_exam: true
+  subject_group:
+CP45:
+  code: CP45
+  name: ANALISIS MATEMATICO I (2DO.SEM.)
+  credits: 0
+  has_exam: false
+  subject_group:
+CP46:
+  code: CP46
+  name: GEOMETRIA Y ALGEBRA LINEAL (1ER.SEM.)
+  credits: 0
+  has_exam: true
+  subject_group:
+CP47:
+  code: CP47
+  name: GEOMETRIA Y ALGEBRA LINEAL (2DO.SEM.)
+  credits: 0
+  has_exam: true
+  subject_group:
+CP48:
+  code: CP48
+  name: ANALISIS MATEMATICO II (1ER.SEM.)
+  credits: 0
+  has_exam: true
+  subject_group:
+CP49:
+  code: CP49
+  name: ANALISIS MATEMATICO II (2DO.SEM.)
+  credits: 0
+  has_exam: true
+  subject_group:
+CP51:
+  code: CP51
+  name: DISEÑO LOGICO
+  credits: 0
+  has_exam: true
+  subject_group:
+CP52:
+  code: CP52
+  name: COMPUTACION
+  credits: 0
+  has_exam: true
+  subject_group:
+CP55:
+  code: CP55
+  name: TALLER LABORATORIO I (MODULO DE DIBUJO)
+  credits: 0
+  has_exam: false
+  subject_group:
+CP59:
+  code: CP59
+  name: MEDIDAS ELECTRICAS
+  credits: 0
+  has_exam: false
+  subject_group:
+CP6:
+  code: CP6
+  name: ANALISIS MATEMATICO II
+  credits: 0
+  has_exam: true
+  subject_group:
+CP7:
+  code: CP7
+  name: ANALISIS COMPLEJO
+  credits: 0
+  has_exam: true
+  subject_group:
+CP74:
+  code: CP74
+  name: REDES ELECTRICAS I
+  credits: 0
+  has_exam: true
+  subject_group:
+CP8:
+  code: CP8
+  name: MECANICA II
+  credits: 0
+  has_exam: true
+  subject_group:
+CP9:
+  code: CP9
+  name: PROGRAMACION I
+  credits: 0
+  has_exam: true
+  subject_group:
+DMA01:
+  code: DMA01
+  name: CÁLCULO DIFERENCIAL E INTEGRAL EN UNA VARIABLE
+  credits: 12
+  has_exam: false
+  subject_group: '011'
+DMA02:
+  code: DMA02
+  name: MATEMÁTICA DISCRETA
+  credits: 12
+  has_exam: false
+  subject_group: '011'
+DMA03:
+  code: DMA03
+  name: GEOMETRÍA Y ÁLGEBRA LINEAL 1
+  credits: 12
+  has_exam: false
+  subject_group: '011'
+DMA04:
+  code: DMA04
+  name: GEOMETRÍA Y ALGEBRA LINEAL II
+  credits: 12
+  has_exam: false
+  subject_group: '011'
+DMA05:
+  code: DMA05
+  name: MATEMÁTICA INICIAL
+  credits: 4
+  has_exam: false
+  subject_group: '011'
+DMA06:
+  code: DMA06
+  name: CALCULO DIFERENCIAL E INTEGRAL EN VARIAS VARIABLES
+  credits: 13
+  has_exam: false
+  subject_group: '011'
+EL31:
+  code: EL31
+  name: ÉTICA
+  credits: 8
+  has_exam: false
+  subject_group: '042'
+ESII:
+  code: ESII
+  name: ESTADÍSTICA II
+  credits: 10
+  has_exam: false
+  subject_group: '011'
+ESTAI:
+  code: ESTAI
+  name: ESTADÍSTICA I
+  credits: 10
+  has_exam: false
+  subject_group: '011'
+ETSON:
+  code: ETSON
+  name: 'TÉCNICAS DE SONOMONTAJE: EDICIÓN Y PROC. AUDIO'
+  credits: 4
+  has_exam: true
+  subject_group: '037'
+F10:
+  code: F10
+  name: CREDITOS ASIGNADOS POR REVALIDA
+  credits: 0
+  has_exam: false
+  subject_group:
+F1Y3:
+  code: F1Y3
+  name: CREDITOS ASIGNADOS POR REVALIDA
+  credits: 0
+  has_exam: false
+  subject_group:
+F30:
+  code: F30
+  name: CREDITOS ASIGNADOS POR REVALIDA
+  credits: 0
+  has_exam: false
+  subject_group:
+F7:
+  code: F7
+  name: CREDITOS ASIGNADOS POR REVALIDA
+  credits: 0
+  has_exam: true
+  subject_group:
+F8:
+  code: F8
+  name: CREDITOS ASIGNADOS POR REVALIDA
+  credits: 0
+  has_exam: true
+  subject_group:
+FF12:
+  code: FF12
+  name: CREDITOS ASIGNADOS POR REVALIDA
+  credits: 0
+  has_exam: true
+  subject_group:
+FG:
+  code: FG
+  name: CREDITOS ASIGNADOS POR REVALIDA
+  credits: 0
+  has_exam: false
+  subject_group:
+FG2:
+  code: FG2
+  name: CREDITOS ASIGNADOS POR REVALIDA
+  credits: 0
+  has_exam: true
+  subject_group:
+FI10:
+  code: FI10
+  name: CREDITOS ASIGNADOS POR REVALIDA
+  credits: 0
+  has_exam: false
+  subject_group:
+FI13:
+  code: FI13
+  name: CREDITOS ASIGNADOS POR REVALIDA
+  credits: 0
+  has_exam: false
+  subject_group:
+FI15:
+  code: FI15
+  name: CREDITOS ASIGNADOS POR REVALIDA
+  credits: 0
+  has_exam: true
+  subject_group:
+FIS13:
+  code: FIS13
+  name: CREDITOS ASIGNADOS POR REVALIDA
+  credits: 0
+  has_exam: false
+  subject_group:
+FIS14:
+  code: FIS14
+  name: CREDITOS ASIGNADOS POR REVALIDA
+  credits: 0
+  has_exam: true
+  subject_group:
+FIS45:
+  code: FIS45
+  name: CREDITOS ASIGNADOS POR REVALIDA
+  credits: 0
+  has_exam: true
+  subject_group:
+FUN12:
+  code: FUN12
+  name: CREDITOS ASIGNADOS POR REVALIDA
+  credits: 0
+  has_exam: false
+  subject_group:
+GAL1P:
+  code: GAL1P
+  name: GEOMETRIA Y ALGEBRA LINEAL 1 INTERACTIVA
+  credits: 9
+  has_exam: true
+  subject_group: '011'
+GAL7:
+  code: GAL7
+  name: CREDITOS ASIGNADOS POR REVALIDA
+  credits: 0
+  has_exam: true
+  subject_group:
+IDUCS:
+  code: IDUCS
+  name: INTROD. A LAS DINAMICAS UNIVERSITARIAS
+  credits: 3
+  has_exam: false
+  subject_group: '043'
+INF20:
+  code: INF20
+  name: CREDITOS ASIGNADOS POR REVALIDA
+  credits: 0
+  has_exam: false
+  subject_group:
+INF6:
+  code: INF6
+  name: CREDITOS ASIGNADOS POR REVALIDA
+  credits: 0
+  has_exam: false
+  subject_group:
+INS18:
+  code: INS18
+  name: CREDITOS ASIGNADOS POR REVALIDA
+  credits: 0
+  has_exam: true
+  subject_group:
+IYS12:
+  code: IYS12
+  name: CREDITOS ASIGNADOS POR REVALIDA
+  credits: 0
+  has_exam: false
+  subject_group:
+IYS14:
+  code: IYS14
+  name: CREDITOS ASIGNADOS POR REVALIDA
+  credits: 0
+  has_exam: false
+  subject_group:
+LG103:
+  code: LG103
+  name: HERRAMIENTAS PARA EL TRABAJO COLECTIVO
+  credits: 5
+  has_exam: false
+  subject_group: '043'
+LG12:
+  code: LG12
+  name: ANÁLISIS DE LAS INTERACCIONES ECONÓMICAS
+  credits: 10
+  has_exam: false
+  subject_group: '042'
+LIB10:
+  code: LIB10
+  name: TALLER DE INGENIERÍA BIOLÓGICA II
+  credits: 8
+  has_exam: true
+  subject_group: '038'
+LIB36:
+  code: LIB36
+  name: INFORMÁTICA EN BIOLOGÍA Y MEDICINA
+  credits: 10
+  has_exam: true
+  subject_group: '033'
+LIB38:
+  code: LIB38
+  name: FISIOLOGÍA CUANTITATIVA
+  credits: 10
+  has_exam: true
+  subject_group: '013'
+M12:
+  code: M12
+  name: CREDITOS ASIGNADOS POR REVALIDA
+  credits: 0
+  has_exam: true
+  subject_group:
+M13:
+  code: M13
+  name: CREDITOS ASIGNADOS POR REVALIDA
+  credits: 0
+  has_exam: true
+  subject_group:
+M14:
+  code: M14
+  name: CREDITOS ASIGNADOS POR REVALIDA
+  credits: 0
+  has_exam: true
+  subject_group:
+M24:
+  code: M24
+  name: CREDITOS ASIGNADOS POR REVALIDA
+  credits: 0
+  has_exam: true
+  subject_group:
+M9:
+  code: M9
+  name: CREDITOS ASIGNADOS POR REVALIDA
+  credits: 0
+  has_exam: true
+  subject_group:
+MA01:
+  code: MA01
+  name: CALCULO DIFERENCIAL E INTEGRAL I
+  credits: 0
+  has_exam: false
+  subject_group:
+MA09:
+  code: MA09
+  name: CREDITOS ASIGNADOS POR REVALIDA
+  credits: 0
+  has_exam: true
+  subject_group:
+MA10:
+  code: MA10
+  name: CREDITOS ASIGNADOS POR REVALIDA
+  credits: 0
+  has_exam: true
+  subject_group:
+MA11:
+  code: MA11
+  name: CREDITOS ASIGNADOS POR REVALIDA
+  credits: 0
+  has_exam: true
+  subject_group:
+MA13:
+  code: MA13
+  name: CÁLCULO DIFERENCIAL E INTEGRAL I (F)
+  credits: 0
+  has_exam: false
+  subject_group:
+MA15:
+  code: MA15
+  name: CREDITOS ASIGNADOS POR REVALIDA
+  credits: 0
+  has_exam: false
+  subject_group:
+MA25:
+  code: MA25
+  name: CREDITOS ASIGNADOS POR REVALIDA
+  credits: 0
+  has_exam: true
+  subject_group:
+MA29:
+  code: MA29
+  name: CREDITOS ASIGNADOS POR REVALIDA
+  credits: 0
+  has_exam: false
+  subject_group:
+MA47:
+  code: MA47
+  name: CREDITOS ASIGNADOS POR REVALIDA
+  credits: 0
+  has_exam: true
+  subject_group:
+MA5:
+  code: MA5
+  name: CREDITOS ASIGNADOS POR REVALIDA
+  credits: 0
+  has_exam: true
+  subject_group:
+MA51:
+  code: MA51
+  name: CREDITOS ASIGNADOS POR REVALIDA
+  credits: 0
+  has_exam: true
+  subject_group:
+MA7:
+  code: MA7
+  name: CREDITOS ASIGNADOS POR REVALIDA
+  credits: 0
+  has_exam: true
+  subject_group:
+MAT14:
+  code: MAT14
+  name: CREDITOS ASIGNADOS POR REVALIDA
+  credits: 0
+  has_exam: true
+  subject_group:
+MAT18:
+  code: MAT18
+  name: CREDITOS ASIGNADOS POR REVALIDA
+  credits: 0
+  has_exam: true
+  subject_group:
+MAT33:
+  code: MAT33
+  name: CREDITOS ASIGNADOS POR REVALIDA
+  credits: 0
+  has_exam: true
+  subject_group:
+MC13:
+  code: MC13
+  name: CREDITOS ASIGNADOS POR REVALIDA
+  credits: 0
+  has_exam: true
+  subject_group:
+MC3:
+  code: MC3
+  name: CREDITOS ASIGNADOS POR REVALIDA
+  credits: 0
+  has_exam: true
+  subject_group:
+MI2:
+  code: MI2
+  name: MATEMATICA INICIAL
+  credits: 4
+  has_exam: true
+  subject_group: '011'
+O2525:
+  code: O2525
+  name: COMUNICACIÓN E INTELIGENCIA ARTIFICIAL(PPP)
+  credits: 9
+  has_exam: false
+  subject_group: '042'
+O6211:
+  code: O6211
+  name: TECNOLOGÍA DE MEDIOS AL SERVICIO DE LA PRESERVACIÓN DEL PATRIMONIO HISTÓRICO
+    DOC
+  credits: 8
+  has_exam: false
+  subject_group: '043'
+O6221:
+  code: O6221
+  name: LABORATORIO DE ACCESIBILIDAD A LOS MEDIOS (INV. - EXT.)
+  credits: 10
+  has_exam: false
+  subject_group: '043'
+O6311:
+  code: O6311
+  name: TALLER DE INTERACCIÓN
+  credits: 6
+  has_exam: false
+  subject_group: '043'
+O6521:
+  code: O6521
+  name: TEORÍAS Y PRÁCTICAS DE LA ACCESIBILIDAD EN LA COMUNICACIÓN - LIM
+  credits: 8
+  has_exam: false
+  subject_group: '043'
+O7245:
+  code: O7245
+  name: INTRODUCCIÓN A LA PROGRAMACIÓN Y ANÁLISIS DE TEXTO CON R (LIM)
+  credits: 4
+  has_exam: false
+  subject_group: '033'
+O7246:
+  code: O7246
+  name: TECNOLOGÍAS DE DIGITALIZACIÓN Y TRANSCODIFICACIÓN. IDENTIFICACIÓN Y PRESERVACIÓN
+  credits: 8
+  has_exam: false
+  subject_group: '043'
+PQIF:
+  code: PQIF
+  name: PRINCIPIOS DE QUÍMICA PARA ING. FORESTAL
+  credits: 10
+  has_exam: false
+  subject_group: '013'
+Q16:
+  code: Q16
+  name: INT. A LA PREVENCION DE RIESGOS LABORALES
+  credits: 6
+  has_exam: true
+  subject_group: '041'
+Q47:
+  code: Q47
+  name: BATERIAS RECARGABLES Y CELDAS DE COMBUSTIBLE
+  credits: 8
+  has_exam: false
+  subject_group: '032'
+Q58:
+  code: Q58
+  name: INT. A LA PREVENCION DE RIESGOS LABORALES
+  credits: 0
+  has_exam: false
+  subject_group:
+R100:
+  code: R100
+  name: ANALISIS MATEMATICO I
+  credits: 0
+  has_exam: false
+  subject_group:
+R101:
+  code: R101
+  name: GEOMETRIA Y ALGEBRA LINEAL
+  credits: 0
+  has_exam: false
+  subject_group:
+REF04:
+  code: REF04
+  name: FÍSICA 1
+  credits: 10
+  has_exam: false
+  subject_group: '012'
+RN04:
+  code: RN04
+  name: CONCEPTOS DE ECONOMIA Y DESARROLLO LOCAL
+  credits: 10
+  has_exam: false
+  subject_group: '042'
+RN102:
+  code: RN102
+  name: EVALUACIÓN DE RECURSOS NATURALES
+  credits: 7
+  has_exam: false
+  subject_group: '042'
+RN115:
+  code: RN115
+  name: ESTADÍSTICA I 2022
+  credits: 10
+  has_exam: false
+  subject_group: '011'
+RN252:
+  code: RN252
+  name: FISICA 1 BIOCIENCIAS 2017
+  credits: 12
+  has_exam: false
+  subject_group: '012'
+RN253:
+  code: RN253
+  name: FISICA 2 BIOCIENCIAS 2017
+  credits: 12
+  has_exam: false
+  subject_group: '012'
+RN404:
+  code: RN404
+  name: MATEMATICA I
+  credits: 11
+  has_exam: false
+  subject_group: '011'
+RN407:
+  code: RN407
+  name: MATEMATICA II
+  credits: 12
+  has_exam: false
+  subject_group: '011'
+SD10:
+  code: SD10
+  name: CREDITOS ASIGNADOS POR REVALIDA
+  credits: 0
+  has_exam: false
+  subject_group:
+SIS10:
+  code: SIS10
+  name: CREDITOS ASIGNADOS POR REVALIDA
+  credits: 0
+  has_exam: false
+  subject_group:
+SO001:
+  code: SO001
+  name: INTRODUCCIÓN A LA VIDA UNIVERSITARIA (IVU)
+  credits: 1
+  has_exam: false
+  subject_group: '043'
+SRN02:
+  code: SRN02
+  name: CÁLCULO I
+  credits: 16
+  has_exam: false
+  subject_group: '011'
+SRN03:
+  code: SRN03
+  name: ALGEBRA LINEAL I
+  credits: 12
+  has_exam: false
+  subject_group: '011'
+SRN06:
+  code: SRN06
+  name: TALLER DE DISEÑO
+  credits: 6
+  has_exam: false
+  subject_group: '043'
+SRN09:
+  code: SRN09
+  name: CÁLCULO II
+  credits: 16
+  has_exam: false
+  subject_group: '011'
+SRN10:
+  code: SRN10
+  name: ALGEBRA LINEAL II
+  credits: 12
+  has_exam: false
+  subject_group: '011'
+SRN11:
+  code: SRN11
+  name: FÍSICA 2
+  credits: 10
+  has_exam: false
+  subject_group: '012'
+SRN14:
+  code: SRN14
+  name: MATEMÁTICA DISCRETA I
+  credits: 10
+  has_exam: false
+  subject_group: '011'
+SRN17:
+  code: SRN17
+  name: PROGRAMACIÓN I- CIO CT-LHRH
+  credits: 0
+  has_exam: true
+  subject_group:
+SRN26:
+  code: SRN26
+  name: FÍSICA 3
+  credits: 10
+  has_exam: false
+  subject_group: '012'
+SRN30:
+  code: SRN30
+  name: TALLER DE ROBÓTICA-CIO CT- INGBIOL
+  credits: 2
+  has_exam: false
+  subject_group: '043'
+SRN47:
+  code: SRN47
+  name: PRINCIPIOS DE QUÍMICA GENERAL - CIOCT-RH-AGR
+  credits: 10
+  has_exam: false
+  subject_group: '013'
+TD6:
+  code: TD6
+  name: CREDITOS ASIGNADOS POR REVALIDA
+  credits: 0
+  has_exam: false
+  subject_group:
+TELE8:
+  code: TELE8
+  name: CREDITOS ASIGNADOS POR REVALIDA
+  credits: 0
+  has_exam: false
+  subject_group:
+TTR13:
+  code: TTR13
+  name: TALLER DE GESTION DE REDES
+  credits: 11
+  has_exam: false
+  subject_group: '037'
+TTR6:
+  code: TTR6
+  name: PROGRAMACION I
+  credits: 10
+  has_exam: false
+  subject_group: '026'

--- a/db/data/electrica/subject_overrides.yml
+++ b/db/data/electrica/subject_overrides.yml
@@ -1,0 +1,66 @@
+---
+'1061':
+  eva_id: '1024'
+  second_semester_eva_id: '1504'
+  openfing_id: cdiv-2022
+  short_name: Cálculo DIV
+  category: 'first_semester'
+'1030':
+  eva_id: '256'
+  openfing_id: gal1-2022
+  short_name: GAL 1
+  category: 'first_semester'
+MI2:
+  category: 'first_semester'
+'1151':
+  eva_id: '87'
+  openfing_id: f1-2018
+  category: 'first_semester'
+'5904':
+  eva_id: '405'
+  short_name: 'Tallerine'
+  category: 'first_semester'
+'1062':
+  eva_id: '1594'
+  second_semester_eva_id: '1131'
+  openfing_id: cdivv-2022
+  short_name: Cálculo DIVV
+  category: 'second_semester'
+'1031':
+  eva_id: '270'
+  openfing_id: gal219
+  short_name: GAL 2
+  category: 'second_semester'
+'1152':
+  eva_id: '32'
+  second_semester_eva_id: '1546'
+  openfing_id: f2-2023
+  category: 'second_semester'
+'1373':
+  eva_id: '58'
+  openfing_id: p1
+  category: 'second_semester'
+'1063':
+  eva_id: '1498'
+  second_semester_eva_id: '1183'
+  category: 'third_semester'
+'1025':
+  eva_id: '54'
+  second_semester_eva_id: '1537'
+  category: 'third_semester'
+'1153':
+  category: 'third_semester'
+'1122':
+  category: 'third_semester'
+'1154':
+  category: 'third_semester'
+'1064':
+  category: 'fourth_semester'
+'1128':
+  category: 'fourth_semester'
+'1155':
+  category: 'fourth_semester'
+'1456':
+  category: 'fourth_semester'
+'1512':
+  category: 'fourth_semester'

--- a/db/migrate/20250421184824_create_degrees.rb
+++ b/db/migrate/20250421184824_create_degrees.rb
@@ -1,0 +1,14 @@
+class CreateDegrees < ActiveRecord::Migration[8.0]
+  def change
+    create_table :degrees do |t|
+      t.string :name
+      t.string :key, null: false, default: ""
+      t.string :current_plan
+      t.boolean :include_inco_subjects
+
+      t.timestamps
+    end
+
+    add_index :degrees, :key, unique: true
+  end
+end

--- a/db/migrate/20250502182232_add_degree_to_user.rb
+++ b/db/migrate/20250502182232_add_degree_to_user.rb
@@ -1,0 +1,5 @@
+class AddDegreeToUser < ActiveRecord::Migration[8.0]
+  def change
+    add_reference :users, :degree, foreign_key: true
+  end
+end

--- a/db/migrate/20250513173739_add_multitenancy_columns.rb
+++ b/db/migrate/20250513173739_add_multitenancy_columns.rb
@@ -1,0 +1,21 @@
+class AddMultitenancyColumns < ActiveRecord::Migration[8.0]
+  def change
+    add_column :approvables, :degree_id, :integer
+    add_index :approvables, :degree_id
+
+    add_column :prerequisites, :degree_id, :integer
+    add_index :prerequisites, :degree_id
+
+    add_column :reviews, :degree_id, :integer
+    add_index :reviews, :degree_id
+
+    add_column :subject_groups, :degree_id, :integer
+    add_index :subject_groups, :degree_id
+
+    add_column :subject_plans, :degree_id, :integer
+    add_index :subject_plans, :degree_id
+
+    add_column :subjects, :degree_id, :integer
+    add_index :subjects, :degree_id
+  end
+end

--- a/db/migrate/20250513184637_remove_uniqueness_from_subject_code.rb
+++ b/db/migrate/20250513184637_remove_uniqueness_from_subject_code.rb
@@ -1,0 +1,6 @@
+class RemoveUniquenessFromSubjectCode < ActiveRecord::Migration[8.0]
+  def change
+    remove_index :subjects, :code
+    add_index :subjects, :code
+  end
+end

--- a/db/migrate/20250513184859_remove_uniqueness_from_subject_group_code.rb
+++ b/db/migrate/20250513184859_remove_uniqueness_from_subject_group_code.rb
@@ -1,0 +1,6 @@
+class RemoveUniquenessFromSubjectGroupCode < ActiveRecord::Migration[8.0]
+  def change
+    remove_index :subject_groups, :code
+    add_index :subject_groups, :code
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_01_26_183903) do
+ActiveRecord::Schema[8.0].define(version: 2025_04_21_184824) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "unaccent"
@@ -20,6 +20,16 @@ ActiveRecord::Schema[8.0].define(version: 2025_01_26_183903) do
     t.boolean "is_exam", null: false
     t.datetime "created_at", precision: nil, null: false
     t.datetime "updated_at", precision: nil, null: false
+  end
+
+  create_table "degrees", force: :cascade do |t|
+    t.string "name"
+    t.string "key", default: "", null: false
+    t.string "current_plan"
+    t.boolean "include_inco_subjects"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["key"], name: "index_degrees_on_key", unique: true
   end
 
   create_table "prerequisites", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -20,6 +20,8 @@ ActiveRecord::Schema[8.0].define(version: 2025_05_13_184859) do
     t.boolean "is_exam", null: false
     t.datetime "created_at", precision: nil, null: false
     t.datetime "updated_at", precision: nil, null: false
+    t.integer "degree_id"
+    t.index ["degree_id"], name: "index_approvables_on_degree_id"
   end
 
   create_table "degrees", force: :cascade do |t|
@@ -41,6 +43,8 @@ ActiveRecord::Schema[8.0].define(version: 2025_05_13_184859) do
     t.integer "subject_group_id"
     t.integer "approvable_needed_id"
     t.integer "amount_of_subjects_needed"
+    t.integer "degree_id"
+    t.index ["degree_id"], name: "index_prerequisites_on_degree_id"
   end
 
   create_table "reviews", force: :cascade do |t|
@@ -49,6 +53,8 @@ ActiveRecord::Schema[8.0].define(version: 2025_05_13_184859) do
     t.integer "rating", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer "degree_id"
+    t.index ["degree_id"], name: "index_reviews_on_degree_id"
     t.index ["subject_id", "user_id"], name: "index_reviews_on_subject_id_and_user_id", unique: true
   end
 
@@ -58,7 +64,9 @@ ActiveRecord::Schema[8.0].define(version: 2025_05_13_184859) do
     t.datetime "updated_at", precision: nil, null: false
     t.string "code"
     t.integer "credits_needed", default: 0, null: false
-    t.index ["code"], name: "index_subject_groups_on_code", unique: true
+    t.integer "degree_id"
+    t.index ["code"], name: "index_subject_groups_on_code"
+    t.index ["degree_id"], name: "index_subject_groups_on_degree_id"
   end
 
   create_table "subject_plans", force: :cascade do |t|
@@ -67,6 +75,8 @@ ActiveRecord::Schema[8.0].define(version: 2025_05_13_184859) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.integer "semester", null: false
+    t.integer "degree_id"
+    t.index ["degree_id"], name: "index_subject_plans_on_degree_id"
     t.index ["user_id", "subject_id"], name: "index_subject_plans_on_user_id_and_subject_id", unique: true
   end
 
@@ -83,7 +93,9 @@ ActiveRecord::Schema[8.0].define(version: 2025_05_13_184859) do
     t.string "category", default: "optional"
     t.boolean "current_optional_subject", default: false
     t.string "second_semester_eva_id"
-    t.index ["code"], name: "index_subjects_on_code", unique: true
+    t.integer "degree_id"
+    t.index ["code"], name: "index_subjects_on_code"
+    t.index ["degree_id"], name: "index_subjects_on_degree_id"
   end
 
   create_table "users", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_04_21_184824) do
+ActiveRecord::Schema[8.0].define(version: 2025_05_13_184859) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "unaccent"
@@ -101,6 +101,8 @@ ActiveRecord::Schema[8.0].define(version: 2025_04_21_184824) do
     t.integer "failed_attempts", default: 0, null: false
     t.datetime "locked_at"
     t.string "unlock_token"
+    t.bigint "degree_id"
+    t.index ["degree_id"], name: "index_users_on_degree_id"
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
     t.index ["unlock_token"], name: "index_users_on_unlock_token", unique: true
@@ -110,4 +112,5 @@ ActiveRecord::Schema[8.0].define(version: 2025_04_21_184824) do
   add_foreign_key "reviews", "users"
   add_foreign_key "subject_plans", "subjects"
   add_foreign_key "subject_plans", "users"
+  add_foreign_key "users", "degrees"
 end

--- a/spec/controllers/reviews_controller_spec.rb
+++ b/spec/controllers/reviews_controller_spec.rb
@@ -1,9 +1,10 @@
 require 'rails_helper'
 
 RSpec.describe ReviewsController, type: :request do
-  let(:user) { create(:user) }
-  let(:subject) { create(:subject) }
-  let(:review) { create(:review, user:, subject:) }
+  let(:degree) { create :degree }
+  let(:user) { create :user, degree: }
+  let(:subject) { create :subject, degree: }
+  let(:review) { create :review, user:, subject:, degree: }
 
   before do
     sign_in user

--- a/spec/factories/degree.rb
+++ b/spec/factories/degree.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :degree do
+    name { 'Masters in Testeneering' }
+    sequence(:key) { |n| "testeneering_#{n}" }
+  end
+end

--- a/spec/factories/reviews.rb
+++ b/spec/factories/reviews.rb
@@ -3,5 +3,6 @@ FactoryBot.define do
     user
     subject
     rating { 3 }
+    degree
   end
 end

--- a/spec/models/cookie_student_spec.rb
+++ b/spec/models/cookie_student_spec.rb
@@ -222,4 +222,37 @@ RSpec.describe CookieStudent, type: :model do
       expect(student).to be_graduated
     end
   end
+
+  describe '#change_degree' do
+    let(:degree) { create :degree }
+    let(:cookies) { build :cookie }
+    let(:student) { build :cookie_student, cookies: }
+
+    it 'sets the degree cookie with the correct value and domain' do
+      student.change_degree(degree.id)
+
+      expect(cookies[:degree]).to eq(degree.id)
+    end
+  end
+
+  describe '#degree' do
+    let(:degree) { create :degree }
+    let(:student) { build :cookie_student, cookies: }
+
+    context 'when a degree is set' do
+      let(:cookies) { build :cookie, degree: degree.id }
+
+      it 'returns the correct degree' do
+        expect(student.degree).to eq(degree)
+      end
+    end
+
+    context 'when no degree is set' do
+      let(:cookies) { build :cookie }
+
+      it 'returns nil when cookie is not set' do
+        expect(student.degree).to eq(nil)
+      end
+    end
+  end
 end

--- a/spec/models/degree_spec.rb
+++ b/spec/models/degree_spec.rb
@@ -1,0 +1,10 @@
+require 'rails_helper'
+
+RSpec.describe Degree, type: :model do
+  describe 'validations' do
+    subject { described_class.new(key: 'foo') }
+
+    it { should validate_presence_of(:key) }
+    it { should validate_uniqueness_of(:key) }
+  end
+end

--- a/spec/models/subject_group_spec.rb
+++ b/spec/models/subject_group_spec.rb
@@ -11,6 +11,6 @@ RSpec.describe SubjectGroup, type: :model do
 
   describe 'validations' do
     it { should validate_presence_of(:name) }
-    it { should validate_uniqueness_of(:code) }
+    it { should validate_uniqueness_of(:code).scoped_to(:degree_id) }
   end
 end

--- a/spec/models/subject_spec.rb
+++ b/spec/models/subject_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe Subject, type: :model do
 
     it { should validate_presence_of(:name) }
     it { should validate_presence_of(:credits) }
-    it { should validate_uniqueness_of(:code) }
+    it { should validate_uniqueness_of(:code).scoped_to(:degree_id) }
   end
 
   describe '#approved_credits' do

--- a/spec/models/user_student_spec.rb
+++ b/spec/models/user_student_spec.rb
@@ -214,4 +214,25 @@ RSpec.describe UserStudent, type: :model do
       expect(user.reload.approvals).to contain_exactly(subject.course.id, subject.exam.id)
     end
   end
+
+  describe '#change_degree' do
+    let(:user) { create :user }
+    let(:degree) { create :degree }
+    let(:student) { described_class.new(user) }
+
+    it 'updates the user degree' do
+      student.change_degree(degree.id)
+      expect(user.reload.degree_id).to eq(degree.id)
+    end
+  end
+
+  describe '#degree' do
+    let(:degree) { create :degree }
+    let(:user) { create :user, degree: }
+    let(:student) { described_class.new(user) }
+
+    it 'delegates #degree to user' do
+      expect(student.degree).to eq(user.degree)
+    end
+  end
 end

--- a/spec/requests/student_degrees_spec.rb
+++ b/spec/requests/student_degrees_spec.rb
@@ -1,0 +1,17 @@
+require 'rails_helper'
+
+RSpec.describe "StudentDegrees", type: :request do
+  describe "PATCH /student_degrees" do
+    let(:student) { build(:cookie_student) }
+
+    before do
+      allow_any_instance_of(ApplicationController).to receive(:current_student).and_return(student)
+    end
+
+    it 'calls change_degree with the correct param and redirects' do
+      expect(student).to receive(:change_degree).with('electrica')
+      patch student_degrees_path, params: { degree: 'electrica' }
+      expect(response).to redirect_to(root_path)
+    end
+  end
+end

--- a/spec/system/planned_subjects_spec.rb
+++ b/spec/system/planned_subjects_spec.rb
@@ -5,6 +5,9 @@ RSpec.describe "PlannedSubjects", type: :system do
   include PlannedSubjectsTestHelper
 
   it "can add and remove subjects to planner" do
+    degree = create :degree, name: "Ing. comp", key: "computacion"
+    ActsAsTenant.current_tenant = degree
+
     gal1 = create :subject, :with_exam, name: "GAL 1", credits: 9, code: "1030"
     create :subject_prerequisite, approvable: gal1.exam, approvable_needed: gal1.course
 
@@ -16,7 +19,7 @@ RSpec.describe "PlannedSubjects", type: :system do
 
     taller = create :subject, name: "Taller 1", short_name: 'T1', credits: 11
 
-    user = create(:user, approvals: [taller.course.id])
+    user = create(:user, approvals: [taller.course.id], degree:)
 
     ENV['ENABLE_PLANNER'] = 'true'
 

--- a/spec/system/subject_spec.rb
+++ b/spec/system/subject_spec.rb
@@ -2,11 +2,19 @@ require 'rails_helper'
 
 RSpec.describe "Subject", type: :system do
   it "lists entrollment prerequisites correctly" do
+    degree = create :degree, name: "Ing. comp", key: "computacion"
+    ActsAsTenant.current_tenant = degree
+
     subject = create :subject
     other_subject = create :subject, :with_exam, short_name: "Other Subject"
     create :and_prerequisite, approvable: subject.course, operands_prerequisites: [
       create(:enrollment_prerequisite, approvable_needed: other_subject.exam)
     ]
+
+    visit root_path
+    expect(page).to have_content("Ing. comp")
+    click_on 'Seleccionar'
+    expect(page).to have_current_path(root_path)
 
     visit subject_path(subject)
 

--- a/test/factories/approvables.rb
+++ b/test/factories/approvables.rb
@@ -2,6 +2,7 @@ FactoryBot.define do
   factory :approvable, aliases: [:course] do
     is_exam { false }
     subject
+    degree
 
     trait :with_prerequisites do
       prerequisite_tree { association(:subject_prerequisite) }

--- a/test/factories/cookies.rb
+++ b/test/factories/cookies.rb
@@ -3,12 +3,14 @@ FactoryBot.define do
     transient do
       welcome_banner_viewed { nil }
       approved_approvable_ids { nil }
+      degree { nil }
     end
 
     initialize_with do
       cookies = {}
       cookies[:approved_approvable_ids] = approved_approvable_ids.to_json if approved_approvable_ids
       cookies[:welcome_banner_viewed] = welcome_banner_viewed.to_json unless welcome_banner_viewed.nil?
+      cookies[:degree] = degree.to_json if degree
 
       ActionDispatch::Cookies::CookieJar.build(ActionDispatch::Request.empty, cookies)
     end

--- a/test/factories/prerequisites.rb
+++ b/test/factories/prerequisites.rb
@@ -1,18 +1,22 @@
 FactoryBot.define do
   factory :subject_prerequisite do
     approvable_needed factory: :course
+    degree
   end
 
   factory :enrollment_prerequisite do
     approvable_needed factory: :course
+    degree
   end
 
   factory :credits_prerequisite do
     credits_needed { 5 }
+    degree
   end
 
   factory :logical_prerequisite do
     operands_prerequisites { nil }
+    degree
 
     factory :and_prerequisite do
       logical_operator { "and" }
@@ -33,5 +37,6 @@ FactoryBot.define do
 
   factory :activity_prerequisite do
     approvable_needed factory: :exam
+    degree
   end
 end

--- a/test/factories/subject_groups.rb
+++ b/test/factories/subject_groups.rb
@@ -2,5 +2,6 @@ FactoryBot.define do
   factory :subject_group, aliases: [:group] do
     sequence(:code) { |n| "GROUP-#{n}" }
     sequence(:name) { |n| "Subject Group #{n}" }
+    degree
   end
 end

--- a/test/factories/subject_plans.rb
+++ b/test/factories/subject_plans.rb
@@ -3,5 +3,6 @@ FactoryBot.define do
     user
     subject
     semester { 1 }
+    degree
   end
 end

--- a/test/factories/subjects.rb
+++ b/test/factories/subjects.rb
@@ -4,8 +4,9 @@ FactoryBot.define do
     sequence(:name) { |n| "Subject #{n}" }
     credits { 5 }
     category { 'first_semester' }
-    group
-    course { association :course, subject: instance }
+    degree
+    group { association :group, degree: degree }
+    course { association :course, subject: instance, degree: degree }
 
     trait :with_exam do
       exam { association :exam, subject: instance }

--- a/test/factories/users.rb
+++ b/test/factories/users.rb
@@ -2,5 +2,6 @@ FactoryBot.define do
   factory :user do
     sequence(:email) { |n| "user#{n}@example.com" }
     password { "S3cr3tP@ssw0rd!" }
+    degree
   end
 end

--- a/test/system/approvals_test.rb
+++ b/test/system/approvals_test.rb
@@ -2,6 +2,9 @@ require "application_system_test_case"
 
 class ApprovalsTest < ApplicationSystemTestCase
   test "can check and uncheck approvables from index and show page" do
+    degree = create :degree, name: "Ing. comp", key: "computacion"
+    ActsAsTenant.current_tenant = degree
+
     gal1 = create :subject, :with_exam, name: "GAL 1", credits: 9, code: "1030"
     create :subject_prerequisite, approvable: gal1.exam, approvable_needed: gal1.course
 
@@ -14,6 +17,9 @@ class ApprovalsTest < ApplicationSystemTestCase
     taller = create :subject, name: "Taller", credits: 11
 
     visit root_path
+    assert_text "Ing. comp"
+    click_on 'Seleccionar'
+    assert_current_path root_path
 
     assert_text "GAL 1"
     assert_no_text "GAL 2"

--- a/test/system/subjects_test.rb
+++ b/test/system/subjects_test.rb
@@ -2,6 +2,9 @@ require "application_system_test_case"
 
 class SubjectsTest < ApplicationSystemTestCase
   test "can search for subjects" do
+    degree = create :degree, name: "Ing. comp", key: "computacion"
+    ActsAsTenant.current_tenant = degree
+
     gal1 = create :subject, :with_exam, name: "GAL 1", credits: 9, code: "1030"
     create :subject_prerequisite, approvable: gal1.exam, approvable_needed: gal1.course
 
@@ -12,6 +15,11 @@ class SubjectsTest < ApplicationSystemTestCase
     ]
 
     create :subject, name: "Taller 1", short_name: 'T1', credits: 11, code: "1040"
+
+    visit root_path
+    assert_text "Ing. comp"
+    click_on 'Seleccionar'
+    assert_current_path root_path
 
     visit all_subjects_path
 
@@ -71,10 +79,18 @@ class SubjectsTest < ApplicationSystemTestCase
   end
 
   test "can review subjects" do
+    degree = create :degree, name: "Ing. comp", key: "computacion"
+    ActsAsTenant.current_tenant = degree
+
     subject = create :subject
-    user = create :user
+    user = create :user, degree: degree
 
     # Not logged
+    visit root_path
+    assert_text "Ing. comp"
+    click_on 'Seleccionar'
+    assert_current_path root_path
+
     visit subject_path(subject)
 
     assert_text "Sin calificar"

--- a/test/system/user_test.rb
+++ b/test/system/user_test.rb
@@ -89,7 +89,6 @@ class UserTest < ApplicationSystemTestCase
 
     assert_text "Cerraste sesión correctamente"
 
-    click_user_menu
     click_on "Ingresar"
 
     fill_in "Correo electrónico", with: user.email


### PR DESCRIPTION
- Agregar multi-tenancy con la gema `acts_as_tenant`:
La idea es tener un tenant por carrera, de modo de mantener la data separada.

- Agregar tabla para carreras `Degrees`
- Agregar columnas `degree_id` para multitenancy en las tablas cuya data queremos separar por carrera
- Los usuarios pueden tener un degree seleccionado de dos formas: En la cookie (usuarios no logueados), persistido en la tabla de `Users` (usuarios logueados)
- Mostrar modal para elegir carrera si el usuario no tiene un degree seleccionado.
- Permitir elegir carrera en el form de registro de usuario.
- Agregar `Ingeniería eléctrica` a `degrees.yml`
- Agregar `subject_overrides` con los primeros 4 semestres de Ingeniería Eléctrica

