### PR TITLE
No mostrar materias catalogadas como inactivas en el planner

### DIFF
--- a/app/controllers/subject_plans_controller.rb
+++ b/app/controllers/subject_plans_controller.rb
@@ -47,7 +47,7 @@ class SubjectPlansController < ApplicationController
       TreePreloader.preload(current_user.planned_subjects.select('subjects.*', 'subject_plans.semester')
         .order('subject_plans.semester'))
     @not_planned_approved_subjects, @not_planned_subjects =
-      TreePreloader.preload(Subject.ordered_by_category.ordered_by_short_or_full_name).reject { |subject|
+      TreePreloader.preload(Subject.active.ordered_by_category.ordered_by_short_or_full_name).reject { |subject|
         current_user.planned?(subject)
       }.partition { |subject| current_student.approved?(subject) }
   end

--- a/app/models/subject.rb
+++ b/app/models/subject.rb
@@ -16,6 +16,7 @@ class Subject < ApplicationRecord
       .or(where("lower(unaccent(short_name)) LIKE lower(unaccent(?))", "%#{term.strip}%"))
       .or(where("lower(code) LIKE lower(?)", "%#{term.strip}%"))
   }
+  scope :active, -> { where.not(category: 'inactive') }
 
   CATEGORIES = %i[
     first_semester

--- a/spec/models/subject_spec.rb
+++ b/spec/models/subject_spec.rb
@@ -178,6 +178,15 @@ RSpec.describe Subject, type: :model do
     end
   end
 
+  describe '.active' do
+    let!(:inactive_subject) { create(:subject, category: 'inactive') }
+    let!(:active_subject) { create(:subject, category: 'optional') }
+
+    it 'returns only active subjects' do
+      expect(Subject.active).to contain_exactly(active_subject)
+    end
+  end
+
   describe '#ordered_by_category_and_name' do
     let(:s1) { create :subject, category: :first_semester, name: 'A' }
     let(:s2) { create :subject, category: :second_semester, name: 'B' }


### PR DESCRIPTION
#### Why?

Creemos que genera confusión mostrar las materias inactivas en el planner.

Por ejemplo:

<img width="543" height="270" alt="image" src="https://github.com/user-attachments/assets/ab3b1bd7-6447-4bad-918b-82e38d120d2a" />


Al no mostrar las materias inactivas, quedaría:

<img width="530" height="253" alt="image" src="https://github.com/user-attachments/assets/09e2efe6-55ff-4ba4-bf32-0d5aac123332" />
