### PR TITLE
Disable Rubocop SuggestExtensions

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -8,6 +8,7 @@ inherit_mode:
 
 AllCops:
   DisabledByDefault: true
+  SuggestExtensions: false
   NewCops: disable
   Exclude:
     - "bin/*"


### PR DESCRIPTION
Cuando corremos rubocop imprime esto:

```
Tip: Based on detected gems, the following RuboCop extension libraries might be helpful:
  * rubocop-capybara (https://rubygems.org/gems/rubocop-capybara)
  * rubocop-factory_bot (https://rubygems.org/gems/rubocop-factory_bot)
  * rubocop-rspec (https://rubygems.org/gems/rubocop-rspec)
  * rubocop-rspec_rails (https://rubygems.org/gems/rubocop-rspec_rails)

You can opt out of this message by adding the following to your config (see https://docs.rubocop.org/rubocop/extensions.html#extension-suggestions for more options):
  AllCops:
    SuggestExtensions: false
```

ya que por ahora no nos interesó agregarlas, creo que no es necesario que nos avise cada vez que corremos rubocop