### PR TITLE
Arreglar `db/schema.rb`

### DIFF
--- a/db/schema.rb
+++ b/db/schema.rb
@@ -13,6 +13,7 @@
 ActiveRecord::Schema[8.0].define(version: 2025_06_27_211639) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
+  enable_extension "pgcrypto"
   enable_extension "unaccent"
 
   create_table "approvables", force: :cascade do |t|


### PR DESCRIPTION
## Motivación

Me estaba dando un error correr las migraciones

```
PG::UndefinedFunction: ERROR:  function gen_random_uuid() does not exist
HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
)
Caused by: ActiveRecord::StatementInvalid (PG::UndefinedFunction: ERROR:  function gen_random_uuid() does not exist
HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
)
```

Lo pude arreglar haciendo:

```
psql -c '\x' -c 'CREATE EXTENSION IF NOT EXISTS pgcrypto CASCADE;' -U santiago_rodriguez -d mi_carrera_development
```

Lo que me permitió correr las migraciones. Sin embargo, después de correrlas, se me generaron estos cambios en nuestro `db/schema.rb`.