### PR TITLE
Force sortable.js autoscroll

### DIFF
--- a/app/javascript/controllers/planner_draggable_controller.js
+++ b/app/javascript/controllers/planner_draggable_controller.js
@@ -9,6 +9,7 @@ export default class extends Controller {
 
   connect() {
     Sortable.create(this.element, {
+      forceAutoScrollFallback: true,
       group: {
         name: 'shared',
         put: this.putValue


### PR DESCRIPTION
El scroll no estaba funcionando en desktop Chrome al menos.

Por lo que entiendo de la doc [acá](https://github.com/SortableJS/Sortable/tree/3696da44b57c81dbe441aa48af28b0c38f6b11e2/plugins/AutoScroll#forceautoscrollfallback-option), SortablJS tiene un plugin custom que por defecto solo se usa en móvil y en algunos navegadores, y en el resto usa el autoscroll del browser. En nuestro caso, entiendo que ese autoscroll del browser por alguna razón no está funcionando, pero parece que forzando a que use el plugin de la librería funciona