### PR TITLE
Utilizar `submit` helper en lugar de `button`

### DIFF
--- a/app/components/button_component.rb
+++ b/app/components/button_component.rb
@@ -7,8 +7,9 @@ class ButtonComponent < ViewComponent::Base
   end
 
   def call
-    klass = 'bg-primary text-white font-bold shadow-sm cursor-pointer p-2 rounded-md'
+    klass = 'bg-primary text-white font-bold shadow-sm cursor-pointer p-2 rounded-md ' \
+            'disabled:opacity-50 disabled:cursor-not-allowed'
 
-    @form.button @label, class: klass
+    @form.submit @label, class: klass
   end
 end


### PR DESCRIPTION
#### Summary

Este PR cambia el helper utilizado en el `Button` component por `submit`, este helper desactiva el botón mientras se esta enviando el formulario, esto sumado con Tailwind nos permite cambiar el botón mientras se esta mandando el form.

#### Antes

https://github.com/user-attachments/assets/cb7f1c63-2e6d-4abe-9888-498dfc19cdf4


#### Ahora


https://github.com/user-attachments/assets/48ddc166-03f2-4548-b760-fbe040594365

