### PR TITLE
Remove useless test

### DIFF
--- a/spec/models/approvable_spec.rb
+++ b/spec/models/approvable_spec.rb
@@ -6,10 +6,6 @@ RSpec.describe Approvable, type: :model do
     it { should have_one(:prerequisite_tree).class_name('Prerequisite').dependent(:destroy) }
   end
 
-  describe 'validations' do
-    it { should validate_inclusion_of(:is_exam).in_array([true, false]) }
-  end
-
   describe '#approved?' do
     context 'when not is_exam and course approved' do
       it 'is true' do


### PR DESCRIPTION
```
************************************************************************
Warning from shoulda-matchers:

You are using `validate_inclusion_of` to assert that a boolean column
allows boolean values and disallows non-boolean ones. Be aware that it
is not possible to fully test this, as boolean columns will
automatically convert non-boolean values to boolean ones. Hence, you
should consider removing this test.
************************************************************************
```