### PR TITLE
Use default text

### DIFF
--- a/app/components/email_field_component.html.erb
+++ b/app/components/email_field_component.html.erb
@@ -1,10 +1,8 @@
 <div>
-  <%= form.label attribute, label, class: "text-sm/6 font-medium text-gray-700 with-error:text-red-600" %>
-
+  <%= form.label attribute, label, class: "font-medium text-gray-700 with-error:text-red-600" %>
   <%= form.email_field attribute, input_options %>
-
   <% if error_messages.present? %>
-    <div class="text-red-600 text-sm/6 mt-1">
+    <div class="text-red-600 mt-1">
       <%= error_messages %>
     </div>
   <% end %>

--- a/app/components/password_field_component.html.erb
+++ b/app/components/password_field_component.html.erb
@@ -1,20 +1,17 @@
 <div>
-  <%= form.label attribute, label, class: "text-sm/6 font-medium text-gray-700 with-error:text-red-600" %>
-
+  <%= form.label attribute, label, class: "font-medium text-gray-700 with-error:text-red-600" %>
   <div class="relative w-full" data-controller="show-password">
     <%= form.password_field attribute, input_options %>
-
     <%= button_tag type: "button", class: STYLES[:icon], data: { action: "show-password#toggle" } do %>
       <span class="material-icons" data-show-password-target="icon">visibility</span>
     <% end %>
   </div>
-
   <% if error_messages.present? %>
-    <div class="text-red-600 text-sm/6 mt-1">
+    <div class="text-red-600 mt-1">
       <%= error_messages %>
     </div>
   <% elsif hint.present? %>
-    <div class="text-gray-500 text-sm/6 mt-1">
+    <div class="text-gray-500 mt-1">
       <%= hint %>
     </div>
   <% end %>

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -6,7 +6,7 @@
       <% if current_user.oauth_user? %>
         <div class="flex items-center p-4 mb-4 text-yellow-800 rounded-lg bg-yellow-50">
           <%= material_icon("info") %>
-          <span class="ms-3 text-sm/6 font-medium"> Si cambias tu correo electrónico, perderás el acceso con Google </span>
+          <span class="ms-3 font-medium"> Si cambias tu correo electrónico, perderás el acceso con Google </span>
         </div>
       <% end %>
 

--- a/app/views/devise/shared/_links.html.erb
+++ b/app/views/devise/shared/_links.html.erb
@@ -1,19 +1,19 @@
 <%- if controller_name != 'sessions' %>
-  <p class="text-center text-sm/6 text-neutral-500">
+  <p class="text-center text-neutral-500">
     ¿Ya estás registrado?
 
     <%= link_to "Ingresar", new_session_path(resource), class: "font-semibold text-indigo-700 hover:text-indigo-500 hover:underline" %>
   </p>
 <% end %>
 <%- if controller_name != 'registrations' %>
-  <p class="text-center text-sm/6 text-neutral-500">
+  <p class="text-center text-neutral-500">
     ¿No estás registrado?
 
     <%= link_to "Registrarte", new_registration_path(resource), class: "font-semibold text-indigo-700 hover:text-indigo-500 hover:underline" %>
   </p>
 <% end %>
 <%- if controller_name != 'passwords' && controller_name != 'registrations' %>
-  <p class="text-center text-sm/6 text-neutral-500">
+  <p class="text-center text-neutral-500">
     ¿Has olvidado tu contraseña?
 
     <%= link_to "Restablecer contraseña", new_password_path(resource), class: "font-semibold text-indigo-700 hover:text-indigo-500 hover:underline" %>

--- a/app/views/shared/_alert.html.erb
+++ b/app/views/shared/_alert.html.erb
@@ -1,5 +1,4 @@
 <div class="flex flex-row items-center p-4 mb-4 rounded-lg bg-red-100 text-red-600">
   <%= material_icon("cancel") %>
-
-  <span class="ms-3 text-sm/6 font-medium"><%= flash[:alert] %></span>
+  <span class="ms-3 font-medium"><%= flash[:alert] %></span>
 </div>

--- a/app/views/shared/_google_sso.html.erb
+++ b/app/views/shared/_google_sso.html.erb
@@ -2,7 +2,7 @@
   <%= form_with url: omniauth_authorize_path(resource_name, provider), method: :post do |f| %>
     <%= f.button class: "w-full flex items-center justify-center p-2 rounded-lg border-1 border-neutral-300 cursor-pointer bg-white" do %>
       <%= image_tag "google-icon.png", class: "w-6" %>
-      <span class="text-sm text-neutral-700 font-semibold">Google</span>
+      <span class="text-neutral-700 font-semibold">Google</span>
     <% end %>
   <% end %>
 <% end %>

--- a/app/views/shared/_menu.html.erb
+++ b/app/views/shared/_menu.html.erb
@@ -1,27 +1,19 @@
-<div data-navigation-drawer-target="drawer" class="fixed inset-y-0 w-64 bg-white transform -translate-x-full transition-transform duration-300 z-50 space-y-2 font-semibold text-sm px-3" >
+<div data-navigation-drawer-target="drawer" class="fixed inset-y-0 w-64 bg-white transform -translate-x-full transition-transform duration-300 z-50 space-y-2 font-semibold px-3" >
   <%= image_tag "icon.png", class: "size-12 mb-4 mt-2" %>
-
   <%= drawer_menu_navigation_item "Avance de Carrera", root_path %>
-
   <%= drawer_menu_navigation_item "Todas las Materias", all_subjects_path %>
-
   <%= drawer_menu_navigation_item "Materias INCO semestre actual", current_optional_subjects_path %>
-
   <% if ENV['ENABLE_PLANNER'].present? %>
     <%= drawer_menu_navigation_item "Planificador", subject_plans_path, new_badge: true %>
   <% end %>
-
   <hr class="text-gray-200"/>
-
   <%= link_to "https://github.com/cedarcode/mi_carrera", target: "_blank", class: "flex items-center gap-1 p-2 rounded-sm hover:bg-gray-100 text-gray-600 hover:text-gray-800" do %>
     <%= material_icon("open_in_new") %>
     Colabora en Github
   <% end %>
-
   <%= link_to "mailto:feedback-micarrera@cedarcode.com", target: "_blank", class: "flex items-center gap-1 p-2 rounded-sm hover:bg-gray-100 text-gray-600 hover:text-gray-800" do %>
     <%= material_icon("rate_review") %>
     Opina de la app
   <% end %>
 </div>
-
 <div data-navigation-drawer-target="overlay" data-action="click->navigation-drawer#toggle" class="fixed inset-0 bg-black/30 hidden z-40"></div>

--- a/app/views/shared/_notice.html.erb
+++ b/app/views/shared/_notice.html.erb
@@ -3,6 +3,5 @@
   class="fixed end-0 bottom-4 flex justify-center items-center max-w-xs p-4 bg-white border-1 border-gray-100 space-x-2 rounded-lg shadow-xl z-1 transform transition-all duration-300 ease-in-out translate-x-full opacity-0"
 >
   <%= material_icon("check_circle_outline", "text-green-500") %>
-
-  <span class="text-sm"><%= flash[:notice] %></span>
+  <span><%= flash[:notice] %></span>
 </div>

--- a/app/views/shared/_welcome_banner.html.erb
+++ b/app/views/shared/_welcome_banner.html.erb
@@ -1,10 +1,10 @@
 <div class="sticky bg-purple-100 w-full top-14 sm:top-16" data-controller="welcome-banner">
   <div class="max-w-[600px] mx-auto px-3 py-2.5 flex items-center gap-x-3">
-    <p class="text-sm/6 text-gray-900">
+    <p class="text-gray-900">
       ¡Bienvenido! Marcá los cursos y exámenes que aprobaste para ver qué materias podés cursar.
     </p>
     <%= form_with url: user_onboardings_path, method: :patch, data: { turbo: true, action: "welcome-banner#dismiss" } do |f| %>
-      <%= f.button 'Listo', class: "py-1 text-sm font-semibold text-primary cursor-pointer uppercase" %>
+      <%= f.button 'Listo', class: "py-1 font-semibold text-primary cursor-pointer uppercase" %>
     <% end %>
   </div>
 </div>

--- a/app/views/subject_plans/_credits_counter.html.erb
+++ b/app/views/subject_plans/_credits_counter.html.erb
@@ -1,4 +1,4 @@
-<div class="mx-4 my-3 font-medium text-sm">
+<div class="mx-4 my-3 font-medium">
   <% planned_approvable_ids = planned_subjects.map { |subject| [subject.course.id, subject.exam&.id] }.flatten.compact %>
   <strong> Créditos planeados:</strong> <%= Subject.approved_credits(planned_approvable_ids) %>
 </div>

--- a/app/views/subjects/_not_planned_subjects_list.html.erb
+++ b/app/views/subjects/_not_planned_subjects_list.html.erb
@@ -1,10 +1,9 @@
 <% if subjects.any? %>
   <div class="bg-white rounded-lg border border-gray-100 shadow-sm">
-    <h3 class="bg-gray-50 text-sm font-bold px-4 py-3">
+    <h3 class="bg-gray-50 font-bold px-4 py-3">
       Materias aprobadas sin semestre asignado
     </h3>
-    
-    <% subjects.each do |subject| %> 
+    <% subjects.each do |subject| %>
       <%= form_with(
         model: SubjectPlan.new,
         url: subject_plans_path,
@@ -12,14 +11,14 @@
         data: { turbo: true },
         class: 'flex items-center gap-3 p-3 hover:bg-gray-100'
       ) do |form| %>
-        <%= link_to display_name(subject), subject, class: "grow text-sm/6 text-gray-900" %>
+        <%= link_to display_name(subject), subject, class: "grow text-gray-900" %>
         <%= material_icon("check", "text-green-500") %>
         <%= 
           form.select(
             :semester,
             (1..10).map { |i| ["Sem. #{i}", i] },
             {}, 
-            class: 'min-w-24 h-6 px-2 rounded-md text-sm/6 text-gray-900 shadow-sm border border-gray-300 truncate cursor-pointer'
+            class: 'min-w-24 h-6 px-2 rounded-md text-gray-900 shadow-sm border border-gray-300 truncate cursor-pointer'
           )
         %>
         <%= form.hidden_field :subject_id, value: subject.id %>

--- a/app/views/subjects/_planned_subjects_list.html.erb
+++ b/app/views/subjects/_planned_subjects_list.html.erb
@@ -1,15 +1,13 @@
 <%= render partial: "subjects/not_planned_subjects_list", locals: { subjects: @not_planned_approved_subjects } %>
-
 <% (1..10).each do |semester| %>
   <% planned_subjects = @planned_subjects.select { |subject| subject.semester == semester } %>
   <div class="bg-white rounded-lg border border-gray-100 shadow-sm">
     <div class="flex items-center justify-between h-10 bg-gray-50">
-      <h3 class="text-sm font-bold ml-4">
+      <h3 class="font-bold ml-4">
         <%= semester_display_name(semester) %>
       </h3>
       <%= render partial: "credits_counter", locals: { planned_subjects: planned_subjects } %>
     </div>
-    
     <% if planned_subjects.any? %>
       <% planned_subjects.each do |subject| %>
         <%= form_with(
@@ -18,25 +16,22 @@
             data: { turbo: true },
             class: 'flex items-center gap-3 px-4 py-3 hover:bg-gray-100',
           ) do |form| %>
-            <%= link_to display_name(subject), subject, class: "grow text-sm/6 text-gray-900" %>
-            
-            <% if current_student.approved?(subject) %>
-              <%= material_icon("check", "text-green-500") %>
-            <% elsif !current_student.available?(subject) %>
-              <%= material_icon("lock_outline", "text-gray-400") %>
-            <% end %>
-
-            <%= form.button type: :submit, class: "cursor-pointer py-2 ps-3 material-icons text-gray-400" do %>
-              remove_circle_outline
-            <% end %>
+          <%= link_to display_name(subject), subject, class: "grow text-gray-900" %>
+          <% if current_student.approved?(subject) %>
+            <%= material_icon("check", "text-green-500") %>
+          <% elsif !current_student.available?(subject) %>
+            <%= material_icon("lock_outline", "text-gray-400") %>
           <% end %>
+          <%= form.button type: :submit, class: "cursor-pointer py-2 ps-3 material-icons text-gray-400" do %>
+            remove_circle_outline
+          <% end %>
+        <% end %>
       <% end %>
     <% else %>
-      <div class="text-sm/6 text-gray-900 mx-4 h-[44px] my-3 italic flex items-center">
+      <div class="text-gray-900 mx-4 h-[44px] my-3 italic flex items-center">
         No hay materias planificadas para este semestre
       </div>
     <% end %>
-    
     <%= form_with(
       model: SubjectPlan.new,
       url: subject_plans_path,
@@ -44,18 +39,18 @@
       data: { turbo: true },
       class: 'flex items-center gap-3 px-4 py-3 hover:bg-gray-100 border-t border-gray-100'
     ) do |form| %>
-      <span class="grow text-sm/6 text-gray-900">
+      <span class="grow text-gray-900">
         Planificar:
       </span>
       <%= form.select(
         :subject_id,
         @not_planned_subjects.map { |s| [display_planned_subject_name_and_code(s), s.id] },
         { prompt: 'Materia' },
-        class: 'w-24 h-6 px-2 rounded-md text-sm/6 text-gray-900 shadow-sm border border-gray-300 truncate cursor-pointer'
+        class: 'w-24 h-6 px-2 rounded-md text-gray-900 shadow-sm border border-gray-300 truncate cursor-pointer'
       ) %>
       <%= form.hidden_field :semester, value: semester %>
       <%= form.button type: :submit, class: "cursor-pointer py-2 ps-3 material-icons text-gray-400" do %>
-          add_circle_outline
+        add_circle_outline
       <% end %>
     <% end %>
   </div>

--- a/app/views/subjects/_subject.html.erb
+++ b/app/views/subjects/_subject.html.erb
@@ -1,7 +1,6 @@
 <li>
-  <%= link_to subject_path(subject), class: "flex gap-x-4 p-3 justify-between items-center hover:bg-gray-100 text-sm/6 text-gray-900" do %>
+  <%= link_to subject_path(subject), class: "flex gap-x-4 p-3 justify-between items-center hover:bg-gray-100 text-gray-900" do %>
     <%= display_name(subject) %>
-
     <span class='flex h-[40px] w-[100px] min-w-[100px] ms-[15px]'>
       <%= render(ApprovableCheckboxComponent.new(approvable: subject.course, subject_show: false, current_student: current_student)) %>
       <% if subject.exam %>

--- a/app/views/subjects/_subjects_bulk_approve.html.erb
+++ b/app/views/subjects/_subjects_bulk_approve.html.erb
@@ -1,7 +1,7 @@
 <div data-controller="bedel loading <%= "confetti" if @graduated %>" id="subjects" >
   <%= render "approvals/spinner_template" %>
   <% @subjects.group_by(&:category).each do |category, subjects| %>
-    <div class="flex items-center h-[50px] border-y border-t-gray-100 border-b-gray-200 bg-gray-50 px-3 py-1.5 text-sm/6 font-semibold text-gray-900">
+    <div class="flex items-center h-[50px] border-y border-t-gray-100 border-b-gray-200 bg-gray-50 px-3 py-1.5 font-semibold text-gray-900">
       <h3 class="grow"><%= formatted_category(category) %></h3>
       <h3 class='w-[50px] text-center'>Curso</h3>
       <h3 class='w-[50px] text-center'>Examen</h3>

--- a/app/views/subjects/_subjects_list.html.erb
+++ b/app/views/subjects/_subjects_list.html.erb
@@ -1,9 +1,8 @@
 <ul>
   <% subjects.each do |subject| %>
     <li>
-      <%= link_to subject_path(subject), class: "flex gap-x-4 p-3 justify-between items-center hover:bg-gray-100 text-sm/6 text-gray-900" do %>
+      <%= link_to subject_path(subject), class: "flex gap-x-4 p-3 justify-between items-center hover:bg-gray-100 text-gray-900" do %>
         <%= display_name(subject) %>
-
         <% if current_student.approved?(subject) %>
           <%= material_icon("check", "text-green-500") %>
         <% elsif !current_student.available?(subject) %>

--- a/app/views/subjects/all.html.erb
+++ b/app/views/subjects/all.html.erb
@@ -3,10 +3,9 @@
 <% end %>
 <% if @subjects.any? %>
   <% @subjects.group_by(&:category).each do |category, subjects| %>
-    <div class="flex items-center h-[50px] border-y border-t-gray-100 border-b-gray-200 bg-gray-50 px-3 py-1.5 text-sm/6 font-semibold text-gray-900">
+    <div class="flex items-center h-[50px] border-y border-t-gray-100 border-b-gray-200 bg-gray-50 px-3 py-1.5 font-semibold text-gray-900">
       <h3 class="grow"><%= formatted_category(category) %></h3>
     </div>
-
     <%= render partial: "subjects/subjects_list", locals: { subjects: subjects } %>
   <% end %>
 <% else %>

--- a/app/views/subjects/show.html.erb
+++ b/app/views/subjects/show.html.erb
@@ -1,7 +1,7 @@
 <h3 class="mx-4 my-3 text-2xl"><%= @subject.code %> - <%= @subject.name %></h3>
 <hr class="border-gray-200"/>
 
-<h3 class="mx-4 my-3 text-sm font-medium">Información general</h3>
+<h3 class="mx-4 my-3 font-medium">Información general</h3>
 
 <div class="py-3 px-4">Créditos: <%= @subject.credits %></div>
 
@@ -25,12 +25,12 @@
 
 <hr class="border-gray-200"/>
 
-<h3 class="mx-4 my-3 text-sm font-medium">Aprobación</h3>
+<h3 class="mx-4 my-3 font-medium">Aprobación</h3>
 <%= render 'approvables' %>
 <hr class="border-gray-200"/>
 
 <% if @subject.openfing_id || @subject.eva_id %>
-  <h3 class="mx-4 my-3 text-sm font-medium">Links de interés</h3>
+  <h3 class="mx-4 my-3 font-medium">Links de interés</h3>
 
   <% if @subject.openfing_id %>
     <%= link_to "https://open.fing.edu.uy/courses/#{@subject.openfing_id}", target: "_blank", class: "flex items-center py-3 px-4 hover:bg-gray-100" do %>
@@ -49,7 +49,7 @@
   <hr class="border-gray-200"/>
 <% end %>
 
-<h3 class="mx-4 my-3 text-sm font-medium">Previas</h3>
+<h3 class="mx-4 my-3 font-medium">Previas</h3>
 
 <% if @subject.course.prerequisite_tree %>
   <span class="mx-4">Del curso:</span>
@@ -65,6 +65,6 @@
 
 <hr class="border-gray-200"/>
 
-<%= link_to "mailto:feedback-micarrera@cedarcode.com", target: "_blank", class: "block px-4 py-3 hover:bg-gray-100 no-underline font-medium text-sm/6" do %>
+<%= link_to "mailto:feedback-micarrera@cedarcode.com", target: "_blank", class: "block px-4 py-3 hover:bg-gray-100 no-underline font-medium" do %>
   ¿Hay un error? ¿Hay información que falta? Repórtalo acá
 <% end %>

--- a/app/views/transcripts/create.turbo_stream.erb
+++ b/app/views/transcripts/create.turbo_stream.erb
@@ -16,7 +16,6 @@
           </div>
         </div>
       <% end %>
-
       <% if @failed_entries.present? %>
         <div class="sm:flex sm:items-start mt-5">
           <div class="mx-auto flex size-12 shrink-0 items-center justify-center rounded-full bg-yellow-100 sm:mx-0 sm:size-10">
@@ -30,11 +29,10 @@
               <% end %>
             </div>
           </div>
-      <% end %>
-    </div>
-
-    <div class="mt-5 sm:mt-6">
-      <%= link_to "Ir al inicio", root_path, class: "inline-flex w-full justify-center rounded-md bg-primary px-3 py-2 text-sm font-semibold text-white shadow-xs focus-visible:outline-2 focus-visible:outline-offset-2" %>
-    </div>
-  </dialog>
-<% end %>
+        <% end %>
+      </div>
+      <div class="mt-5 sm:mt-6">
+        <%= link_to "Ir al inicio", root_path, class: "inline-flex w-full justify-center rounded-md bg-primary px-3 py-2 font-semibold text-white shadow-xs focus-visible:outline-2 focus-visible:outline-offset-2" %>
+      </div>
+    </dialog>
+  <% end %>

--- a/app/views/transcripts/new.html.erb
+++ b/app/views/transcripts/new.html.erb
@@ -1,6 +1,6 @@
 <div class="py-6 px-3 sm:px-6 space-y-6">
   <h2 class="text-3xl/9 text-center text-neutral-700">Importar Materias</h2>
-  <div class="text-sm/6 text-gray-600">
+  <div class="text-gray-600">
     <p>Cargá tu escolaridad para marcar automáticamente las materias que ya cursaste.</p>
     <p class="mt-2">Si no tenés tu escolaridad, podés conseguirla siguiendo los pasos a continuación:</p>
     <ol class="list-decimal list-inside">
@@ -10,10 +10,10 @@
     </ol>
   </div>
   <%= form_with url: transcripts_path, method: :post, data: { turbo: true }, html: { multipart: true }, class: 'flex flex-col' do |form| %>
-    <%= form.label :file, "Subí la escolaridad", class: "block text-sm/6 font-medium text-gray-900 mb-1" %>
+    <%= form.label :file, "Subí la escolaridad", class: "block font-medium text-gray-900 mb-1" %>
     <%= form.file_field :file, accept: "application/pdf", required: true, class: "relative flex w-full border mb-4
       overflow-hidden border-gray-200
-      shadow-2xs rounded-lg text-sm
+      shadow-2xs rounded-lg
       focus:outline-hidden focus:z-10
       file:h-full file:py-2 file:px-4
       file:bg-gray-100 file:text-nowrap

--- a/app/views/users/passkeys/index.html.erb
+++ b/app/views/users/passkeys/index.html.erb
@@ -18,7 +18,7 @@
     </ul>
 
     <%= form_with url: user_passkeys_path, method: :post, class: "flex flex-col w-full space-y-6", data: { action: "passkeys#create:prevent", controller: "passkeys", passkeys_public_key_param: @create_passkey_options } do |f| %>
-      <%= f.label :name, "Nombre", class: "text-sm/6 font-medium text-gray-700 with-error:text-red-600" %>
+      <%= f.label :name, "Nombre", class: "font-medium text-gray-700 with-error:text-red-600" %>
       <%= f.text_field :name, class: "bg-white w-full rounded-md px-3 py-1.5 outline-1 outline-gray-300 focus:outline-2 focus:outline-indigo-600", required: true %>
 
       <%= render ButtonComponent.new(form: f, label: "Agregar Passkey") %>


### PR DESCRIPTION
# Use browser default text size instead of forced small text
## Summary
Removed `text-sm` and `text-sm/6` Tailwind CSS classes from view templates and components to allow the browser to use its default text size instead of forcing small text.
## Changes
**Components:** Updated `email_field_component.html.erb` and `password_field_component.html.erb`
**Authentication views:** Updated registration edit form, shared links, alerts, and Google SSO components
**Navigation:** Updated menu, notice, and welcome banner components
**Subject views:** Updated all subject-related templates including lists, individual subject pages, planning views, and transcript import
**User management:** Updated passkey management interface