### PR TITLE
Mejorar performance usando `.approved_subjects`

### DIFF
--- a/app/controllers/planner/not_planned_subjects_controller.rb
+++ b/app/controllers/planner/not_planned_subjects_controller.rb
@@ -29,10 +29,10 @@ module Planner
           current_degree
             .subjects
             .where.not(id: current_user.planned_subjects)
+            .where.not(id: current_student.approved_subjects)
             .ordered_by_category
             .ordered_by_short_or_full_name
         )
-        .reject { |subject| current_student.approved?(subject) }
     end
   end
 end

--- a/app/controllers/subject_plans_controller.rb
+++ b/app/controllers/subject_plans_controller.rb
@@ -47,15 +47,11 @@ class SubjectPlansController < ApplicationController
       TreePreloader.preload(current_user.planned_subjects.select('subjects.*', 'subject_plans.semester')
         .order('subject_plans.semester'))
 
-    @not_planned_approved_subjects = not_planned_approved_subjects
-  end
-
-  def not_planned_approved_subjects
-    current_student
-      .approved_subjects
-      .where.not(id: current_user.planned_subjects)
-      .ordered_by_category
-      .ordered_by_short_or_full_name
+    @not_planned_approved_subjects = current_student
+                                     .approved_subjects
+                                     .where.not(id: @planned_subjects)
+                                     .ordered_by_category
+                                     .ordered_by_short_or_full_name
   end
 
   def subject_plan_params

--- a/app/controllers/subject_plans_controller.rb
+++ b/app/controllers/subject_plans_controller.rb
@@ -47,21 +47,15 @@ class SubjectPlansController < ApplicationController
       TreePreloader.preload(current_user.planned_subjects.select('subjects.*', 'subject_plans.semester')
         .order('subject_plans.semester'))
 
-    @not_planned_approved_subjects =
-      not_planned_subjects.select { |subject|
-        current_student.approved?(subject)
-      }
+    @not_planned_approved_subjects = not_planned_approved_subjects
   end
 
-  def not_planned_subjects
-    TreePreloader
-      .preload(
-        current_degree
-          .subjects
-          .where.not(id: current_user.planned_subjects)
-          .ordered_by_category
-          .ordered_by_short_or_full_name
-      )
+  def not_planned_approved_subjects
+    current_student
+      .approved_subjects
+      .where.not(id: current_user.planned_subjects)
+      .ordered_by_category
+      .ordered_by_short_or_full_name
   end
 
   def subject_plan_params

--- a/app/controllers/subject_plans_controller.rb
+++ b/app/controllers/subject_plans_controller.rb
@@ -52,6 +52,7 @@ class SubjectPlansController < ApplicationController
                                      .where.not(id: @planned_subjects)
                                      .ordered_by_category
                                      .ordered_by_short_or_full_name
+                                     .to_a
   end
 
   def subject_plan_params

--- a/app/controllers/subject_plans_controller.rb
+++ b/app/controllers/subject_plans_controller.rb
@@ -52,7 +52,7 @@ class SubjectPlansController < ApplicationController
                                      .where.not(id: @planned_subjects)
                                      .ordered_by_category
                                      .ordered_by_short_or_full_name
-                                     .to_a
+                                     .load
   end
 
   def subject_plan_params

--- a/app/models/base_student.rb
+++ b/app/models/base_student.rb
@@ -35,7 +35,7 @@ class BaseStudent
   def graduated? = total_credits >= 450 && groups_credits_met?
   def banner_viewed?(_) = raise NoMethodError
   def mark_banner_as_viewed!(_) = raise NoMethodError
-  def approved_subjects = Subject.approved_with(ids)
+  def approved_subjects = Subject.approved_for(ids)
 
   private
 

--- a/app/models/base_student.rb
+++ b/app/models/base_student.rb
@@ -35,7 +35,7 @@ class BaseStudent
   def graduated? = total_credits >= 450 && groups_credits_met?
   def banner_viewed?(_) = raise NoMethodError
   def mark_banner_as_viewed!(_) = raise NoMethodError
-  def approved_subjects = Subject.approved_for(ids)
+  def approved_subjects = degree.subjects.approved_for(ids)
 
   private
 

--- a/app/models/base_student.rb
+++ b/app/models/base_student.rb
@@ -35,6 +35,7 @@ class BaseStudent
   def graduated? = total_credits >= 450 && groups_credits_met?
   def banner_viewed?(_) = raise NoMethodError
   def mark_banner_as_viewed!(_) = raise NoMethodError
+  def approved_subjects = Subject.approved_with(ids)
 
   private
 

--- a/app/models/subject.rb
+++ b/app/models/subject.rb
@@ -40,14 +40,14 @@ class Subject < ApplicationRecord
   scope :ordered_by_short_or_full_name, -> { order(Arel.sql('unaccent(COALESCE(short_name, name))')) }
   scope :ordered_by_category_and_name, -> { ordered_by_category.order(:name) }
   scope :current_semester_optionals, -> { where(current_optional_subject: true) }
-  scope :approved_with, ->(approved_approvable_ids) {
+  scope :approved_for, ->(approved_approvable_ids) {
     without_exam.where(course: { id: approved_approvable_ids }).or(
       with_exam.where(exam: { id: approved_approvable_ids })
     )
   }
 
   def self.approved_credits(approved_approvable_ids)
-    approved_with(approved_approvable_ids).sum(:credits)
+    approved_for(approved_approvable_ids).sum(:credits)
   end
 
   def approved?(approved_approvable_ids)

--- a/app/models/subject.rb
+++ b/app/models/subject.rb
@@ -40,11 +40,14 @@ class Subject < ApplicationRecord
   scope :ordered_by_short_or_full_name, -> { order(Arel.sql('unaccent(COALESCE(short_name, name))')) }
   scope :ordered_by_category_and_name, -> { ordered_by_category.order(:name) }
   scope :current_semester_optionals, -> { where(current_optional_subject: true) }
-
-  def self.approved_credits(approved_approvable_ids)
+  scope :approved_with, ->(approved_approvable_ids) {
     without_exam.where(course: { id: approved_approvable_ids }).or(
       with_exam.where(exam: { id: approved_approvable_ids })
-    ).sum(:credits)
+    )
+  }
+
+  def self.approved_credits(approved_approvable_ids)
+    approved_with(approved_approvable_ids).sum(:credits)
   end
 
   def approved?(approved_approvable_ids)

--- a/spec/models/cookie_student_spec.rb
+++ b/spec/models/cookie_student_spec.rb
@@ -229,4 +229,15 @@ RSpec.describe CookieStudent, type: :model do
       expect(student.degree).to eq(Degree.default)
     end
   end
+
+  describe "#approved_subjects" do
+    it "returns approved subjects for the student" do
+      subject1 = create(:subject, :with_exam)
+      subject2 = create(:subject, :with_exam)
+      cookies = build(:cookie, approved_approvable_ids: [subject1.course.id, subject2.exam.id])
+      student = build(:cookie_student, cookies:)
+
+      expect(student.approved_subjects).to contain_exactly(subject2)
+    end
+  end
 end

--- a/spec/models/subject_spec.rb
+++ b/spec/models/subject_spec.rb
@@ -196,4 +196,25 @@ RSpec.describe Subject, type: :model do
       expect(Subject.current_semester_optionals).to eq([s1])
     end
   end
+
+  describe ".approved_with" do
+    context "when the subject doesn't have an exam" do
+      it "returns it if the course is is in the param" do
+        subject = create(:subject, name: "Subject 1")
+
+        expect(Subject.approved_with([subject.course.id])).to include(subject)
+        expect(Subject.approved_with([])).to be_empty
+      end
+    end
+
+    context "when the subject has an exam" do
+      it "returns it if the exam are in the param" do
+        subject = create(:subject, :with_exam, name: "Subject 2")
+
+        expect(Subject.approved_with([subject.exam.id])).to include(subject)
+        expect(Subject.approved_with([subject.course.id])).to be_empty
+        expect(Subject.approved_with([])).to be_empty
+      end
+    end
+  end
 end

--- a/spec/models/subject_spec.rb
+++ b/spec/models/subject_spec.rb
@@ -197,13 +197,13 @@ RSpec.describe Subject, type: :model do
     end
   end
 
-  describe ".approved_with" do
+  describe ".approved_for" do
     context "when the subject doesn't have an exam" do
       it "returns it if the course is is in the param" do
         subject = create(:subject, name: "Subject 1")
 
-        expect(Subject.approved_with([subject.course.id])).to include(subject)
-        expect(Subject.approved_with([])).to be_empty
+        expect(Subject.approved_for([subject.course.id])).to include(subject)
+        expect(Subject.approved_for([])).to be_empty
       end
     end
 
@@ -211,9 +211,9 @@ RSpec.describe Subject, type: :model do
       it "returns it if the exam are in the param" do
         subject = create(:subject, :with_exam, name: "Subject 2")
 
-        expect(Subject.approved_with([subject.exam.id])).to include(subject)
-        expect(Subject.approved_with([subject.course.id])).to be_empty
-        expect(Subject.approved_with([])).to be_empty
+        expect(Subject.approved_for([subject.exam.id])).to include(subject)
+        expect(Subject.approved_for([subject.course.id])).to be_empty
+        expect(Subject.approved_for([])).to be_empty
       end
     end
   end

--- a/spec/models/user_student_spec.rb
+++ b/spec/models/user_student_spec.rb
@@ -260,4 +260,17 @@ RSpec.describe UserStudent, type: :model do
       expect { student.mark_banner_as_viewed!('invalid') }.to raise_error(NoMethodError)
     end
   end
+
+  describe "#approved_subjects" do
+    let(:user) { create :user }
+    let(:student) { described_class.new(user) }
+
+    it 'returns approved subjects for the user' do
+      subject1 = create(:subject, :with_exam)
+      subject2 = create(:subject, :with_exam)
+      user.approvals = [subject1.course.id, subject2.exam.id]
+
+      expect(student.approved_subjects).to contain_exactly(subject2)
+    end
+  end
 end


### PR DESCRIPTION
### Resumen
* Agregar scope `approved_with` en Subject que devuelve las subjects dado un arreglo de approvable ids
* Agregar un metodo nuevo al base student `.approved_subjects` que te da las subjects aprobadas en funcion del array de approvable ids del user
* Usar este método para cargar las subjects en el planner en lugar de preguntar en cada una si el user la tiene aprobada.

### Por que?
Vemos que la performance tiene bastante para mejorar y este es un punto en donde estamos gastando bastante tiempo de forma innecesaria. Se pueden obtener todas de una con una query. Probando localmente, el planner pasa de demorar ~889ms a ~372ms al cargar la pagina.