### PR TITLE
Fix: Add safe navigation WebAuthn

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -83,6 +83,6 @@ Rails.application.configure do
   # Skip DNS rebinding protection for the default health check endpoint.
   # config.host_authorization = { exclude: ->(request) { request.path == "/up" } }
 
-  config.webauthn_origin = ENV.fetch('WEBAUTHN_ORIGIN').split(',')
+  config.webauthn_origin = ENV['WEBAUTHN_ORIGIN']&.split(',')
   config.webauthn_rp_id = ENV['WEBAUTHN_RP_ID']
 end


### PR DESCRIPTION
- Add safe navigation when accessing `allowed_origins` in WebAuthn configuration