### PR TITLE
Usar evento showDropdown en vez de onClick

### DIFF
--- a/app/views/subject_plans/semester_card/_add_subject_form.html.erb
+++ b/app/views/subject_plans/semester_card/_add_subject_form.html.erb
@@ -7,7 +7,6 @@
     turbo: true,
     controller: "subject-selector",
     "subject-selector-url-value": planner_not_planned_subjects_path,
-    action: "click->subject-selector#onClick"
   },
   class: 'flex items-center gap-3 px-4 py-3 hover:bg-gray-100 border-t border-gray-100'
 ) do |form| %>
@@ -15,7 +14,13 @@
     :subject_id,
     [],
     {},
-    { data: { subject_selector_target: "select", action: "subject-selector#onChange" }, class: "invisible absolute" }
+    {
+      data: {
+        subject_selector_target: "select",
+        action: "subject-selector#onChange showDropdown->subject-selector#onClick",
+      },
+      class: "invisible absolute"
+    }
   ) %>
   <%= form.hidden_field :semester, value: semester %>
   <%= form.button type: :submit, class: "cursor-pointer py-2 ps-3 material-icons text-gray-400 disabled:opacity-50 disabled:cursor-not-allowed", disabled: true, data: { subject_selector_target: "submitButton" } do %>


### PR DESCRIPTION
### Resumen
Usar evento showDropdown en vez de onClick para cargar las opciones del select

### Por qué?
Fue sugerido en en [este comment](https://github.com/cedarcode/mi_carrera/pull/874#discussion_r2214448755) y ahora permite cargar las options usando el teclado y no solo el link.