### PR TITLE
Agregar indices y claves foráneas faltantes

### DIFF
--- a/app/models/activity_prerequisite.rb
+++ b/app/models/activity_prerequisite.rb
@@ -20,3 +20,17 @@ end
 #  parent_prerequisite_id    :integer
 #  subject_group_id          :integer
 #
+# Indexes
+#
+#  index_prerequisites_on_approvable_id           (approvable_id)
+#  index_prerequisites_on_approvable_needed_id    (approvable_needed_id)
+#  index_prerequisites_on_parent_prerequisite_id  (parent_prerequisite_id)
+#  index_prerequisites_on_subject_group_id        (subject_group_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (approvable_id => approvables.id)
+#  fk_rails_...  (approvable_needed_id => approvables.id)
+#  fk_rails_...  (parent_prerequisite_id => prerequisites.id)
+#  fk_rails_...  (subject_group_id => subject_groups.id)
+#

--- a/app/models/activity_prerequisite.rb
+++ b/app/models/activity_prerequisite.rb
@@ -23,9 +23,7 @@ end
 # Indexes
 #
 #  index_prerequisites_on_approvable_id           (approvable_id)
-#  index_prerequisites_on_approvable_needed_id    (approvable_needed_id)
 #  index_prerequisites_on_parent_prerequisite_id  (parent_prerequisite_id)
-#  index_prerequisites_on_subject_group_id        (subject_group_id)
 #
 # Foreign Keys
 #

--- a/app/models/approvable.rb
+++ b/app/models/approvable.rb
@@ -27,3 +27,11 @@ end
 #  updated_at :datetime         not null
 #  subject_id :integer          not null
 #
+# Indexes
+#
+#  index_approvables_on_subject_id  (subject_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (subject_id => subjects.id)
+#

--- a/app/models/credits_prerequisite.rb
+++ b/app/models/credits_prerequisite.rb
@@ -25,3 +25,17 @@ end
 #  parent_prerequisite_id    :integer
 #  subject_group_id          :integer
 #
+# Indexes
+#
+#  index_prerequisites_on_approvable_id           (approvable_id)
+#  index_prerequisites_on_approvable_needed_id    (approvable_needed_id)
+#  index_prerequisites_on_parent_prerequisite_id  (parent_prerequisite_id)
+#  index_prerequisites_on_subject_group_id        (subject_group_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (approvable_id => approvables.id)
+#  fk_rails_...  (approvable_needed_id => approvables.id)
+#  fk_rails_...  (parent_prerequisite_id => prerequisites.id)
+#  fk_rails_...  (subject_group_id => subject_groups.id)
+#

--- a/app/models/credits_prerequisite.rb
+++ b/app/models/credits_prerequisite.rb
@@ -28,9 +28,7 @@ end
 # Indexes
 #
 #  index_prerequisites_on_approvable_id           (approvable_id)
-#  index_prerequisites_on_approvable_needed_id    (approvable_needed_id)
 #  index_prerequisites_on_parent_prerequisite_id  (parent_prerequisite_id)
-#  index_prerequisites_on_subject_group_id        (subject_group_id)
 #
 # Foreign Keys
 #

--- a/app/models/enrollment_prerequisite.rb
+++ b/app/models/enrollment_prerequisite.rb
@@ -20,3 +20,17 @@ end
 #  parent_prerequisite_id    :integer
 #  subject_group_id          :integer
 #
+# Indexes
+#
+#  index_prerequisites_on_approvable_id           (approvable_id)
+#  index_prerequisites_on_approvable_needed_id    (approvable_needed_id)
+#  index_prerequisites_on_parent_prerequisite_id  (parent_prerequisite_id)
+#  index_prerequisites_on_subject_group_id        (subject_group_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (approvable_id => approvables.id)
+#  fk_rails_...  (approvable_needed_id => approvables.id)
+#  fk_rails_...  (parent_prerequisite_id => prerequisites.id)
+#  fk_rails_...  (subject_group_id => subject_groups.id)
+#

--- a/app/models/enrollment_prerequisite.rb
+++ b/app/models/enrollment_prerequisite.rb
@@ -23,9 +23,7 @@ end
 # Indexes
 #
 #  index_prerequisites_on_approvable_id           (approvable_id)
-#  index_prerequisites_on_approvable_needed_id    (approvable_needed_id)
 #  index_prerequisites_on_parent_prerequisite_id  (parent_prerequisite_id)
-#  index_prerequisites_on_subject_group_id        (subject_group_id)
 #
 # Foreign Keys
 #

--- a/app/models/logical_prerequisite.rb
+++ b/app/models/logical_prerequisite.rb
@@ -51,9 +51,7 @@ end
 # Indexes
 #
 #  index_prerequisites_on_approvable_id           (approvable_id)
-#  index_prerequisites_on_approvable_needed_id    (approvable_needed_id)
 #  index_prerequisites_on_parent_prerequisite_id  (parent_prerequisite_id)
-#  index_prerequisites_on_subject_group_id        (subject_group_id)
 #
 # Foreign Keys
 #

--- a/app/models/logical_prerequisite.rb
+++ b/app/models/logical_prerequisite.rb
@@ -48,3 +48,17 @@ end
 #  parent_prerequisite_id    :integer
 #  subject_group_id          :integer
 #
+# Indexes
+#
+#  index_prerequisites_on_approvable_id           (approvable_id)
+#  index_prerequisites_on_approvable_needed_id    (approvable_needed_id)
+#  index_prerequisites_on_parent_prerequisite_id  (parent_prerequisite_id)
+#  index_prerequisites_on_subject_group_id        (subject_group_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (approvable_id => approvables.id)
+#  fk_rails_...  (approvable_needed_id => approvables.id)
+#  fk_rails_...  (parent_prerequisite_id => prerequisites.id)
+#  fk_rails_...  (subject_group_id => subject_groups.id)
+#

--- a/app/models/prerequisite.rb
+++ b/app/models/prerequisite.rb
@@ -21,3 +21,17 @@ end
 #  parent_prerequisite_id    :integer
 #  subject_group_id          :integer
 #
+# Indexes
+#
+#  index_prerequisites_on_approvable_id           (approvable_id)
+#  index_prerequisites_on_approvable_needed_id    (approvable_needed_id)
+#  index_prerequisites_on_parent_prerequisite_id  (parent_prerequisite_id)
+#  index_prerequisites_on_subject_group_id        (subject_group_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (approvable_id => approvables.id)
+#  fk_rails_...  (approvable_needed_id => approvables.id)
+#  fk_rails_...  (parent_prerequisite_id => prerequisites.id)
+#  fk_rails_...  (subject_group_id => subject_groups.id)
+#

--- a/app/models/prerequisite.rb
+++ b/app/models/prerequisite.rb
@@ -24,9 +24,7 @@ end
 # Indexes
 #
 #  index_prerequisites_on_approvable_id           (approvable_id)
-#  index_prerequisites_on_approvable_needed_id    (approvable_needed_id)
 #  index_prerequisites_on_parent_prerequisite_id  (parent_prerequisite_id)
-#  index_prerequisites_on_subject_group_id        (subject_group_id)
 #
 # Foreign Keys
 #

--- a/app/models/subject.rb
+++ b/app/models/subject.rb
@@ -85,8 +85,10 @@ end
 #
 #  index_subjects_on_degree_id           (degree_id)
 #  index_subjects_on_degree_id_and_code  (degree_id,code) UNIQUE
+#  index_subjects_on_group_id            (group_id)
 #
 # Foreign Keys
 #
 #  fk_rails_...  (degree_id => degrees.id)
+#  fk_rails_...  (group_id => subject_groups.id)
 #

--- a/app/models/subject_prerequisite.rb
+++ b/app/models/subject_prerequisite.rb
@@ -20,3 +20,17 @@ end
 #  parent_prerequisite_id    :integer
 #  subject_group_id          :integer
 #
+# Indexes
+#
+#  index_prerequisites_on_approvable_id           (approvable_id)
+#  index_prerequisites_on_approvable_needed_id    (approvable_needed_id)
+#  index_prerequisites_on_parent_prerequisite_id  (parent_prerequisite_id)
+#  index_prerequisites_on_subject_group_id        (subject_group_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (approvable_id => approvables.id)
+#  fk_rails_...  (approvable_needed_id => approvables.id)
+#  fk_rails_...  (parent_prerequisite_id => prerequisites.id)
+#  fk_rails_...  (subject_group_id => subject_groups.id)
+#

--- a/app/models/subject_prerequisite.rb
+++ b/app/models/subject_prerequisite.rb
@@ -23,9 +23,7 @@ end
 # Indexes
 #
 #  index_prerequisites_on_approvable_id           (approvable_id)
-#  index_prerequisites_on_approvable_needed_id    (approvable_needed_id)
 #  index_prerequisites_on_parent_prerequisite_id  (parent_prerequisite_id)
-#  index_prerequisites_on_subject_group_id        (subject_group_id)
 #
 # Foreign Keys
 #

--- a/db/migrate/20250620202619_add_missing_foreign_keys_to_approvable.rb
+++ b/db/migrate/20250620202619_add_missing_foreign_keys_to_approvable.rb
@@ -1,0 +1,6 @@
+class AddMissingForeignKeysToApprovable < ActiveRecord::Migration[8.0]
+  def change
+    add_foreign_key :approvables, :subjects
+    add_index :approvables, :subject_id
+  end
+end

--- a/db/migrate/20250620203334_add_fk_to_prerequisite.rb
+++ b/db/migrate/20250620203334_add_fk_to_prerequisite.rb
@@ -1,0 +1,13 @@
+class AddFkToPrerequisite < ActiveRecord::Migration[8.0]
+  def change
+    add_foreign_key :prerequisites, :prerequisites, column: :parent_prerequisite_id
+    add_foreign_key :prerequisites, :approvables
+    add_foreign_key :prerequisites, :approvables, column: :approvable_needed_id
+    add_foreign_key :prerequisites, :subject_groups
+
+    add_index :prerequisites, :parent_prerequisite_id
+    add_index :prerequisites, :approvable_id
+    add_index :prerequisites, :approvable_needed_id
+    add_index :prerequisites, :subject_group_id
+  end
+end

--- a/db/migrate/20250620203334_add_fk_to_prerequisite.rb
+++ b/db/migrate/20250620203334_add_fk_to_prerequisite.rb
@@ -7,7 +7,5 @@ class AddFkToPrerequisite < ActiveRecord::Migration[8.0]
 
     add_index :prerequisites, :parent_prerequisite_id
     add_index :prerequisites, :approvable_id
-    add_index :prerequisites, :approvable_needed_id
-    add_index :prerequisites, :subject_group_id
   end
 end

--- a/db/migrate/20250620203849_add_fk_and_index_to_subject.rb
+++ b/db/migrate/20250620203849_add_fk_and_index_to_subject.rb
@@ -1,0 +1,7 @@
+class AddFkAndIndexToSubject < ActiveRecord::Migration[8.0]
+  def change
+    add_foreign_key :subjects, :subject_groups, column: :group_id
+
+    add_index :subjects, :group_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_06_13_175743) do
+ActiveRecord::Schema[8.0].define(version: 2025_06_20_202619) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "unaccent"
@@ -20,6 +20,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_06_13_175743) do
     t.boolean "is_exam", null: false
     t.datetime "created_at", precision: nil, null: false
     t.datetime "updated_at", precision: nil, null: false
+    t.index ["subject_id"], name: "index_approvables_on_subject_id"
   end
 
   create_table "degrees", id: :string, force: :cascade do |t|
@@ -122,6 +123,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_06_13_175743) do
     t.index ["unlock_token"], name: "index_users_on_unlock_token", unique: true
   end
 
+  add_foreign_key "approvables", "subjects"
   add_foreign_key "passkeys", "users"
   add_foreign_key "reviews", "subjects"
   add_foreign_key "reviews", "users"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -52,9 +52,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_06_20_203849) do
     t.integer "approvable_needed_id"
     t.integer "amount_of_subjects_needed"
     t.index ["approvable_id"], name: "index_prerequisites_on_approvable_id"
-    t.index ["approvable_needed_id"], name: "index_prerequisites_on_approvable_needed_id"
     t.index ["parent_prerequisite_id"], name: "index_prerequisites_on_parent_prerequisite_id"
-    t.index ["subject_group_id"], name: "index_prerequisites_on_subject_group_id"
   end
 
   create_table "reviews", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_06_20_202619) do
+ActiveRecord::Schema[8.0].define(version: 2025_06_20_203334) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "unaccent"
@@ -51,6 +51,10 @@ ActiveRecord::Schema[8.0].define(version: 2025_06_20_202619) do
     t.integer "subject_group_id"
     t.integer "approvable_needed_id"
     t.integer "amount_of_subjects_needed"
+    t.index ["approvable_id"], name: "index_prerequisites_on_approvable_id"
+    t.index ["approvable_needed_id"], name: "index_prerequisites_on_approvable_needed_id"
+    t.index ["parent_prerequisite_id"], name: "index_prerequisites_on_parent_prerequisite_id"
+    t.index ["subject_group_id"], name: "index_prerequisites_on_subject_group_id"
   end
 
   create_table "reviews", force: :cascade do |t|
@@ -125,6 +129,10 @@ ActiveRecord::Schema[8.0].define(version: 2025_06_20_202619) do
 
   add_foreign_key "approvables", "subjects"
   add_foreign_key "passkeys", "users"
+  add_foreign_key "prerequisites", "approvables"
+  add_foreign_key "prerequisites", "approvables", column: "approvable_needed_id"
+  add_foreign_key "prerequisites", "prerequisites", column: "parent_prerequisite_id"
+  add_foreign_key "prerequisites", "subject_groups"
   add_foreign_key "reviews", "subjects"
   add_foreign_key "reviews", "users"
   add_foreign_key "subject_groups", "degrees"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_06_20_203334) do
+ActiveRecord::Schema[8.0].define(version: 2025_06_20_203849) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "unaccent"
@@ -102,6 +102,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_06_20_203334) do
     t.string "degree_id", null: false
     t.index ["degree_id", "code"], name: "index_subjects_on_degree_id_and_code", unique: true
     t.index ["degree_id"], name: "index_subjects_on_degree_id"
+    t.index ["group_id"], name: "index_subjects_on_group_id"
   end
 
   create_table "users", force: :cascade do |t|
@@ -139,5 +140,6 @@ ActiveRecord::Schema[8.0].define(version: 2025_06_20_203334) do
   add_foreign_key "subject_plans", "subjects"
   add_foreign_key "subject_plans", "users"
   add_foreign_key "subjects", "degrees"
+  add_foreign_key "subjects", "subject_groups", column: "group_id"
   add_foreign_key "users", "degrees"
 end

--- a/spec/services/tree_preloader_spec.rb
+++ b/spec/services/tree_preloader_spec.rb
@@ -9,9 +9,9 @@ RSpec.describe TreePreloader do
 
       subjects = described_class.new(Subject).preload.sort_by(&:name)
 
-      Subject.destroy_all
-      Approvable.destroy_all
       Prerequisite.destroy_all
+      Approvable.destroy_all
+      Subject.destroy_all
 
       # check all entities are destroyed
       expect(Subject.count).to eq(0)


### PR DESCRIPTION
### Resumen
Por cada asociación que tenemos, agregue una clave foránea y un índice por las cuales accedemos.

### Por qué?
Al agregar la gema anotate y pasar por los modelos vi que faltaban varios indices y foráneas. 

Esto va a validar que se pongan valores correctos y si hacemos búsquedas por las asociaciones que sean rápidas.