### PR TITLE
Arreglar espaciado en Navbar

### DIFF
--- a/app/views/layouts/_navbar.html.erb
+++ b/app/views/layouts/_navbar.html.erb
@@ -2,13 +2,13 @@
   <% show_search_bar = params[:search].present? %>
 
   <div class="flex w-full h-14 sm:h-16 px-2 sm:px-4 <%= show_search_bar ? 'hidden' : '' %>" data-search-target="appBar">
-    <div class="flex items-center gap-4">
+    <div class="flex items-center gap-2 sm:gap-4">
       <%= button_tag "menu", type: "button", class: "size-6 cursor-pointer material-icons", data: { action: "click->navigation-drawer#toggle" } %>
 
       <%= link_to 'MiCarrera', root_path, class: 'text-xl font-bold' %>
     </div>
 
-    <div class="flex w-full justify-end items-center">
+    <div class="flex w-full justify-end items-center gap-2 sm:gap-4">
       <%= button_tag "search", type: "button", class: "cursor-pointer material-icons", data: { action: "search#toggle" } %>
 
       <span hidden>


### PR DESCRIPTION
### Summary

Este es un follow-up de #779, en especial mirar https://github.com/cedarcode/mi_carrera/pull/779#discussion_r2135735888

Este PR arregla el espaciado de los iconos en la navbar para desktop y mobile.


#### Antes

<img width="375" alt="image" src="https://github.com/user-attachments/assets/7e265503-09ff-45e4-8fd7-9e37c782b485" />

<img width="1840" alt="image" src="https://github.com/user-attachments/assets/d47e39ac-81db-4b56-b373-3e88d267ae64" />


#### Ahora

<img width="376" alt="image" src="https://github.com/user-attachments/assets/e802138e-75e8-44a5-b194-763fd2547be0" />

<img width="1840" alt="image" src="https://github.com/user-attachments/assets/ba57d9fa-83ed-416e-91ce-441d03298bd9" />

