### PR TITLE
Mostrar el link al planner en el side menu para los usuarios no logueados

### DIFF
--- a/app/views/shared/_menu.html.erb
+++ b/app/views/shared/_menu.html.erb
@@ -7,7 +7,7 @@
 
   <%= drawer_menu_navigation_item "Materias INCO semestre actual", current_optional_subjects_path %>
 
-  <% if current_user && ENV['ENABLE_PLANNER'].present? %>
+  <% if ENV['ENABLE_PLANNER'].present? %>
     <%= drawer_menu_navigation_item "Planificador", subject_plans_path, new_badge: true %>
   <% end %>
 


### PR DESCRIPTION
## Motivación

De esta forma es más visible que la feature existe. Los usuarios no logueados van a ser dirigidos a la página de iniciar sesión al intentar entrar.

La idea surgió en https://github.com/cedarcode/mi_carrera/pull/799#discussion_r2146110308