### PR TITLE
Borrar feature flag del planificador

### DIFF
--- a/app/controllers/subject_plans_controller.rb
+++ b/app/controllers/subject_plans_controller.rb
@@ -1,6 +1,5 @@
 class SubjectPlansController < ApplicationController
   before_action :authenticate_user!
-  before_action :ensure_feature_enabled!
 
   def index
     set_planned_and_not_planned_subjects
@@ -44,10 +43,6 @@ class SubjectPlansController < ApplicationController
   end
 
   private
-
-  def ensure_feature_enabled!
-    redirect_to root_path if ENV['ENABLE_PLANNER'].blank?
-  end
 
   def set_planned_and_not_planned_subjects
     @planned_subjects =

--- a/app/views/shared/_menu.html.erb
+++ b/app/views/shared/_menu.html.erb
@@ -7,9 +7,7 @@
 
   <%= drawer_menu_navigation_item "Materias INCO semestre actual", current_optional_subjects_path %>
 
-  <% if ENV['ENABLE_PLANNER'].present? %>
-    <%= drawer_menu_navigation_item "Planificador", subject_plans_path, new_badge: true %>
-  <% end %>
+  <%= drawer_menu_navigation_item "Planificador", subject_plans_path, new_badge: true %>
 
   <hr class="text-gray-200"/>
 

--- a/config/deploy.staging.yml
+++ b/config/deploy.staging.yml
@@ -15,5 +15,4 @@ env:
   clear:
     ROLLBAR_ENV: staging
     APPSIGNAL_APP_ENV: staging
-    ENABLE_PLANNER: true
     ENABLE_PASSKEYS: true

--- a/spec/system/planned_subjects_spec.rb
+++ b/spec/system/planned_subjects_spec.rb
@@ -20,12 +20,6 @@ RSpec.describe "PlannedSubjects", type: :system do
     sign_in user
   end
 
-  around do |example|
-    ENV['ENABLE_PLANNER'] = 'true'
-    example.run
-    ENV.delete('ENABLE_PLANNER')
-  end
-
   it "can add and remove subjects to planner" do
     visit subject_plans_path
 


### PR DESCRIPTION
## Motivación

Sentimos que el planificador está en un lugar bastante potable, por lo que tiene sentido sacar la flag para que la gente lo empieze a usar