### PR TITLE
Cambiar los estilos de `semester card` 

### DIFF
--- a/app/views/subject_plans/_semester_card.html.erb
+++ b/app/views/subject_plans/_semester_card.html.erb
@@ -1,4 +1,4 @@
-<div id="semester-<%= semester %>" class="bg-white rounded-lg border border-gray-100 shadow-sm my-4">
+<div id="semester-<%= semester %>" class="bg-gray-50 rounded-lg border border-gray-100 shadow-sm my-4">
   <%= render "subject_plans/semester_card/header", semester:, planned_subjects: %>
 
   <%= render "subject_plans/semester_card/subjects_list", semester:, planned_subjects: %>

--- a/app/views/subject_plans/semester_card/_add_subject_form.html.erb
+++ b/app/views/subject_plans/semester_card/_add_subject_form.html.erb
@@ -17,7 +17,7 @@
     { data: { subject_selector_target: "select", action: "subject-selector#onChange" }, class: "invisible absolute" }
   ) %>
   <%= form.hidden_field :semester, value: semester %>
-  <%= form.button type: :submit, class: "cursor-pointer py-2 ps-3 material-icons text-gray-400 disabled:opacity-50 disabled:cursor-not-allowed", disabled: true, data: { subject_selector_target: "submitButton" } do %>
+  <%= form.button type: :submit, class: "cursor-pointer py-2 ps-3 material-icons text-gray-400 hover:text-green-500 disabled:hover:text-gray-400 disabled:opacity-50 disabled:cursor-not-allowed", disabled: true, data: { subject_selector_target: "submitButton" } do %>
       add_circle_outline
   <% end %>
 <% end %>

--- a/app/views/subject_plans/semester_card/_add_subject_form.html.erb
+++ b/app/views/subject_plans/semester_card/_add_subject_form.html.erb
@@ -4,7 +4,7 @@
   url: subject_plans_path,
   method: :post,
   data: { turbo: true, controller: "subject-selector" },
-  class: 'flex items-center gap-3 px-4 py-3 hover:bg-gray-100 border-t border-gray-100'
+  class: 'flex items-center gap-3 px-4 py-3 bg-gray-50'
 ) do |form| %>
   <%= form.select(
     :subject_id,

--- a/app/views/subject_plans/semester_card/_add_subject_form.html.erb
+++ b/app/views/subject_plans/semester_card/_add_subject_form.html.erb
@@ -4,7 +4,7 @@
   url: subject_plans_path,
   method: :post,
   data: { turbo: true, controller: "subject-selector" },
-  class: 'flex items-center gap-3 px-4 py-3 bg-gray-50'
+  class: 'flex items-center gap-3 px-4 py-3'
 ) do |form| %>
   <%= form.select(
     :subject_id,

--- a/app/views/subject_plans/semester_card/_subjects_list.html.erb
+++ b/app/views/subject_plans/semester_card/_subjects_list.html.erb
@@ -5,7 +5,7 @@
 
   <ul class="min-h-[65px]" data-semester="<%= semester %>" data-controller="planner-draggable">
     <% planned_subjects.each do |subject| %>
-      <li class="relative flex items-center gap-3 px-4 py-3 hover:bg-gray-100 bg-white" data-planner-draggable-url="<%= subject_plan_path(subject_id: subject.id) %>" data-planner-draggable-method="put">
+      <li class="relative flex items-center gap-3 px-4 py-3 bg-white" data-planner-draggable-url="<%= subject_plan_path(subject_id: subject.id) %>" data-planner-draggable-method="put">
         <span class="material-icons text-gray-400 cursor-pointer" data-planner-draggable-handle> drag_handle </span>
 
         <%= link_to display_name(subject), subject, class: "grow text-sm/6 text-gray-900" %>

--- a/app/views/subject_plans/semester_card/_subjects_list.html.erb
+++ b/app/views/subject_plans/semester_card/_subjects_list.html.erb
@@ -16,7 +16,7 @@
           <%= material_icon("lock_outline", "text-gray-400") %>
         <% end %>
 
-        <%= button_to subject_plan_path(subject_id: subject.id), method: :delete, class: "cursor-pointer py-2 ps-3 material-icons text-gray-400", form: { data: { turbo: true } } do %>
+        <%= button_to subject_plan_path(subject_id: subject.id), method: :delete, class: "cursor-pointer py-2 ps-3 material-icons text-gray-400 hover:text-red-500", form: { data: { turbo: true } } do %>
           remove_circle_outline
         <% end %>
       </li>


### PR DESCRIPTION
#### Summary

Este PR cambia:

- Colores de botones de añadir/quitar materias al hacerle hover
- No cambiar el color de fondo al hacerle hover a las materias ni al select


Antes:

https://github.com/user-attachments/assets/9daf9243-8d36-4e2a-82a5-9a7a085c5188




Después:

https://github.com/user-attachments/assets/72a302cd-d4a8-4434-91e9-f32200a74ee6


