### PR TITLE
Remove unnecessary alert on redirect to root

### DIFF
--- a/app/controllers/subject_plans_controller.rb
+++ b/app/controllers/subject_plans_controller.rb
@@ -22,7 +22,7 @@ class SubjectPlansController < ApplicationController
   private
 
   def ensure_feature_enabled!
-    redirect_to root_path, alert: 'Feature is not available' if ENV['ENABLE_PLANNER'].blank?
+    redirect_to root_path if ENV['ENABLE_PLANNER'].blank?
   end
 
   def set_planned_and_not_planned_subjects

--- a/app/controllers/users/passkeys_controller.rb
+++ b/app/controllers/users/passkeys_controller.rb
@@ -52,7 +52,7 @@ module Users
     private
 
     def ensure_feature_enabled!
-      redirect_to root_path, alert: 'Feature is not available' if ENV['ENABLE_PASSKEYS'].blank?
+      redirect_to root_path if ENV['ENABLE_PASSKEYS'].blank?
     end
   end
 end


### PR DESCRIPTION
En el root no mostramos los alert, así que creo que no sirve de nada ponerlo en el redirect