### PR TITLE
Usar Material Icons para todos los iconos

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -78,5 +78,3 @@ input {
     transition-delay: calc(infinity * 1s);
   }
 }
-
-.material-icons.md-16 { font-size: 16px; }

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -78,3 +78,5 @@ input {
     transition-delay: calc(infinity * 1s);
   }
 }
+
+.material-icons.md-16 { font-size: 16px; }

--- a/app/components/approvable_checkbox_component.html.erb
+++ b/app/components/approvable_checkbox_component.html.erb
@@ -7,7 +7,7 @@
   class: "mx-[5px]"
 ) do |form| %>
   <div class="box-content w-[18px] h-[18px] p-3">
-    <div class="group grid size-4 grid-cols-1">
+    <div class="grid size-4 grid-cols-1">
       <%= form.checkbox(
         :approved,
         id: dom_id(approvable),
@@ -16,12 +16,7 @@
         class: STYLES[:checkbox],
         data: { action: "click->autosave-check#update click->loading#start", "loading-target": "checkbox" },
       ) %>
-      <svg fill="none" viewBox="0 0 14 14" class="<%= class_names(STYLES[:svg]) %>">
-        <path d="M3 8L6 11L11 3.5" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="opacity-0 group-has-checked:opacity-100">
-        </path>
-        <path d="M3 7H11" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="opacity-0 group-has-indeterminate:opacity-100">
-        </path>
-      </svg>
+      <%= helpers.material_icon("check", class_names(STYLES[:icon])) %>
     </div>
   </div>
 <% end %>

--- a/app/components/approvable_checkbox_component.rb
+++ b/app/components/approvable_checkbox_component.rb
@@ -27,7 +27,7 @@ class ApprovableCheckboxComponent < ViewComponent::Base
       peer
     ],
     icon: %w[
-      md-16
+      text-base/4!
       text-white
       pointer-events-none
       col-start-1

--- a/app/components/approvable_checkbox_component.rb
+++ b/app/components/approvable_checkbox_component.rb
@@ -23,16 +23,18 @@ class ApprovableCheckboxComponent < ViewComponent::Base
       disabled:checked:bg-gray-100
 
       forced-colors:appearance-auto
+
+      peer
     ],
-    svg: %w[
+    icon: %w[
+      md-16
+      text-white
       pointer-events-none
       col-start-1
       row-start-1
-      size-3.5
-      self-center
-      justify-self-center
-      stroke-white
-      group-has-disabled:stroke-white/25
+      opacity-0
+      peer-checked:opacity-100
+      peer-disabled:text-gray-300
     ],
   }
 

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -26,4 +26,8 @@ module ApplicationHelper
       raise "Unexpected logical operator: #{prerequisite.logical_operator}"
     end
   end
+
+  def material_icon(icon, classes = nil)
+    tag.span(icon, class: "material-icons #{classes}")
+  end
 end

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -4,9 +4,7 @@
   <%= form_with(model: resource, url: registration_path(resource_name), method: :put, local: true, class: "flex flex-col w-full max-w-md space-y-6") do |f| %>
     <% if current_user.oauth_user? %>
       <div class="flex items-center p-4 mb-4 text-yellow-800 rounded-lg bg-yellow-50">
-        <svg class="shrink-0 w-4" fill="currentColor" viewBox="0 0 20 20">
-          <path d="M10 .5a9.5 9.5 0 1 0 9.5 9.5A9.51 9.51 0 0 0 10 .5ZM9.5 4a1.5 1.5 0 1 1 0 3 1.5 1.5 0 0 1 0-3ZM12 15H8a1 1 0 0 1 0-2h1v-3H8a1 1 0 0 1 0-2h2a1 1 0 0 1 1 1v4h1a1 1 0 0 1 0 2Z"/>
-        </svg>
+        <%= material_icon("info") %>
         <span class="ms-3 text-sm/6 font-medium"> Si cambias tu correo electrónico, perderás el acceso con Google </span>
       </div>
     <% end %>

--- a/app/views/layouts/_navbar.html.erb
+++ b/app/views/layouts/_navbar.html.erb
@@ -3,9 +3,7 @@
 
   <div class="flex w-full h-14 sm:h-16 <%= show_search_bar ? 'hidden' : '' %>" data-search-target="appBar">
     <div class="flex items-center gap-4 ms-4">
-      <%= button_tag type: "button", class: "size-6 cursor-pointer", data: { action: "click->navigation-drawer#toggle" } do %>
-        <%= material_icon("menu") %>
-      <% end %>
+      <%= button_tag "menu", type: "button", class: "size-6 cursor-pointer material-icons", data: { action: "click->navigation-drawer#toggle" } %>
 
       <%= link_to 'MiCarrera', root_path, class: 'text-xl font-bold' %>
     </div>

--- a/app/views/layouts/_navbar.html.erb
+++ b/app/views/layouts/_navbar.html.erb
@@ -4,9 +4,7 @@
   <div class="flex w-full h-14 sm:h-16 <%= show_search_bar ? 'hidden' : '' %>" data-search-target="appBar">
     <div class="flex items-center gap-4 ms-4">
       <%= button_tag type: "button", class: "size-6 cursor-pointer", data: { action: "click->navigation-drawer#toggle" } do %>
-        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="size-6">
-          <path stroke-linecap="round" stroke-linejoin="round" d="M3.75 6.75h16.5M3.75 12h16.5m-16.5 5.25h16.5" />
-        </svg>
+        <%= material_icon("menu") %>
       <% end %>
 
       <%= link_to 'MiCarrera', root_path, class: 'text-xl font-bold' %>

--- a/app/views/layouts/_navbar.html.erb
+++ b/app/views/layouts/_navbar.html.erb
@@ -26,13 +26,7 @@
               <%= current_user.email.first.capitalize %>
             </div>
           <% else %>
-            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="white" class="size-6">
-              <path
-                fill-rule="evenodd"
-                d="M18.685 19.097A9.723 9.723 0 0 0 21.75 12c0-5.385-4.365-9.75-9.75-9.75S2.25 6.615 2.25 12a9.723 9.723 0 0 0 3.065 7.097A9.716 9.716 0 0 0 12 21.75a9.716 9.716 0 0 0 6.685-2.653Zm-12.54-1.285A7.486 7.486 0 0 1 12 15a7.486 7.486 0 0 1 5.855 2.812A8.224 8.224 0 0 1 12 20.25a8.224 8.224 0 0 1-5.855-2.438ZM15.75 9a3.75 3.75 0 1 1-7.5 0 3.75 3.75 0 0 1 7.5 0Z"
-                clip-rule="evenodd"
-              />
-            </svg>
+            <%= material_icon("account_circle") %>
           <% end %>
         <% end %>
 

--- a/app/views/shared/_alert.html.erb
+++ b/app/views/shared/_alert.html.erb
@@ -1,7 +1,5 @@
 <div class="flex flex-row items-center p-4 mb-4 rounded-lg bg-red-100 text-red-600">
-  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" class="size-5">
-    <path fill-rule="evenodd" d="M10 18a8 8 0 1 0 0-16 8 8 0 0 0 0 16ZM8.28 7.22a.75.75 0 0 0-1.06 1.06L8.94 10l-1.72 1.72a.75.75 0 1 0 1.06 1.06L10 11.06l1.72 1.72a.75.75 0 1 0 1.06-1.06L11.06 10l1.72-1.72a.75.75 0 0 0-1.06-1.06L10 8.94 8.28 7.22Z" clip-rule="evenodd" />
-  </svg>
+  <%= material_icon("cancel") %>
 
   <span class="ms-3 text-sm/6 font-medium"><%= flash[:alert] %></span>
 </div>

--- a/app/views/shared/_menu.html.erb
+++ b/app/views/shared/_menu.html.erb
@@ -13,10 +13,8 @@
 
   <hr class="text-gray-200"/>
 
-  <%= link_to "https://github.com/cedarcode/mi_carrera", target: "_blank", class: "flex items-center p-2 rounded-sm hover:bg-gray-100 text-gray-600 hover:text-gray-800" do %>
-    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="size-6 me-2">
-      <path stroke-linecap="round" stroke-linejoin="round" d="M13.5 6H5.25A2.25 2.25 0 0 0 3 8.25v10.5A2.25 2.25 0 0 0 5.25 21h10.5A2.25 2.25 0 0 0 18 18.75V10.5m-10.5 6L21 3m0 0h-5.25M21 3v5.25" />
-    </svg>
+  <%= link_to "https://github.com/cedarcode/mi_carrera", target: "_blank", class: "flex items-center gap-1 p-2 rounded-sm hover:bg-gray-100 text-gray-600 hover:text-gray-800" do %>
+    <%= material_icon("open_in_new") %>
     Colabora en Github
   <% end %>
 </div>

--- a/app/views/shared/_notice.html.erb
+++ b/app/views/shared/_notice.html.erb
@@ -2,9 +2,7 @@
   data-controller="notice"
   class="fixed end-0 bottom-4 flex justify-center items-center max-w-xs p-4 bg-white border-1 border-gray-100 space-x-2 rounded-lg shadow-xl z-1 transform transition-all duration-300 ease-in-out translate-x-full opacity-0"
 >
-  <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="size-6 text-green-500">
-    <path stroke-linecap="round" stroke-linejoin="round" d="M9 12.75 11.25 15 15 9.75M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z" />
-  </svg>
+  <%= material_icon("check_circle_outline", "text-green-500") %>
 
   <span class="text-sm"><%= flash[:notice] %></span>
 </div>

--- a/app/views/subjects/_not_planned_subjects_list.html.erb
+++ b/app/views/subjects/_not_planned_subjects_list.html.erb
@@ -31,11 +31,8 @@
               )
             %>
             <%= form.hidden_field :subject_id, value: subject.id %>
-            <%= form.button type: :submit, class: "cursor-pointer py-3 ps-3", data: { action: "click->autosave-check#update" } do %>
-              <svg data-icon="add-circle" width="20" height="20" fill="none" stroke="#9ca3af" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
-                <circle cx="12" cy="12" r="10" stroke-width="2"></circle>
-                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8v8m-4-4h8"></path>
-              </svg>
+            <%= form.button type: :submit, class: "cursor-pointer py-3 ps-3 material-icons text-gray-400", data: { action: "click->autosave-check#update" } do %>
+              add_circle_outline
             <% end %>
           <% end %>
         </li>

--- a/app/views/subjects/_planned_subjects_list.html.erb
+++ b/app/views/subjects/_planned_subjects_list.html.erb
@@ -19,9 +19,7 @@
               
               <div class="flex items-center gap-1">
                 <% if current_student.approved?(subject) %>
-                  <svg data-icon="check" width="20" height="20" fill="none" stroke="#22c55e" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg">
-                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 10l4 4 6-8" />
-                  </svg>
+                  <%= material_icon("check", "text-green-500") %>
                 <% elsif !current_student.available?(subject) %>
                   <svg data-icon="lock" width="20" height="20" fill="none" stroke="#9ca3af" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg">
                     <rect x="5" y="9" width="10" height="7" rx="2" stroke-width="2"/>

--- a/app/views/subjects/_planned_subjects_list.html.erb
+++ b/app/views/subjects/_planned_subjects_list.html.erb
@@ -30,11 +30,8 @@
                     data: { controller: "autosave-check" },
                     class: 'inline-flex',
                   ) do |form| %>
-                    <%= form.button type: :submit, class: "cursor-pointer py-3 ps-3", data: { action: "click->autosave-check#update" } do %>
-                      <svg data-icon="remove-circle" width="20" height="20" fill="none" stroke="#9ca3af" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg">
-                        <circle cx="10" cy="10" r="8" stroke-width="2"/>
-                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M7 10h6" />
-                      </svg>
+                    <%= form.button type: :submit, class: "cursor-pointer py-3 ps-3 material-icons text-gray-400", data: { action: "click->autosave-check#update" } do %>
+                      remove_circle_outline
                     <% end %>
                 <% end %>
               </div>

--- a/app/views/subjects/_planned_subjects_list.html.erb
+++ b/app/views/subjects/_planned_subjects_list.html.erb
@@ -21,10 +21,7 @@
                 <% if current_student.approved?(subject) %>
                   <%= material_icon("check", "text-green-500") %>
                 <% elsif !current_student.available?(subject) %>
-                  <svg data-icon="lock" width="20" height="20" fill="none" stroke="#9ca3af" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg">
-                    <rect x="5" y="9" width="10" height="7" rx="2" stroke-width="2"/>
-                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M7 9V7a3 3 0 1 1 6 0v2" />
-                  </svg>
+                  <%= material_icon("lock_outline", "text-gray-400") %>
                 <% end %>
                 
                 <%= form_with(

--- a/app/views/subjects/_planned_subjects_list.html.erb
+++ b/app/views/subjects/_planned_subjects_list.html.erb
@@ -66,11 +66,8 @@
             }
           ) %>
           <%= form.hidden_field :semester, value: semester %>
-          <%= form.button type: :submit, class: "cursor-pointer py-3 ps-3", data: { action: "click->autosave-check#update" } do %>
-            <svg data-icon="add-circle" width="20" height="20" fill="none" stroke="#9ca3af" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
-              <circle cx="12" cy="12" r="10" stroke-width="2"></circle>
-              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8v8m-4-4h8"></path>
-            </svg>
+          <%= form.button type: :submit, class: "cursor-pointer py-3 ps-3 material-icons text-gray-400", data: { action: "click->autosave-check#update" } do %>
+            add_circle_outline
           <% end %>
         <% end %>
       </div>

--- a/app/views/subjects/_subjects_list.html.erb
+++ b/app/views/subjects/_subjects_list.html.erb
@@ -4,9 +4,7 @@
       <%= link_to display_name(subject), subject_path(subject), class: "grow w-full" %>
     </p>
     <% if current_student.approved?(subject) %>
-      <svg width="20" height="20" fill="none" stroke="#22c55e" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg">
-        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 10l4 4 6-8" />
-      </svg>
+      <%= material_icon("check", "text-green-500") %>
     <% elsif !current_student.available?(subject) %>
       <svg width="20" height="20" fill="none" stroke="#9ca3af" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg">
         <rect x="5" y="9" width="10" height="7" rx="2" stroke-width="2"/>

--- a/app/views/subjects/_subjects_list.html.erb
+++ b/app/views/subjects/_subjects_list.html.erb
@@ -6,10 +6,7 @@
     <% if current_student.approved?(subject) %>
       <%= material_icon("check", "text-green-500") %>
     <% elsif !current_student.available?(subject) %>
-      <svg width="20" height="20" fill="none" stroke="#9ca3af" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg">
-        <rect x="5" y="9" width="10" height="7" rx="2" stroke-width="2"/>
-        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M7 9V7a3 3 0 1 1 6 0v2" />
-      </svg>
+      <%= material_icon("lock_outline", "text-gray-400") %>
     <% end %>
   </li>
 <% end %>

--- a/app/views/subjects/all.html.erb
+++ b/app/views/subjects/all.html.erb
@@ -11,11 +11,8 @@
     </ul>
   <% end %>
 <% else %>
-  <div class="flex justify-center items-center mt-12 text-gray-500 text-2xl font-light">
-    <svg xmlns="http://www.w3.org/2000/svg" class="w-6 h-6 inline-block mr-2" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-      <circle cx="11" cy="11" r="7" stroke-width="2" />
-      <line x1="16.65" y1="16.65" x2="21" y2="21" stroke-width="2" stroke-linecap="round"/>
-    </svg>
+  <div class="flex justify-center items-center mt-12 text-gray-500 text-2xl font-light gap-1">
+    <%= material_icon("search") %>
     No hay resultados
   </div>
 <% end %>

--- a/app/views/transcripts/create.turbo_stream.erb
+++ b/app/views/transcripts/create.turbo_stream.erb
@@ -4,9 +4,7 @@
       <% if @successful_subjects.present? %>
         <div class="sm:flex sm:items-start">
           <div class="mx-auto flex size-12 shrink-0 items-center justify-center rounded-full bg-green-100 sm:mx-0 sm:size-10">
-            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true" class="size-6 text-green-600">
-              <path stroke-linecap="round" stroke-linejoin="round" d="m4.5 12.75 6 6 9-13.5" />
-            </svg>
+            <%= material_icon("check", "text-green-500") %>
           </div>
           <div class="mt-3 text-center sm:mt-0 sm:ml-4 sm:text-left w-full">
             <h3 class="text-base font-semibold text-gray-900"><%= @successful_subjects.length %> materias marcadas correctamente</h3>

--- a/app/views/transcripts/create.turbo_stream.erb
+++ b/app/views/transcripts/create.turbo_stream.erb
@@ -20,9 +20,7 @@
       <% if @failed_entries.present? %>
         <div class="sm:flex sm:items-start mt-5">
           <div class="mx-auto flex size-12 shrink-0 items-center justify-center rounded-full bg-yellow-100 sm:mx-0 sm:size-10">
-            <svg class="size-6 text-yellow-600" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true" data-slot="icon">
-              <path stroke-linecap="round" stroke-linejoin="round" d="M12 9v3.75m-9.303 3.376c-.866 1.5.217 3.374 1.948 3.374h14.71c1.73 0 2.813-1.874 1.948-3.374L13.949 3.378c-.866-1.5-3.032-1.5-3.898 0L2.697 16.126ZM12 15.75h.007v.008H12v-.008Z" />
-            </svg>
+            <%= material_icon("warning_amber", "text-yellow-500") %>
           </div>
           <div class="mt-3 text-center sm:mt-0 sm:ml-4 sm:text-left w-full">
             <h3 class="text-base font-semibold text-gray-900">Materias no encontradas</h3>

--- a/spec/components/approvable_checkbox_component_spec.rb
+++ b/spec/components/approvable_checkbox_component_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe ApprovableCheckboxComponent, type: :component do
       expect(page).to have_css "form[action='/approvables/#{approvable.id}/approval?subject_show=false']"
       expect(page).to have_css "input[name='_method'][value='delete']", visible: false
       expect(page).to have_css "input[type='checkbox'][name='approvable[approved]'][checked]"
-      expect(page).to have_css "svg"
+      expect(page).to have_css ".material-icons", text: "check"
     end
   end
 
@@ -26,7 +26,7 @@ RSpec.describe ApprovableCheckboxComponent, type: :component do
 
       expect(page).to have_css "form[action='/approvables/#{approvable.id}/approval?subject_show=false'][method='post']"
       expect(page).to have_css "input[type='checkbox'][name='approvable[approved]']"
-      expect(page).to have_css "svg"
+      expect(page).to have_css ".material-icons", text: "check"
     end
   end
 
@@ -39,7 +39,7 @@ RSpec.describe ApprovableCheckboxComponent, type: :component do
 
       expect(page).to have_css "form[action='/approvables/#{approvable.id}/approval?subject_show=false'][method='post']"
       expect(page).to have_css "input[type='checkbox'][name='approvable[approved]'][disabled]"
-      expect(page).to have_css "svg"
+      expect(page).to have_css ".material-icons", text: "check"
     end
   end
 end

--- a/spec/support/planned_subjects_helper.rb
+++ b/spec/support/planned_subjects_helper.rb
@@ -35,7 +35,7 @@ module PlannedSubjectsHelper
   def assert_subject_with_semester_selector(subject_name)
     expect(page).to have_text subject_name
     within_subject_row(subject_name) do
-      expect(page).to have_selector("svg[data-icon='add-circle']")
+      expect(page).to have_selector(".material-icons", text: "add_circle_outline")
       expect(page).to have_selector("select", text: 'Sem. 1')
     end
   end

--- a/spec/support/planned_subjects_helper.rb
+++ b/spec/support/planned_subjects_helper.rb
@@ -24,7 +24,7 @@ module PlannedSubjectsHelper
   def assert_planned_subject(subject_name)
     expect(page).to have_text subject_name
     within_subject_row(subject_name) do
-      expect(page).to have_selector("svg[data-icon='remove-circle']")
+      expect(page).to have_selector(".material-icons", text: "remove_circle_outline")
     end
   end
 

--- a/spec/support/planned_subjects_helper.rb
+++ b/spec/support/planned_subjects_helper.rb
@@ -2,7 +2,7 @@ module PlannedSubjectsHelper
   def assert_approved_subject(subject_name)
     expect(page).to have_text subject_name
     within_subject_row(subject_name) do
-      expect(page).to have_selector("svg[data-icon='check']")
+      expect(page).to have_selector(".material-icons", text: "check")
     end
   end
 
@@ -16,7 +16,7 @@ module PlannedSubjectsHelper
   def assert_available_subject(subject_name)
     expect(page).to have_text subject_name
     within_subject_row(subject_name) do
-      expect(page).to have_no_selector("svg[data-icon='check']")
+      expect(page).to have_no_selector(".material-icons", text: "check")
       expect(page).to have_no_selector("svg[data-icon='lock']")
     end
   end

--- a/spec/support/planned_subjects_helper.rb
+++ b/spec/support/planned_subjects_helper.rb
@@ -9,7 +9,7 @@ module PlannedSubjectsHelper
   def assert_blocked_subject(subject_name)
     expect(page).to have_text subject_name
     within_subject_row(subject_name) do
-      expect(page).to have_selector("svg[data-icon='lock']")
+      expect(page).to have_selector(".material-icons", text: "lock_outline")
     end
   end
 
@@ -17,7 +17,7 @@ module PlannedSubjectsHelper
     expect(page).to have_text subject_name
     within_subject_row(subject_name) do
       expect(page).to have_no_selector(".material-icons", text: "check")
-      expect(page).to have_no_selector("svg[data-icon='lock']")
+      expect(page).to have_no_selector(".material-icons", text: "lock_outline")
     end
   end
 


### PR DESCRIPTION
La propuesta es volver a los iconos de Material que teníamos antes, así son todos consistentes, y tenemos una forma fácil de agregarlos.

Por lo que puedo ver, Material Icons debería seguir funcionando aunque saquemos Material UI.