### PR TITLE
No pasar `local: true` en `form_with`

### DIFF
--- a/app/views/devise/passwords/edit.html.erb
+++ b/app/views/devise/passwords/edit.html.erb
@@ -3,7 +3,7 @@
 
   <h2 class="text-3xl/9 text-neutral-700">Restablecer contraseña</h2>
 
-  <%= form_with(model: resource, url: password_path(resource_name), method: :put, local: true, class: "flex flex-col w-full max-w-md space-y-6 mb-12") do |f| %>
+  <%= form_with(model: resource, url: password_path(resource_name), method: :put, class: "flex flex-col w-full max-w-md space-y-6 mb-12") do |f| %>
     <%= f.hidden_field :reset_password_token %>
 
     <%= render 'shared/alert' if flash[:alert] %>

--- a/app/views/devise/passwords/new.html.erb
+++ b/app/views/devise/passwords/new.html.erb
@@ -3,7 +3,7 @@
 
   <h2 class="text-3xl/9 text-neutral-700">¿Has olvidado tu contraseña?</h2>
 
-  <%= form_with(model: resource, url: password_path(resource_name), method: :post, local: true, class: "flex flex-col w-full max-w-md space-y-6 mb-12") do |f| %>
+  <%= form_with(model: resource, url: password_path(resource_name), method: :post, class: "flex flex-col w-full max-w-md space-y-6 mb-12") do |f| %>
     <%= render 'shared/alert' if flash[:alert] %>
 
     <%= render EmailFieldComponent.new(form: f, attribute: :email, label: "Correo electrónico", input_options: { required: true, autocomplete: "email", autofocus: true }) %>

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -1,7 +1,7 @@
 <div class="flex flex-col justify-center items-center p-6 space-y-6">
   <h2 class="text-3xl/9 text-neutral-700">Editar Usuario</h2>
 
-  <%= form_with(model: resource, url: registration_path(resource_name), method: :put, local: true, class: "flex flex-col w-full max-w-md space-y-6") do |f| %>
+  <%= form_with(model: resource, url: registration_path(resource_name), method: :put, class: "flex flex-col w-full max-w-md space-y-6") do |f| %>
     <% if current_user.oauth_user? %>
       <div class="flex items-center p-4 mb-4 text-yellow-800 rounded-lg bg-yellow-50">
         <%= material_icon("info") %>

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -4,7 +4,7 @@
   <h2 class="text-3xl/9 text-neutral-700">Registrarse</h2>
 
   <div class="w-full max-w-md space-y-6">
-    <%= form_with(model: resource, url: registration_path(resource_name), local: true, class: "flex flex-col space-y-6") do |f| %>
+    <%= form_with(model: resource, url: registration_path(resource_name), class: "flex flex-col space-y-6") do |f| %>
       <%= render 'shared/alert' if flash[:alert] %>
 
       <%= render EmailFieldComponent.new(form: f, attribute: :email, label: "Correo electrónico", input_options: { required: true, autofocus: true, autocomplete: "email" }) %>

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -4,7 +4,7 @@
   <h2 class="text-3xl/9 text-neutral-700">Iniciar sesión</h2>
 
   <div class="w-full max-w-md space-y-6">
-    <%= form_with(model: resource, url: session_path(resource_name), local: true, class: "flex flex-col space-y-6") do |f| %>
+    <%= form_with(model: resource, url: session_path(resource_name), class: "flex flex-col space-y-6") do |f| %>
       <%= render 'shared/alert' if flash[:alert] %>
 
       <%= render EmailFieldComponent.new(form: f, attribute: :email, label: "Correo electrónico", input_options: { required: true, autofocus: true }) %>

--- a/app/views/layouts/_navbar.html.erb
+++ b/app/views/layouts/_navbar.html.erb
@@ -34,7 +34,7 @@
   </div>
 
   <div class="flex w-full h-14 sm:h-16 px-2 sm:px-4 border-b border-b-gray-700 bg-gray-100 text-gray-800 hover:bg-neutral-100 <%= show_search_bar ? '' : 'hidden' %>" data-search-target="searchbar">
-    <%= form_with(url: all_subjects_path, method: :get, local: true, class: "flex w-full justify-between") do |f| %>
+    <%= form_with(url: all_subjects_path, method: :get, class: "flex w-full justify-between") do |f| %>
       <%= f.text_field :search, value: params[:search], class: "w-full focus:outline-0", placeholder: "Buscar por nombre o código de la materia", autofocus: true, data: { search_target: "searchInput" } %>
 
       <%= button_tag "close", type: "button", class: "cursor-pointer material-icons", data: { action: "search#toggle" }, tabindex: "0" %>

--- a/app/views/shared/_google_sso.html.erb
+++ b/app/views/shared/_google_sso.html.erb
@@ -1,5 +1,5 @@
 <%- resource_class.omniauth_providers.each do |provider| %>
-  <%= form_with url: omniauth_authorize_path(resource_name, provider), method: :post, local: true do |f| %>
+  <%= form_with url: omniauth_authorize_path(resource_name, provider), method: :post do |f| %>
     <%= f.button class: "w-full flex items-center justify-center p-2 rounded-lg border-1 border-neutral-300 cursor-pointer bg-white" do %>
       <%= image_tag "google-icon.png", class: "w-6" %>
       <span class="text-sm text-neutral-700 font-semibold">Google</span>


### PR DESCRIPTION
Extracted from
https://api.rubyonrails.org/classes/ActionView/Helpers/FormHelper.html#method-i-form_with


> When unspecified, the behavior is derived from
`config.action_view.form_with_generates_remote_forms` where the config’s
value is actually the inverse of what local‘s value would be.
As of Rails 6.1, that configuration option defaults to false (which has the
equivalent effect of passing local: true).
