### PR TITLE
Borrar `exam approvables` que no deberían existir

### DIFF
--- a/script/remove_incorrect_exams.rb
+++ b/script/remove_incorrect_exams.rb
@@ -1,3 +1,13 @@
 require_relative "../config/environment"
 
-# Your code goes here
+subjects_data = YAML.load_file(Rails.root.join("db/data/computacion/scraped_subjects.yml"))
+Subject.with_exam.select { |subject| !subjects_data[subject.code]["has_exam"] }.each do |subject|
+  destroyed_approvable = subject.exam.destroy!
+
+  User
+    .select { |user| user.approvals.include?(destroyed_approvable.id) }
+    .each do |user|
+      user.approvals.delete(destroyed_approvable.id)
+      user.save!
+    end
+end

--- a/script/remove_incorrect_exams.rb
+++ b/script/remove_incorrect_exams.rb
@@ -1,0 +1,3 @@
+require_relative "../config/environment"
+
+# Your code goes here


### PR DESCRIPTION
## Motivación

Hace poco nos dimos cuenta que habían materias en producción que tenían examen a pesar de que en `scraped_subjects.yml` no figuraban como si tuvieran examen. Por ejemplo, `1225 - Políticas Científicas En Inf.y Comp.` aparece como que tiene examen en producción cuando en realidad el yml [indica que no debería tener examen](https://github.com/cedarcode/mi_carrera/blob/dd7203f/db/data/computacion/scraped_subjects.yml#L576):

![image](https://github.com/user-attachments/assets/be3f5e87-8fc5-43ea-8e32-99e62fbadee4)

## Detalles

Nos dimos cuenta que hace mucho tiempo atrás, en nuestros archivos en los cuales guardábamos las materias (ni siquiera eran archivos `.yml` en ese entonces), [estas materias aparecían como si tuvieran exámenes](https://github.com/cedarcode/mi_carrera/blob/b2a7184/db/seeds/subjects.yml#L155) y como el `YmlLoader` no tiene la capacidad de darse cuenta de estas discrepancias, nunca nos habíamos dado cuenta hasta ahora.

Para solucionar esto, agregué un script con el objetivo de correrlo en producción para arreglar esta discrepancia. Parece ser que el default en Rails vendría siendo agregar los one-off scripts en la carpeta de `script/` – [link](https://github.com/rails/rails/pull/52335).