### PR TITLE
Arreglar el modal de la página de Importar Materias para que quede centrado en Safari

### DIFF
--- a/app/views/transcripts/create.turbo_stream.erb
+++ b/app/views/transcripts/create.turbo_stream.erb
@@ -1,5 +1,5 @@
 <%= turbo_stream.append_all "body" do %>
-  <dialog data-controller="modal" class="justify-self-center self-center relative transform overflow-hidden rounded-lg bg-white px-4 pb-4 pt-5 text-left shadow-xl sm:my-8 sm:w-full sm:max-w-lg sm:p-6">
+  <dialog data-controller="modal" class="m-auto justify-self-center self-center relative transform overflow-hidden rounded-lg bg-white px-4 pb-4 pt-5 text-left shadow-xl sm:w-full sm:max-w-lg sm:p-6">
     <div>
       <% if @successful_subjects.present? %>
         <div class="sm:flex sm:items-start">


### PR DESCRIPTION
## Motivación

El modal de la página de Importar Materias no aparece centrado en Safari:

![Image](https://github.com/user-attachments/assets/0e625316-b194-4c11-ae66-255b97de512d)

## Detalles

El problema es que, a diferencia de Chrome, los `dialogs` no aparecen centrados en la página por defecto en Safari. Por lo tanto, para arreglarlo, simplemente tenemos que añadirle `margin: auto`.