### PR TITLE
Add password validation when adding new Passkey

### DIFF
--- a/app/views/users/passkeys/index.html.erb
+++ b/app/views/users/passkeys/index.html.erb
@@ -18,8 +18,16 @@
     </ul>
 
     <%= form_with url: user_passkeys_path, method: :post, class: "flex flex-col w-full space-y-6", data: { action: "passkeys#create:prevent", controller: "passkeys", passkeys_public_key_param: @create_passkey_options } do |f| %>
+      <%= render 'shared/alert' if flash[:alert] %>
       <%= f.label :name, "Nombre", class: "text-sm/6 font-medium text-gray-700 with-error:text-red-600" %>
       <%= f.text_field :name, class: "bg-white w-full rounded-md px-3 py-1.5 outline-1 outline-gray-300 focus:outline-2 focus:outline-indigo-600", required: true %>
+      <%= f.label :password, "Contraseña actual", class: "text-sm/6 font-medium text-gray-700 with-error:text-red-600" %>
+      <div class="relative w-full" data-controller="show-password">
+        <%= f.password_field :password, class: "bg-white w-full rounded-md px-3 py-1.5 outline-1 outline-gray-300 focus:outline-2 focus:outline-indigo-600 with-error:outline-red-500 with-error:focus:outline-red-600", data: { show_password_target: "password" }, required: true %>
+        <%= button_tag type: "button", class: "flex items-center absolute inset-y-0 right-0 pr-3 cursor-pointer hover:text-indigo-700", data: { action: "show-password#toggle" } do %>
+          <span class="material-icons" data-show-password-target="icon">visibility</span>
+        <% end %>
+      </div>
 
       <%= render ButtonComponent.new(form: f, label: "Agregar Passkey") %>
     <% end %>

--- a/spec/system/manage_passkeys_spec.rb
+++ b/spec/system/manage_passkeys_spec.rb
@@ -2,20 +2,22 @@ require 'rails_helper'
 
 RSpec.describe 'Manage passkeys' do
   before do
-    sign_in create(:user)
+    ENV['ENABLE_PASSKEYS'] = 'true'
   end
 
-  ENV['ENABLE_PASSKEYS'] = 'true'
-
   describe 'Add and remove credentials' do
-    fake_origin = Rails.configuration.webauthn_origin[0]
-    fake_client = WebAuthn::FakeClient.new(fake_origin, encoding: false)
-    fixed_challenge = SecureRandom.random_bytes(32)
-    fake_credentials = fake_client.create(challenge: fixed_challenge, user_verified: true)
+    let(:user) { create(:user) }
 
     it 'works correctly' do
+      fake_origin = Rails.configuration.webauthn_origin[0]
+      fake_client = WebAuthn::FakeClient.new(fake_origin, encoding: false)
+      fixed_challenge = SecureRandom.random_bytes(32)
+      fake_credentials = fake_client.create(challenge: fixed_challenge, user_verified: true)
+
       allow_any_instance_of(WebAuthn::PublicKeyCredential::CreationOptions).to receive(:raw_challenge)
         .and_return(fixed_challenge)
+
+      sign_in user
 
       visit edit_user_registration_path
 
@@ -24,6 +26,7 @@ RSpec.describe 'Manage passkeys' do
       stub_create(fake_credentials)
 
       fill_in "Nombre", with: "My new passkey"
+      fill_in "Contraseña actual", with: user.password
       click_on "Agregar Passkey"
 
       expect(page).to have_content "My new passkey"
@@ -38,6 +41,31 @@ RSpec.describe 'Manage passkeys' do
 
       expect(page).to have_no_content "My new passkey"
       expect(page).to have_text "Tu passkey ha sido eliminada correctamente"
+    end
+
+    it 'alerts wrong password' do
+      fake_origin2 = Rails.configuration.webauthn_origin[0]
+      fake_client2 = WebAuthn::FakeClient.new(fake_origin2, encoding: false)
+      fixed_challenge2 = SecureRandom.random_bytes(32)
+      fake_credentials2 = fake_client2.create(challenge: fixed_challenge2, user_verified: true)
+
+      allow_any_instance_of(WebAuthn::PublicKeyCredential::CreationOptions).to receive(:raw_challenge)
+        .and_return(fixed_challenge2)
+
+      sign_in user
+
+      visit edit_user_registration_path
+
+      click_on "Administrar Passkeys"
+
+      stub_create(fake_credentials2)
+
+      fill_in "Nombre", with: "My new passkey"
+      fill_in "Contraseña actual", with: "Incorrect Password!"
+      click_on "Agregar Passkey"
+
+      expect(page).to have_text "Contraseña Incorrecta"
+      expect(page).to have_no_content "Tu passkey ha sido agregada correctamente"
     end
   end
 end


### PR DESCRIPTION
### Se incorporó:

- Seguridad al agregar una passkey pidiendo la contraseña del usuario. 
   - Se utilizó el metodo [valid_password](https://github.com/heartcombo/devise/blob/cf93de390a29654620fdf7ac07b4794eb95171d0/lib/devise/models/database_authenticatable.rb#L71) de Device.

<img width="1792" alt="image" src="https://github.com/user-attachments/assets/1f1cb160-a27e-49ed-972b-c8e0d7cfd6b4" />



- Mensaje de error si se ingresa una contraseña incorrecta:

<img width="1792" alt="image" src="https://github.com/user-attachments/assets/5a61c9fd-4e2d-43f8-bca9-38bb03720c26" />