### PR TITLE
No importar `material-symbol`

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -8,7 +8,6 @@
     <%= csp_meta_tag %>
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <%= stylesheet_link_tag :app, "data-turbo-track": "reload" %>
-    <%= stylesheet_link_tag    'https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@48,500,0,0' %>
     <%= stylesheet_link_tag    'https://fonts.googleapis.com/css?family=Roboto:300,400,500,600,700' %>
     <%= stylesheet_link_tag    'https://fonts.googleapis.com/icon?family=Material+Icons' %>
     <%= stylesheet_link_tag    'https://unpkg.com/material-components-web@14.0.0/dist/material-components-web.min.css' %>


### PR DESCRIPTION
#### Summary

Fue añadido en https://github.com/cedarcode/mi_carrera/commit/5c6218a4fa1a4394df0a1482bba84e8c38b31fec

Pero ya no estamos usando más la clase `material-symbols`