### PR TITLE
Forward headers from Cloudflare

### DIFF
--- a/config/deploy.production.yml
+++ b/config/deploy.production.yml
@@ -5,6 +5,7 @@ proxy:
     - www.micarrera.uy
   app_port: 3000
   ssl: true
+  forward_headers: true
 
 servers:
   web:

--- a/config/deploy.staging.yml
+++ b/config/deploy.staging.yml
@@ -2,6 +2,7 @@ proxy:
   host: staging.micarrera.uy
   app_port: 3000
   ssl: true
+  forward_headers: true
 
 servers:
   web:


### PR DESCRIPTION
https://kamal-deploy.org/docs/configuration/proxy/#forward-headers

Creo que deberíamos setear esto ya que estamos usando Cloudflare como proxy. Si no prendemos el `forward_headers` creo que a Rails le llega solo la IP de Cloudflare. Con esto debería llegarle la IP del cliente y la de Cloudflare. 