### PR TITLE
Remover chequeo de available en checkbox de curso

### DIFF
--- a/app/components/approvable_checkbox_component.rb
+++ b/app/components/approvable_checkbox_component.rb
@@ -40,15 +40,20 @@ class ApprovableCheckboxComponent < ViewComponent::Base
 
   attr_reader :approvable, :subject_show, :current_student
 
-  def initialize(approvable:, subject_show:, current_student:)
+  def initialize(approvable:, subject_show:, current_student:, disabled: nil)
     @approvable = approvable
     @subject_show = subject_show
     @current_student = current_student
+    @disabled = disabled
   end
 
   private
 
   def checked? = current_student.approved?(approvable)
 
-  def disabled? = !current_student.available?(approvable) && !current_student.approved?(approvable)
+  def disabled?
+    return @disabled unless @disabled.nil?
+
+    !current_student.available?(approvable) && !current_student.approved?(approvable)
+  end
 end

--- a/app/views/subjects/_subject.html.erb
+++ b/app/views/subjects/_subject.html.erb
@@ -3,7 +3,7 @@
     <%= display_name(subject) %>
 
     <span class='flex h-[40px] w-[100px] min-w-[100px] ms-[15px]'>
-      <%= render(ApprovableCheckboxComponent.new(approvable: subject.course, subject_show: false, current_student: current_student)) %>
+      <%= render(ApprovableCheckboxComponent.new(approvable: subject.course, subject_show: false, current_student: current_student, disabled: false)) %>
       <% if subject.exam %>
         <%= render(ApprovableCheckboxComponent.new(approvable: subject.exam, subject_show: false, current_student: current_student)) %>
       <% end %>


### PR DESCRIPTION
### Resumen
Dejar de hacer chequeo de si el checkbox del curso deberia estar disabled
### Por qué?
Viendo el código me di cuenta que estamos volviendo a evaluar si el curso esta available al renderizar cada checkbox. Esto no es necesario porque ya lo hacemos en el controller. Solo debemos chequear esto para el examen que no sabemos si lo puede marcar o no.
Ademas en el show de la subject hay que evaluar para el curso asi que decidi agregar el parametro opcional disabled que overridea el chequeo