### PR TITLE
Agregar 'aproximacion' a la lista de typos

### DIFF
--- a/lib/typos_list.yml
+++ b/lib/typos_list.yml
@@ -4,6 +4,7 @@ adquisicion: adquisición
 algebra: álgebra
 analisis: análisis
 analitica: analítica
+aproximacion: aproximación
 automatas: autómatas
 automatico: automático
 basicos: básicos


### PR DESCRIPTION
## Motivación

Los cambios mergeados en #859 generaron un typo en la materia `Algoritmos de aproximación` – [ahora le falta el tilde en 'aproximación'.](https://github.com/cedarcode/mi_carrera/pull/859/files#diff-afe4081773d5198bca9eff7ea3d03d81c1ce34dfb7c8f04fbfa7b49c122d179bR1444)

## Detalles

Para arreglarlo simplemente hay que añadir `aproximacion` a la lista de typos