### PR TITLE
Always render not planned subjects wrapper

### DIFF
--- a/app/controllers/subject_plans_controller.rb
+++ b/app/controllers/subject_plans_controller.rb
@@ -31,13 +31,11 @@ class SubjectPlansController < ApplicationController
   def destroy
     subject_plan = current_user.subject_plans.find_by!(subject_id: params[:subject_id])
     @semesters_to_refresh = [subject_plan.semester]
-    subject = subject_plan.subject
     subject_plan.destroy!
 
     set_planned_and_not_planned_subjects
 
     @reload_not_planned_approved_subjects = true
-    @not_planned_approved_subjects_was_empty = @not_planned_approved_subjects == [subject]
 
     render :update
   end

--- a/app/views/subject_plans/update.turbo_stream.erb
+++ b/app/views/subject_plans/update.turbo_stream.erb
@@ -3,14 +3,8 @@
 <% end %>
 
 <% if @reload_not_planned_approved_subjects %>
-  <% if @not_planned_approved_subjects_was_empty %>
-    <%= turbo_stream.before "semester-1" do %>
-      <%= render "subjects/not_planned_subjects_list", subjects: @not_planned_approved_subjects %>
-    <% end %>
-  <% else %>
-    <%= turbo_stream.replace "not-planned-subjects", method: :morph do %>
-      <%= render "subjects/not_planned_subjects_list", subjects: @not_planned_approved_subjects %>
-    <% end %>
+  <%= turbo_stream.replace "not-planned-subjects", method: :morph do %>
+    <%= render "subjects/not_planned_subjects_list", subjects: @not_planned_approved_subjects %>
   <% end %>
 <% end %>
 

--- a/app/views/subjects/_not_planned_subjects_list.html.erb
+++ b/app/views/subjects/_not_planned_subjects_list.html.erb
@@ -1,19 +1,21 @@
-<% if subjects.any? %>
-  <div id="not-planned-subjects" data-controller="collapsible" class="bg-white rounded-lg border border-gray-100 shadow-sm">
-    <a data-action="click->collapsible#toggle" class="flex items-center h-10 px-4 bg-gray-50 rounded-lg cursor-pointer">
-      <span class="material-icons pr-2" data-collapsible-target="button" data-turbo-permanent>chevron_right</span>
-      <span class="flex-1 text-sm font-bold"><%= subjects.size %> Materias aprobadas sin semestre asignado</span>
-    </a>
+<div id="not-planned-subjects">
+  <% if subjects.any? %>
+    <div data-controller="collapsible" class="bg-white rounded-lg border border-gray-100 shadow-sm">
+      <a data-action="click->collapsible#toggle" class="flex items-center h-10 px-4 bg-gray-50 rounded-lg cursor-pointer">
+        <span class="material-icons pr-2" data-collapsible-target="button" data-turbo-permanent>chevron_right</span>
+        <span class="flex-1 text-sm font-bold"><%= subjects.size %> Materias aprobadas sin semestre asignado</span>
+      </a>
 
-    <ul class="hidden" data-collapsible-target="collapsible" data-planner-draggable-target="notPlannedApprovedSubjectsList" data-action="turbo:before-morph-attribute->collapsible#preventToggle">
-      <% subjects.each do |subject| %>
-        <li class="relative flex items-center gap-3 px-4 py-3 bg-white hover:bg-gray-100 h-[64px]" data-planner-draggable-url="<%= subject_plans_path %>" data-planner-draggable-method="post" data-planner-draggable-subject-id="<%= subject.id %>">
-          <span class="material-icons text-gray-400 cursor-pointer" data-planner-draggable-handle> drag_handle </span>
+      <ul class="hidden" data-collapsible-target="collapsible" data-planner-draggable-target="notPlannedApprovedSubjectsList" data-action="turbo:before-morph-attribute->collapsible#preventToggle">
+        <% subjects.each do |subject| %>
+          <li class="relative flex items-center gap-3 px-4 py-3 bg-white hover:bg-gray-100 h-[64px]" data-planner-draggable-url="<%= subject_plans_path %>" data-planner-draggable-method="post" data-planner-draggable-subject-id="<%= subject.id %>">
+            <span class="material-icons text-gray-400 cursor-pointer" data-planner-draggable-handle> drag_handle </span>
 
-          <%= link_to display_name(subject), subject, class: "grow text-sm/6 text-gray-900" %>
-          <%= material_icon("check", "text-green-500") %>
-        </li>
-      <% end %>
-    </ul>
-  </div>
-<% end %>
+            <%= link_to display_name(subject), subject, class: "grow text-sm/6 text-gray-900" %>
+            <%= material_icon("check", "text-green-500") %>
+          </li>
+        <% end %>
+      </ul>
+    </div>
+  <% end %>
+</div>


### PR DESCRIPTION
Siempre renderizar el `<div id="not-planned-subjects">` así podemos remplazarlo siempre en el update (independientemente de si había materias no planeadas o no)