### PR TITLE
Remover `@rails/ujs`

### DIFF
--- a/app/controllers/user_onboardings_controller.rb
+++ b/app/controllers/user_onboardings_controller.rb
@@ -2,8 +2,6 @@ class UserOnboardingsController < ApplicationController
   def update
     current_student.welcome_banner_mark_as_viewed!
 
-    respond_to do |format|
-      format.json { render json: { status: :ok } }
-    end
+    head :ok
   end
 end

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -1,10 +1,7 @@
 // Configure your import map in config/importmap.rb. Read more: https://github.com/rails/importmap-rails
 import { Turbo } from "@hotwired/turbo-rails"
 import "controllers"
-import Rails from "@rails/ujs";
 import "install";
 import "serviceworker-companion";
-
-Rails.start();
 
 Turbo.session.drive = false

--- a/app/views/shared/_user_menu.html.erb
+++ b/app/views/shared/_user_menu.html.erb
@@ -13,7 +13,7 @@
       <li class="border-t border-gray-100 my-1"></li>
       <%= link_to "Editar Perfil", edit_user_registration_path, class: "block px-4 py-2 hover:bg-gray-100", tabindex: 0 %>
       <%= link_to "Importar Materias", new_transcript_path, class: "block px-4 py-2 hover:bg-gray-100", tabindex: 0 %>
-      <%= link_to "Salir", destroy_user_session_path, method: :delete, class: "block px-4 py-2 hover:bg-gray-100", tabindex: 0 %>
+      <%= link_to "Salir", destroy_user_session_path, data: { turbo: true, turbo_method: :delete }, class: "block px-4 py-2 hover:bg-gray-100", tabindex: 0 %>
     <% end %>
   </ul>
 </div>

--- a/app/views/shared/_welcome_banner.html.erb
+++ b/app/views/shared/_welcome_banner.html.erb
@@ -3,7 +3,7 @@
     <p class="text-sm/6 text-gray-900">
       Bienvenido! Marcá los cursos y exámenes que aprobaste para ver qué materias podés cursar.
     </p>
-    <%= form_with url: user_onboardings_path, method: :patch, local: false, data: { action: "welcome-banner#dismiss" } do |f| %>
+    <%= form_with url: user_onboardings_path, method: :patch, data: { turbo: true, action: "welcome-banner#dismiss" } do |f| %>
       <%= f.button 'Listo', class: "py-1 text-sm font-semibold text-primary cursor-pointer uppercase" %>
     <% end %>
   </div>

--- a/config/importmap.rb
+++ b/config/importmap.rb
@@ -6,6 +6,5 @@ pin "serviceworker-companion", to: "serviceworker-companion.js"
 pin "@hotwired/stimulus", to: "stimulus.min.js", preload: true
 pin "@hotwired/stimulus-loading", to: "stimulus-loading.js", preload: true
 pin "@hotwired/turbo-rails", to: "turbo.min.js", preload: true
-pin "@rails/ujs", to: "https://ga.jspm.io/npm:@rails/ujs@7.0.4/lib/assets/compiled/rails-ujs.js"
 pin_all_from "app/javascript/controllers", under: "controllers"
 pin "canvas-confetti", to: "https://ga.jspm.io/npm:canvas-confetti@1.6.0/dist/confetti.module.mjs"


### PR DESCRIPTION
#### Summary
El standard actual en `Rails` es utilizar `turbo` en lugar de `@rails/ujs`