### PR TITLE
Change `webauthn_id` type in `users` [take 1]

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -13,10 +13,6 @@ class User < ApplicationRecord
   has_many :degree_subject_groups, through: :degree, source: :subject_groups
   has_many :passkeys, dependent: :destroy
 
-  after_initialize do
-    self.webauthn_id ||= WebAuthn.generate_user_id
-  end
-
   def self.from_omniauth(auth, cookie)
     # check that user with same email exists
     existing_user = User.find_by(email: auth.info.email)

--- a/spec/system/manage_passkeys_spec.rb
+++ b/spec/system/manage_passkeys_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.describe 'Manage passkeys' do
   before do
-    sign_in create(:user)
+    sign_in create(:user, webauthn_id: "a1b2c3d4e5f6g7h8")
   end
 
   ENV['ENABLE_PASSKEYS'] = 'true'


### PR DESCRIPTION
- Se removió la llamada a WebAuthn para inicializar el atributo `webauthn_id` de los nuevos users

**Aclaración**: se agregó `webauthn_id` en el test de sistema de manera temporal hasta que se realice el PR que agrega el default a este campo.