### PR TITLE
Migrar `Navbar` a `Tailwind`

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -12,25 +12,6 @@ body {
   }
 }
 
-.home-button {
-  color: white;
-  display: flex;
-  justify-content: start;
-  align-items: center;
-  white-space: nowrap;
-  vertical-align: middle;
-  width: 220px;
-  height: 40px;
-  font-size: 21px;
-  font-weight: bold;
-  font-family: "Roboto", sans-serif;
-  text-decoration: none;
-}
-
-.home-button:hover {
-  cursor: pointer;
-}
-
 .credits-counter {
   padding: 0 12px 0 0;
   white-space: nowrap;
@@ -62,10 +43,6 @@ body {
   a {
     color: inherit;
     text-decoration-line: inherit;
-  }
-
-  a.home-button {
-    color: #444;
   }
 
   a.account-session {
@@ -123,10 +100,6 @@ body {
 
 .subject-group-credits-unmet {
   color: red !important;
-}
-
-#butInstall {
-  padding-left: 0px;
 }
 
 .show-password-button {

--- a/app/javascript/controllers/search_controller.js
+++ b/app/javascript/controllers/search_controller.js
@@ -4,7 +4,7 @@ export default class extends Controller {
   static targets = ["appBar", "searchbar", "searchInput"];
 
   toggle() {
-    this.appBarTarget.classList.toggle("d-none")
+    this.appBarTarget.classList.toggle("hidden")
     this.searchInputTarget.value = ""
     this.searchbarTarget.classList.toggle("d-none")
     if (!this.searchbarTarget.classList.contains("d-none")) {

--- a/app/views/layouts/_navbar.html.erb
+++ b/app/views/layouts/_navbar.html.erb
@@ -13,17 +13,11 @@
     </div>
 
     <div class="flex w-full justify-end items-center me-4">
-      <%= button_tag type: "button", class: "me-3 cursor-pointer", data: { action: "search#toggle" } do %>
-        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="size-6">
-          <path stroke-linecap="round" stroke-linejoin="round" d="m21 21-5.197-5.197m0 0A7.5 7.5 0 1 0 5.196 5.196a7.5 7.5 0 0 0 10.607 10.607Z" />
-        </svg>
-      <% end %>
+      <%= button_tag "search", type: "button", class: "me-3 cursor-pointer material-icons", data: { action: "search#toggle" } %>
 
-      <%= button_tag type: "button", class: "me-3 cursor-pointer", id: "butInstall" do %>
-        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" class="size-6">
-          <path fill-rule="evenodd" d="M10.5 3.75a6 6 0 0 0-5.98 6.496A5.25 5.25 0 0 0 6.75 20.25H18a4.5 4.5 0 0 0 2.206-8.423 3.75 3.75 0 0 0-4.133-4.303A6.001 6.001 0 0 0 10.5 3.75Zm2.25 6a.75.75 0 0 0-1.5 0v4.94l-1.72-1.72a.75.75 0 0 0-1.06 1.06l3 3a.75.75 0 0 0 1.06 0l3-3a.75.75 0 1 0-1.06-1.06l-1.72 1.72V9.75Z" clip-rule="evenodd" />
-        </svg>
-      <% end %>
+      <span hidden>
+        <%= button_tag "cloud_download", type: "button", class: "me-3 cursor-pointer material-icons p-2", id: "butInstall" %>
+      </span>
 
       <%= yield :credits %>
 

--- a/app/views/layouts/_navbar.html.erb
+++ b/app/views/layouts/_navbar.html.erb
@@ -13,11 +13,17 @@
     </div>
 
     <div class="flex w-full justify-end items-center me-4">
-      <button id="searchIcon" class="material-icons mdc-top-app-bar__action-item mdc-icon-button" data-action="search#toggle">search</button>
+      <%= button_tag type: "button", class: "me-3 cursor-pointer", data: { action: "search#toggle" }, id: "searchIcon" do %>
+        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="size-6">
+          <path stroke-linecap="round" stroke-linejoin="round" d="m21 21-5.197-5.197m0 0A7.5 7.5 0 1 0 5.196 5.196a7.5 7.5 0 0 0 10.607 10.607Z" />
+        </svg>
+      <% end %>
 
-      <span hidden>
-        <button id="butInstall" class="material-icons mdc-top-app-bar__action-item mdc-icon-button">cloud_download</button>
-      </span>
+      <%= button_tag type: "button", class: "me-3 cursor-pointer", id: "butInstall" do %>
+        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" class="size-6">
+          <path fill-rule="evenodd" d="M10.5 3.75a6 6 0 0 0-5.98 6.496A5.25 5.25 0 0 0 6.75 20.25H18a4.5 4.5 0 0 0 2.206-8.423 3.75 3.75 0 0 0-4.133-4.303A6.001 6.001 0 0 0 10.5 3.75Zm2.25 6a.75.75 0 0 0-1.5 0v4.94l-1.72-1.72a.75.75 0 0 0-1.06 1.06l3 3a.75.75 0 0 0 1.06 0l3-3a.75.75 0 1 0-1.06-1.06l-1.72 1.72V9.75Z" clip-rule="evenodd" />
+        </svg>
+      <% end %>
 
       <%= yield :credits %>
 

--- a/app/views/layouts/_navbar.html.erb
+++ b/app/views/layouts/_navbar.html.erb
@@ -1,7 +1,7 @@
 <header class="fixed top-0 w-full bg-primary text-white z-4" data-controller='search'>
   <% show_search_bar = params[:search].present? %>
 
-  <div class="flex w-full h-16 <%= show_search_bar ? 'hidden' : '' %>" data-search-target="appBar">
+  <div class="flex w-full h-14 sm:h-16 <%= show_search_bar ? 'hidden' : '' %>" data-search-target="appBar">
     <div class="flex items-center gap-4 ms-4">
       <%= button_tag type: "button", class: "size-6 cursor-pointer", data: { action: "click->navigation-drawer#toggle" } do %>
         <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="size-6">

--- a/app/views/layouts/_navbar.html.erb
+++ b/app/views/layouts/_navbar.html.erb
@@ -1,4 +1,4 @@
-<header class="fixed top-0 w-full bg-primary text-white z-4" data-controller='search'>
+<header class="fixed w-full bg-primary text-white z-4" data-controller='search'>
   <% show_search_bar = params[:search].present? %>
 
   <div class="flex w-full h-14 sm:h-16 <%= show_search_bar ? 'hidden' : '' %>" data-search-target="appBar">

--- a/app/views/layouts/_navbar.html.erb
+++ b/app/views/layouts/_navbar.html.erb
@@ -1,40 +1,48 @@
-<header id='app-bar' class="mdc-top-app-bar" data-controller='search'>
+<header class="fixed top-0 w-full bg-primary text-white z-4" data-controller='search'>
   <% show_search_bar = params[:search].present? %>
-  <div class="mdc-top-app-bar__row <%= show_search_bar ? 'd-none' : '' %>" data-search-target="appBar">
-    <div class="flex flex-row justify-center items-center space-x-4 ms-4">
+
+  <div class="flex border-box w-full h-16 <%= show_search_bar ? 'hidden' : '' %>" data-search-target="appBar">
+    <div class="flex items-center gap-4 ms-4">
       <%= button_tag type: "button", class: "size-6 cursor-pointer", data: { action: "click->navigation-drawer#toggle" } do %>
         <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="size-6">
           <path stroke-linecap="round" stroke-linejoin="round" d="M3.75 6.75h16.5M3.75 12h16.5m-16.5 5.25h16.5" />
         </svg>
       <% end %>
-      <%= link_to 'MiCarrera', root_path, class: 'home-button'%>
+
+      <%= link_to 'MiCarrera', root_path, class: 'text-xl font-bold' %>
     </div>
-    <section class="mdc-top-app-bar__section mdc-top-app-bar__section--align-end" role="toolbar">
+
+    <div class="flex w-full justify-end items-center me-4">
       <button id="searchIcon" class="material-icons mdc-top-app-bar__action-item mdc-icon-button" data-action="search#toggle">search</button>
+
       <span hidden>
         <button id="butInstall" class="material-icons mdc-top-app-bar__action-item mdc-icon-button">cloud_download</button>
       </span>
+
       <%= yield :credits %>
+
       <div class="relative mx-3" data-controller='user-menu' data-action="click@document->user-menu#onClick">
         <%= button_tag type: "button", id: "user-menu", class: "flex cursor-pointer", data: { user_menu_target: 'trigger', action: 'click->user-menu#toggle:stop' } do %>
           <% if current_user %>
-            <div class="flex items-center justify-center w-6 h-6 rounded-full bg-sky-500">
+            <div class="flex items-center justify-center size-6 rounded-full bg-sky-500">
               <%= current_user.email.first.capitalize %>
             </div>
           <% else %>
             <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="white" class="size-6">
-              <path 
-                fill-rule="evenodd" 
-                d="M18.685 19.097A9.723 9.723 0 0 0 21.75 12c0-5.385-4.365-9.75-9.75-9.75S2.25 6.615 2.25 12a9.723 9.723 0 0 0 3.065 7.097A9.716 9.716 0 0 0 12 21.75a9.716 9.716 0 0 0 6.685-2.653Zm-12.54-1.285A7.486 7.486 0 0 1 12 15a7.486 7.486 0 0 1 5.855 2.812A8.224 8.224 0 0 1 12 20.25a8.224 8.224 0 0 1-5.855-2.438ZM15.75 9a3.75 3.75 0 1 1-7.5 0 3.75 3.75 0 0 1 7.5 0Z" 
-                clip-rule="evenodd" 
+              <path
+                fill-rule="evenodd"
+                d="M18.685 19.097A9.723 9.723 0 0 0 21.75 12c0-5.385-4.365-9.75-9.75-9.75S2.25 6.615 2.25 12a9.723 9.723 0 0 0 3.065 7.097A9.716 9.716 0 0 0 12 21.75a9.716 9.716 0 0 0 6.685-2.653Zm-12.54-1.285A7.486 7.486 0 0 1 12 15a7.486 7.486 0 0 1 5.855 2.812A8.224 8.224 0 0 1 12 20.25a8.224 8.224 0 0 1-5.855-2.438ZM15.75 9a3.75 3.75 0 1 1-7.5 0 3.75 3.75 0 0 1 7.5 0Z"
+                clip-rule="evenodd"
               />
             </svg>
           <% end %>
         <% end %>
+
         <%= render 'shared/user_menu' %>
       </div>
-    </section>
+    </div>
   </div>
+
   <div id="searchbar" class="mdc-top-app-bar__row <%= show_search_bar ? '' : 'd-none' %>" data-search-target="searchbar">
     <%= form_with(url: all_subjects_path, method: :get, local: true) do |f| %>
       <div class="mdc-text-field mdc-text-field--filled mdc-text-field--label-floating mdc-text-field--no-label mdc-text-field--with-trailing-icon">

--- a/app/views/layouts/_navbar.html.erb
+++ b/app/views/layouts/_navbar.html.erb
@@ -13,7 +13,7 @@
     </div>
 
     <div class="flex w-full justify-end items-center me-4">
-      <%= button_tag type: "button", class: "me-3 cursor-pointer", data: { action: "search#toggle" }, id: "searchIcon" do %>
+      <%= button_tag type: "button", class: "me-3 cursor-pointer", data: { action: "search#toggle" } do %>
         <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="size-6">
           <path stroke-linecap="round" stroke-linejoin="round" d="m21 21-5.197-5.197m0 0A7.5 7.5 0 1 0 5.196 5.196a7.5 7.5 0 0 0 10.607 10.607Z" />
         </svg>

--- a/app/views/layouts/_navbar.html.erb
+++ b/app/views/layouts/_navbar.html.erb
@@ -12,7 +12,7 @@
       <%= link_to 'MiCarrera', root_path, class: 'text-xl font-bold' %>
     </div>
 
-    <div class="flex w-full justify-end items-center me-4">
+    <div class="flex w-full justify-end items-center sm:me-3 me-1">
       <%= button_tag "search", type: "button", class: "me-3 cursor-pointer material-icons", data: { action: "search#toggle" } %>
 
       <span hidden>

--- a/app/views/layouts/_navbar.html.erb
+++ b/app/views/layouts/_navbar.html.erb
@@ -1,0 +1,48 @@
+<header id='app-bar' class="mdc-top-app-bar" data-controller='search'>
+  <% show_search_bar = params[:search].present? %>
+  <div class="mdc-top-app-bar__row <%= show_search_bar ? 'd-none' : '' %>" data-search-target="appBar">
+    <div class="flex flex-row justify-center items-center space-x-4 ms-4">
+      <%= button_tag type: "button", class: "size-6 cursor-pointer", data: { action: "click->navigation-drawer#toggle" } do %>
+        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="size-6">
+          <path stroke-linecap="round" stroke-linejoin="round" d="M3.75 6.75h16.5M3.75 12h16.5m-16.5 5.25h16.5" />
+        </svg>
+      <% end %>
+      <%= link_to 'MiCarrera', root_path, class: 'home-button'%>
+    </div>
+    <section class="mdc-top-app-bar__section mdc-top-app-bar__section--align-end" role="toolbar">
+      <button id="searchIcon" class="material-icons mdc-top-app-bar__action-item mdc-icon-button" data-action="search#toggle">search</button>
+      <span hidden>
+        <button id="butInstall" class="material-icons mdc-top-app-bar__action-item mdc-icon-button">cloud_download</button>
+      </span>
+      <%= yield :credits %>
+      <div class="relative mx-3" data-controller='user-menu' data-action="click@document->user-menu#onClick">
+        <%= button_tag type: "button", id: "user-menu", class: "flex cursor-pointer", data: { user_menu_target: 'trigger', action: 'click->user-menu#toggle:stop' } do %>
+          <% if current_user %>
+            <div class="flex items-center justify-center w-6 h-6 rounded-full bg-sky-500">
+              <%= current_user.email.first.capitalize %>
+            </div>
+          <% else %>
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="white" class="size-6">
+              <path 
+                fill-rule="evenodd" 
+                d="M18.685 19.097A9.723 9.723 0 0 0 21.75 12c0-5.385-4.365-9.75-9.75-9.75S2.25 6.615 2.25 12a9.723 9.723 0 0 0 3.065 7.097A9.716 9.716 0 0 0 12 21.75a9.716 9.716 0 0 0 6.685-2.653Zm-12.54-1.285A7.486 7.486 0 0 1 12 15a7.486 7.486 0 0 1 5.855 2.812A8.224 8.224 0 0 1 12 20.25a8.224 8.224 0 0 1-5.855-2.438ZM15.75 9a3.75 3.75 0 1 1-7.5 0 3.75 3.75 0 0 1 7.5 0Z" 
+                clip-rule="evenodd" 
+              />
+            </svg>
+          <% end %>
+        <% end %>
+        <%= render 'shared/user_menu' %>
+      </div>
+    </section>
+  </div>
+  <div id="searchbar" class="mdc-top-app-bar__row <%= show_search_bar ? '' : 'd-none' %>" data-search-target="searchbar">
+    <%= form_with(url: all_subjects_path, method: :get, local: true) do |f| %>
+      <div class="mdc-text-field mdc-text-field--filled mdc-text-field--label-floating mdc-text-field--no-label mdc-text-field--with-trailing-icon">
+        <span class="mdc-text-field__ripple"></span>
+        <%= f.text_field :search, value: params[:search], class: "mdc-text-field__input", placeholder: "Buscar por nombre o código de la materia", autofocus: true, data: { 'search-target': "searchInput" } %>
+        <i class="material-icons mdc-text-field__icon mdc-text-field__icon--trailing" data-action="click->search#toggle" tabindex="0" role="button">close</i>
+        <span class="mdc-line-ripple"></span>
+      </div>
+    <% end %>
+  </div>
+</header>

--- a/app/views/layouts/_navbar.html.erb
+++ b/app/views/layouts/_navbar.html.erb
@@ -1,7 +1,7 @@
 <header class="fixed top-0 w-full bg-primary text-white z-4" data-controller='search'>
   <% show_search_bar = params[:search].present? %>
 
-  <div class="flex border-box w-full h-16 <%= show_search_bar ? 'hidden' : '' %>" data-search-target="appBar">
+  <div class="flex w-full h-16 <%= show_search_bar ? 'hidden' : '' %>" data-search-target="appBar">
     <div class="flex items-center gap-4 ms-4">
       <%= button_tag type: "button", class: "size-6 cursor-pointer", data: { action: "click->navigation-drawer#toggle" } do %>
         <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="size-6">

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -44,7 +44,7 @@
     <%= render 'shared/menu' %>
 
     <%= render 'layouts/navbar' %>
-    <main class="mdc-top-app-bar--fixed-adjust main-content" id='main-content'>
+    <main class="main-content sm:mt-16 mt-14" id='main-content'>
       <%= render 'shared/notice' if flash[:notice] %>
 
       <%= yield :welcome_banner %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -43,54 +43,7 @@
   <body class="mdc-typography" data-controller='navigation-drawer'>
     <%= render 'shared/menu' %>
 
-    <header id='app-bar' class="mdc-top-app-bar" data-controller='search'>
-      <% show_search_bar = params[:search].present? %>
-      <div class="mdc-top-app-bar__row <%= show_search_bar ? 'd-none' : '' %>" data-search-target="appBar">
-        <div class="flex flex-row justify-center items-center space-x-4 ms-4">
-          <%= button_tag type: "button", class: "size-6 cursor-pointer", data: { action: "click->navigation-drawer#toggle" } do %>
-            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="size-6">
-              <path stroke-linecap="round" stroke-linejoin="round" d="M3.75 6.75h16.5M3.75 12h16.5m-16.5 5.25h16.5" />
-            </svg>
-          <% end %>
-          <%= link_to 'MiCarrera', root_path, class: 'home-button'%>
-        </div>
-        <section class="mdc-top-app-bar__section mdc-top-app-bar__section--align-end" role="toolbar">
-          <button id="searchIcon" class="material-icons mdc-top-app-bar__action-item mdc-icon-button" data-action="search#toggle">search</button>
-          <span hidden>
-            <button id="butInstall" class="material-icons mdc-top-app-bar__action-item mdc-icon-button">cloud_download</button>
-          </span>
-          <%= yield :credits %>
-          <div class="relative mx-3" data-controller='user-menu' data-action="click@document->user-menu#onClick">
-            <%= button_tag type: "button", id: "user-menu", class: "flex cursor-pointer", data: { user_menu_target: 'trigger', action: 'click->user-menu#toggle:stop' } do %>
-              <% if current_user %>
-                <div class="flex items-center justify-center w-6 h-6 rounded-full bg-sky-500">
-                  <%= current_user.email.first.capitalize %>
-                </div>
-              <% else %>
-                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="white" class="size-6">
-                  <path 
-                    fill-rule="evenodd" 
-                    d="M18.685 19.097A9.723 9.723 0 0 0 21.75 12c0-5.385-4.365-9.75-9.75-9.75S2.25 6.615 2.25 12a9.723 9.723 0 0 0 3.065 7.097A9.716 9.716 0 0 0 12 21.75a9.716 9.716 0 0 0 6.685-2.653Zm-12.54-1.285A7.486 7.486 0 0 1 12 15a7.486 7.486 0 0 1 5.855 2.812A8.224 8.224 0 0 1 12 20.25a8.224 8.224 0 0 1-5.855-2.438ZM15.75 9a3.75 3.75 0 1 1-7.5 0 3.75 3.75 0 0 1 7.5 0Z" 
-                    clip-rule="evenodd" 
-                  />
-                </svg>
-              <% end %>
-            <% end %>
-            <%= render 'shared/user_menu' %>
-          </div>
-        </section>
-      </div>
-      <div id="searchbar" class="mdc-top-app-bar__row <%= show_search_bar ? '' : 'd-none' %>" data-search-target="searchbar">
-        <%= form_with(url: all_subjects_path, method: :get, local: true) do |f| %>
-          <div class="mdc-text-field mdc-text-field--filled mdc-text-field--label-floating mdc-text-field--no-label mdc-text-field--with-trailing-icon">
-            <span class="mdc-text-field__ripple"></span>
-            <%= f.text_field :search, value: params[:search], class: "mdc-text-field__input", placeholder: "Buscar por nombre o código de la materia", autofocus: true, data: { 'search-target': "searchInput" } %>
-            <i class="material-icons mdc-text-field__icon mdc-text-field__icon--trailing" data-action="click->search#toggle" tabindex="0" role="button">close</i>
-            <span class="mdc-line-ripple"></span>
-          </div>
-        <% end %>
-      </div>
-    </header>
+    <%= render 'layouts/navbar' %>
     <main class="mdc-top-app-bar--fixed-adjust main-content" id='main-content'>
       <%= render 'shared/notice' if flash[:notice] %>
 

--- a/spec/system/subject_spec.rb
+++ b/spec/system/subject_spec.rb
@@ -32,7 +32,9 @@ RSpec.describe "Subject", type: :system do
     expect(page).to have_text('GAL 2')
     expect(page).to have_text('T1')
 
-    click_on "search"
+    search_button = find('button[data-action="search#toggle"]')
+
+    search_button.click
 
     fill_in 'search', with: "Taller\n"
 

--- a/spec/system/subject_spec.rb
+++ b/spec/system/subject_spec.rb
@@ -32,9 +32,7 @@ RSpec.describe "Subject", type: :system do
     expect(page).to have_text('GAL 2')
     expect(page).to have_text('T1')
 
-    search_button = find('button[data-action="search#toggle"]')
-
-    search_button.click
+    click_on "search"
 
     fill_in 'search', with: "Taller\n"
 


### PR DESCRIPTION
### Summary

Este PR migra la navbar a `Tailwind`, en #780 se migra el search

### Screenshots

#### Antes
<img width="1840" alt="image" src="https://github.com/user-attachments/assets/530158cc-1047-4490-95a8-48d226891a98" />


#### Ahora
<img width="1840" alt="image" src="https://github.com/user-attachments/assets/7922eb78-0818-41c3-9290-5cc8e74654c2" />
