### PR TITLE
Raise error if exam doesn't exist anymore

### DIFF
--- a/app/services/yml_loader.rb
+++ b/app/services/yml_loader.rb
@@ -66,7 +66,12 @@ class YmlLoader
       new_subject.save!
 
       new_subject.create_course! unless new_subject.course
-      new_subject.create_exam! if subject["has_exam"] && !new_subject.exam
+
+      if subject["has_exam"]
+        new_subject.create_exam! unless new_subject.exam
+      else
+        raise "Subject #{code} no longer has an exam" if new_subject.exam
+      end
     end
   end
 


### PR DESCRIPTION
Para los casos en que en algún momento existió el examen de una materia, y ya no existe más.

Me parece que es algo muy raro, por eso propongo tirar un error y manejarlo a mano.
Pasó una vez, pero ahora deberíamos darnos cuenta cuando cambian los YML