### PR TITLE
Mostrar `badge` de inactivo en el `show` de una materia

### DIFF
--- a/app/views/subjects/show.html.erb
+++ b/app/views/subjects/show.html.erb
@@ -7,10 +7,6 @@
     <span class="inline-flex items-center rounded-md bg-red-50 px-2 py-1 text-xs font-medium text-red-700 ring-1 ring-inset ring-red-600/20">
       Inactiva
     </span>
-  <% else %>
-    <span class="inline-flex items-center rounded-md bg-green-50 px-2 py-1 text-xs font-medium text-green-700 ring-1 ring-inset ring-green-600/20">
-      Activa
-    </span>
   <% end %>
 </div>
 

--- a/app/views/subjects/show.html.erb
+++ b/app/views/subjects/show.html.erb
@@ -1,4 +1,19 @@
-<h3 class="mx-4 my-3 text-2xl"><%= @subject.code %> - <%= @subject.name %></h3>
+<div class="flex items-center justify-between px-4 py-3">
+  <h3 class="text-2xl">
+    <%= @subject.code %> - <%= @subject.name %>
+  </h3>
+
+  <% if @subject.inactive? %>
+    <span class="inline-flex items-center rounded-md bg-red-50 px-2 py-1 text-xs font-medium text-red-700 ring-1 ring-inset ring-red-600/20">
+      Inactiva
+    </span>
+  <% else %>
+    <span class="inline-flex items-center rounded-md bg-green-50 px-2 py-1 text-xs font-medium text-green-700 ring-1 ring-inset ring-green-600/20">
+      Activa
+    </span>
+  <% end %>
+</div>
+
 <hr class="border-gray-200"/>
 
 <h3 class="mx-4 my-3 text-sm font-medium">Información general</h3>


### PR DESCRIPTION
#### Why?

Utilizando la app, me pareció útil tener la información de si esta inactiva una materia al estar viendola.

Por ejemplo para una materia con el mismo nombre:

<img width="1552" height="987" alt="image" src="https://github.com/user-attachments/assets/bc9c7c93-d3ca-429e-9e46-8cd20576e013" />


<img width="1552" height="987" alt="image" src="https://github.com/user-attachments/assets/66975217-5d80-4762-98d0-4c674032f1ad" />



