### PR TITLE
[Plnificador] Remover el texto `'Planificar` de la sección para añadir materias a los semestres

### DIFF
--- a/app/javascript/controllers/subject_selector_controller.js
+++ b/app/javascript/controllers/subject_selector_controller.js
@@ -8,13 +8,13 @@ export default class extends Controller {
     this.choices = new Choices(this.selectTarget, {
       searchEnabled: true,
       searchPlaceholderValue: "Buscar materia...",
-      placeholderValue: "Seleccionar materia...",
+      placeholderValue: "Seleccionar materia para planificar...",
       itemSelectText: "",
       noResultsText: "No se encontraron materias",
       noChoicesText: "No hay materias disponibles",
       shouldSort: false,
       classNames: {
-        containerOuter: ["choices", "!m-0", "!h-10"],
+        containerOuter: ["choices", "!m-0", "!h-10", "flex-grow-1"],
         containerInner: [
           "choices__inner",
           "!min-h-10",

--- a/app/views/subject_plans/_semester_add_subject_form.html.erb
+++ b/app/views/subject_plans/_semester_add_subject_form.html.erb
@@ -6,9 +6,6 @@
   data: { turbo: true, controller: "subject-selector" },
   class: 'flex items-center gap-3 px-4 py-3 hover:bg-gray-100 border-t border-gray-100'
 ) do |form| %>
-  <span class="grow text-sm/6 text-gray-900">
-    Planificar:
-  </span>
   <%= form.select(
     :subject_id,
     grouped_options_for_select(


### PR DESCRIPTION
### Motivación

Surge a partir de la discusión en https://github.com/cedarcode/mi_carrera/pull/848#issuecomment-3025204123.

### Screenshot

<img width="374" alt="image" src="https://github.com/user-attachments/assets/4ddc30dd-586e-4f4d-bbb6-f2aae0ec5e93" />
