### PR TITLE
Arreglar padding cuando tabeamos el icono de mostrar contraseña

### DIFF
--- a/app/components/password_field_component.rb
+++ b/app/components/password_field_component.rb
@@ -25,6 +25,8 @@ class PasswordFieldComponent < ViewComponent::Base
       right-0
       px-3
 
+      focus:outline-indigo-600
+
       cursor-pointer
       hover:text-indigo-700
     ]

--- a/app/components/password_field_component.rb
+++ b/app/components/password_field_component.rb
@@ -23,7 +23,7 @@ class PasswordFieldComponent < ViewComponent::Base
       absolute
       inset-y-0
       right-0
-      pr-3
+      px-3
 
       cursor-pointer
       hover:text-indigo-700


### PR DESCRIPTION
#### Antes
<img width="480" alt="image" src="https://github.com/user-attachments/assets/40b03780-d24a-4f2a-96cf-8cab792ca39b" />


#### Después
<img width="472" alt="image" src="https://github.com/user-attachments/assets/227764aa-6c7b-4980-90ac-a15a0994a093" />

