### PR TITLE
Cambiar screenshots path en `Upload screenshots`

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -91,7 +91,7 @@ jobs:
       uses: actions/upload-artifact@v4
       with:
         name: system_test_screenshots
-        path: ./tmp/screenshots
+        path: ./tmp/capybara
         retention-days: 2
 
     - uses: joshmfrankel/simplecov-check-action@main


### PR DESCRIPTION
Si los specs de sistema fallan las screenshots se guardan en `Capybara.save_path` que es `tmp/capybara`.

Pero en `Upload screenshot` nos  estamos fijando en `tmp/screenshot`. (Supongo que ahí se guardaban con minitest?) 
Ejemplo: https://github.com/cedarcode/mi_carrera/actions/runs/15687569985/job/44194493155

Ejemplo habiéndolo cambiado a `tmp/capybara`: https://github.com/cedarcode/mi_carrera/actions/runs/15687660478/job/44194788018