### PR TITLE
Renombrar test helper

### DIFF
--- a/spec/support/form_field_helper.rb
+++ b/spec/support/form_field_helper.rb
@@ -1,4 +1,4 @@
-module FormFieldHelpers
+module FormFieldHelper
   def within_form_field(label, &block)
     within(:xpath, "//label[normalize-space(text())='#{label}']/parent::*/parent::*", &block)
   end

--- a/spec/system/user_spec.rb
+++ b/spec/system/user_spec.rb
@@ -1,9 +1,9 @@
 require 'rails_helper'
-require 'support/form_fields_helpers'
+require 'support/form_field_helper'
 require 'support/password_helper'
 
 RSpec.describe 'User', type: :system do
-  include FormFieldHelpers
+  include FormFieldHelper
   include PasswordHelper
 
   it 'can sign up' do


### PR DESCRIPTION
### Summary

Este PR renombra `form_fields_helpers` a `form_field_helper` para mantener la consistencia con los otros helpers los cuales están nombrados en singular :)