### PR TITLE
No pasar `local: false` a `form_with`

### DIFF
--- a/app/components/approvable_checkbox_component.html.erb
+++ b/app/components/approvable_checkbox_component.html.erb
@@ -3,7 +3,6 @@
   url: approvable_approval_path(approvable, subject_show: subject_show),
   data: { controller: "autosave-check" },
   method: current_student.approved?(approvable) ? :delete : :post,
-  local: false,
   class: "mx-[5px]"
 ) do |form| %>
   <div class="box-content w-[18px] h-[18px] p-3">

--- a/app/views/subjects/_not_planned_subjects_list.html.erb
+++ b/app/views/subjects/_not_planned_subjects_list.html.erb
@@ -10,8 +10,7 @@
         url: subject_plans_path,
         method: :post,
         data: { turbo: true },
-        class: 'flex items-center gap-3 p-3 hover:bg-gray-100',
-        local: false
+        class: 'flex items-center gap-3 p-3 hover:bg-gray-100'
       ) do |form| %>
         <%= link_to display_name(subject), subject, class: "grow text-sm/6 text-gray-900" %>
         <%= material_icon("check", "text-green-500") %>

--- a/app/views/subjects/_planned_subjects_list.html.erb
+++ b/app/views/subjects/_planned_subjects_list.html.erb
@@ -42,8 +42,7 @@
       url: subject_plans_path,
       method: :post,
       data: { turbo: true },
-      class: 'flex items-center gap-3 px-4 py-3 hover:bg-gray-100 border-t border-gray-100',
-      local: false
+      class: 'flex items-center gap-3 px-4 py-3 hover:bg-gray-100 border-t border-gray-100'
     ) do |form| %>
       <span class="grow text-sm/6 text-gray-900">
         Planificar:


### PR DESCRIPTION
#### Summary

Follow-up de #801 y #804

- En el `approvable checkbox` el submit esta siendo interceptado por el controller de javascript y posteriormente se esta mandando con Turbo
https://github.com/cedarcode/mi_carrera/blob/05959aa9b6015fc80bc822695edb93b6e9801ab8/app/javascript/controllers/autosave_check_controller.js#L1-L13

- En los otros dos `form_with` se esta usando `turbo: true`
https://github.com/cedarcode/mi_carrera/blob/05959aa9b6015fc80bc822695edb93b6e9801ab8/app/views/subjects/_not_planned_subjects_list.html.erb#L8-L15
https://github.com/cedarcode/mi_carrera/blob/05959aa9b6015fc80bc822695edb93b6e9801ab8/app/views/subjects/_planned_subjects_list.html.erb#L40-L47

Por lo que no se debería ser necesario `local: false`