### PR TITLE
Mostrar más de 4 resultados al buscar en el select

### DIFF
--- a/app/javascript/controllers/subject_selector_controller.js
+++ b/app/javascript/controllers/subject_selector_controller.js
@@ -8,6 +8,7 @@ export default class extends Controller {
     this.choices = new Choices(this.selectTarget, {
       searchEnabled: true,
       searchPlaceholderValue: "Buscar materia...",
+      searchResultLimit: -1,
       placeholderValue: "Seleccionar materia para planificar...",
       itemSelectText: "",
       noResultsText: "No se encontraron materias",


### PR DESCRIPTION
Actualmente cuando buscamos en el select, solo se muestran 4 resultados:
<img width="534" height="259" alt="image" src="https://github.com/user-attachments/assets/ac6e8283-5cf8-451c-bf6a-fd63900be151" />

Este PR setea en `-1` la opción `searchResultLimit` la cual muestra todos los resultados:

<img width="534" height="392" alt="image" src="https://github.com/user-attachments/assets/bfc21cc2-ca5f-4991-896b-454c1e0aef12" />



Docs:
https://github.com/Choices-js/Choices?tab=readme-ov-file#searchresultlimit-4