### PR TITLE
Ignorar errores `ActionDispatch::RemoteIp::IpSpoofAttackError` en AppSignal

### DIFF
--- a/config/appsignal.rb
+++ b/config/appsignal.rb
@@ -17,5 +17,5 @@ Appsignal.configure do |config|
   # Configure errors that should not be recorded by AppSignal.
   # For more information see our docs:
   # https://docs.appsignal.com/ruby/configuration/ignore-errors.html
-  config.ignore_errors << "ActionController::RoutingError"
+  config.ignore_errors += ["ActionController::RoutingError", "ActionDispatch::RemoteIp::IpSpoofAttackError"]
 end


### PR DESCRIPTION
Por lo que entiendo, esto pasa cuando el cliente manda el header `Client-Ip` y esta IP no matchea la IP del header `X-Forwarded-For`.

https://github.com/rails/rails/blob/v8.0.2/actionpack/lib/action_dispatch/middleware/remote_ip.rb#L135-L154