### PR TITLE
[Planner] Añadir indicador de que la página está cargando

### DIFF
--- a/app/javascript/controllers/planner_draggable_controller.js
+++ b/app/javascript/controllers/planner_draggable_controller.js
@@ -4,6 +4,7 @@ import { FetchRequest } from '@rails/request.js';
 
 export default class extends Controller {
   static targets = ['semesterSubjectsList', 'notPlannedApprovedSubjectsList'];
+  static outlets = ['planner-loading']
 
   connect() {
     this.semesterSubjectsListTargets.forEach((list) => {
@@ -28,6 +29,8 @@ export default class extends Controller {
 
   async onEnd(event) {
     if (event.from === event.to) { return; }
+
+    this.plannerLoadingOutlet.start();
 
     const url = event.item.dataset.plannerDraggableUrl;
     const method = event.item.dataset.plannerDraggableMethod;

--- a/app/javascript/controllers/planner_loading_controller.js
+++ b/app/javascript/controllers/planner_loading_controller.js
@@ -1,0 +1,13 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  start() {
+    var foregroundLayer = document.createElement("div");
+    foregroundLayer.classList.add("bg-gray-300", "min-h-full", "w-full", "absolute", "top-0", "opacity-40");
+    foregroundLayer.setAttribute("id", "foreground-layer");;
+    foregroundLayer.addEventListener("click", function(event) {
+      event.preventDefault();
+    });
+    this.element.append(foregroundLayer);
+  }
+}

--- a/app/views/subject_plans/index.html.erb
+++ b/app/views/subject_plans/index.html.erb
@@ -8,7 +8,7 @@
       message: 'Bienvenido a tu planificador de materias: arrastra, suelta y organiza tu semestre' %>
 <% end %>
 
-<div class="my-3 space-y-4" data-controller="planner-loading">
+<div id="planner" class="my-3 space-y-4" data-controller="planner-loading">
   <div class="flex items-center justify-between h-10 mb-3">
     <h3 class="text-lg font-bold ml-4">
       Planificador

--- a/app/views/subject_plans/index.html.erb
+++ b/app/views/subject_plans/index.html.erb
@@ -8,7 +8,7 @@
       message: 'Bienvenido a tu planificador de materias: arrastra, suelta y organiza tu semestre' %>
 <% end %>
 
-<div id="planner" class="my-3 space-y-4" data-controller="planner-loading">
+<div id="planner" class="relative pt-3 space-y-4" data-controller="planner-loading">
   <div class="flex items-center justify-between h-10 mb-3">
     <h3 class="text-lg font-bold ml-4">
       Planificador

--- a/app/views/subject_plans/index.html.erb
+++ b/app/views/subject_plans/index.html.erb
@@ -8,7 +8,7 @@
       message: 'Bienvenido a tu planificador de materias: arrastra, suelta y organiza tu semestre' %>
 <% end %>
 
-<div class="my-3 space-y-4">
+<div class="my-3 space-y-4" data-controller="planner-loading">
   <div class="flex items-center justify-between h-10 mb-3">
     <h3 class="text-lg font-bold ml-4">
       Planificador

--- a/app/views/subject_plans/semester_card/_add_subject_form.html.erb
+++ b/app/views/subject_plans/semester_card/_add_subject_form.html.erb
@@ -17,7 +17,7 @@
     { data: { subject_selector_target: "select", action: "subject-selector#onChange" }, class: "invisible absolute" }
   ) %>
   <%= form.hidden_field :semester, value: semester %>
-  <%= form.button type: :submit, class: "cursor-pointer py-2 ps-3 material-icons text-gray-400 disabled:opacity-50 disabled:cursor-not-allowed", disabled: true, data: { subject_selector_target: "submitButton" } do %>
+  <%= form.button type: :submit, class: "cursor-pointer py-2 ps-3 material-icons text-gray-400 disabled:opacity-50 disabled:cursor-not-allowed", disabled: true, data: { subject_selector_target: "submitButton", action: "planner-loading#start" } do %>
       add_circle_outline
   <% end %>
 <% end %>

--- a/app/views/subject_plans/semester_card/_subjects_list.html.erb
+++ b/app/views/subject_plans/semester_card/_subjects_list.html.erb
@@ -16,7 +16,7 @@
           <%= material_icon("lock_outline", "text-gray-400") %>
         <% end %>
 
-        <%= button_to subject_plan_path(subject_id: subject.id), method: :delete, class: "cursor-pointer py-2 ps-3 material-icons text-gray-400", form: { data: { turbo: true } } do %>
+        <%= button_to subject_plan_path(subject_id: subject.id), method: :delete, class: "cursor-pointer py-2 ps-3 material-icons text-gray-400", form: { data: { turbo: true } }, data: { action: "planner-loading#start" } do %>
           remove_circle_outline
         <% end %>
       </li>

--- a/app/views/subject_plans/update.turbo_stream.erb
+++ b/app/views/subject_plans/update.turbo_stream.erb
@@ -25,3 +25,5 @@
     <%= render 'subject_plans/semester_card/add_subject_form', semester:, not_planned_subjects: @not_planned_subjects %>
   <% end %>
 <% end %>
+
+<%= turbo_stream.remove "foreground-layer" %>

--- a/app/views/subjects/_planned_subjects_list.html.erb
+++ b/app/views/subjects/_planned_subjects_list.html.erb
@@ -1,4 +1,4 @@
-<div data-controller="planner-draggable">
+<div data-controller="planner-draggable" data-planner-draggable-planner-loading-outlet="#planner">
   <%= render partial: "subjects/not_planned_subjects_list", locals: { subjects: @not_planned_approved_subjects } %>
 
   <% (1..10).each do |semester| %>


### PR DESCRIPTION
## Motivación

Cuando añadís o removes materias o las cambiás de semestre, no queda tan claro de que hay algo que está cargando por abajo y pareciera que se pudiera seguir usando la app, cuando de repente se actualizan los semestres porque se completó el request. 

La idea es darles a los usuarios una forma clara de entender que la página está cargando.

## Detalles

Este PR agrega funcionalidad para que al agregar, remover o mover una materia en el planificador, apareza un 'foreground layer' para indicarles a los usuarios de que la página está cargando.

Quizás no es la mejor solución, pero es una solución simple que puede andar bien por ahora mientras pensamos en algo más sofisticado.