### PR TITLE
Aumentar area de clickeo de los checkbox para evitar navegación accidental

### DIFF
--- a/app/components/approvable_checkbox_component.html.erb
+++ b/app/components/approvable_checkbox_component.html.erb
@@ -11,10 +11,10 @@
       id: dom_id(approvable),
       checked: checked?,
       disabled: disabled?,
-      class: STYLES[:checkbox],
+      class: STYLES[:checkbox_input],
       data: { action: "click->autosave-check#update click->loading#start", "loading-target": "checkbox" },
     ) %>
-    <div class="<%= class_names(STYLES[:visual_checkbox]) %>"></div>
+    <div class="<%= class_names(STYLES[:checkbox]) %>"></div>
     <%= helpers.material_icon("check", class_names(STYLES[:icon])) %>
   </div>
 <% end %>

--- a/app/components/approvable_checkbox_component.html.erb
+++ b/app/components/approvable_checkbox_component.html.erb
@@ -5,7 +5,7 @@
   method: current_student.approved?(approvable) ? :delete : :post,
   class: "mx-[5px]"
 ) do |form| %>
-  <div class="box-content w-[18px] h-[18px] p-3">
+  <div class="box-content w-[18px] h-[18px] p-3 relative">
     <div class="grid size-4 grid-cols-1">
       <%= form.checkbox(
         :approved,
@@ -15,6 +15,7 @@
         class: STYLES[:checkbox],
         data: { action: "click->autosave-check#update click->loading#start", "loading-target": "checkbox" },
       ) %>
+      <div class="<%= class_names(STYLES[:visual_checkbox]) %>"></div>
       <%= helpers.material_icon("check", class_names(STYLES[:icon])) %>
     </div>
   </div>

--- a/app/components/approvable_checkbox_component.html.erb
+++ b/app/components/approvable_checkbox_component.html.erb
@@ -5,18 +5,16 @@
   method: current_student.approved?(approvable) ? :delete : :post,
   class: "mx-[5px]"
 ) do |form| %>
-  <div class="box-content w-[18px] h-[18px] p-3 relative">
-    <div class="grid size-4 grid-cols-1">
-      <%= form.checkbox(
-        :approved,
-        id: dom_id(approvable),
-        checked: checked?,
-        disabled: disabled?,
-        class: STYLES[:checkbox],
-        data: { action: "click->autosave-check#update click->loading#start", "loading-target": "checkbox" },
-      ) %>
-      <div class="<%= class_names(STYLES[:visual_checkbox]) %>"></div>
-      <%= helpers.material_icon("check", class_names(STYLES[:icon])) %>
-    </div>
+  <div class="box-content w-[18px] h-[18px] p-3 relative grid grid-cols-1 place-items-center">
+    <%= form.checkbox(
+      :approved,
+      id: dom_id(approvable),
+      checked: checked?,
+      disabled: disabled?,
+      class: STYLES[:checkbox],
+      data: { action: "click->autosave-check#update click->loading#start", "loading-target": "checkbox" },
+    ) %>
+    <div class="<%= class_names(STYLES[:visual_checkbox]) %>"></div>
+    <%= helpers.material_icon("check", class_names(STYLES[:icon])) %>
   </div>
 <% end %>

--- a/app/components/approvable_checkbox_component.rb
+++ b/app/components/approvable_checkbox_component.rb
@@ -3,19 +3,11 @@
 class ApprovableCheckboxComponent < ViewComponent::Base
   STYLES = {
     checkbox: %w[
-      col-start-1
-      row-start-1
       appearance-none
-
       peer
-
       absolute
-      inset-0
-      w-full
-      h-full
-      m-0
+      size-full
       cursor-pointer
-      z-10
     ],
     visual_checkbox: %w[
       col-start-1

--- a/app/components/approvable_checkbox_component.rb
+++ b/app/components/approvable_checkbox_component.rb
@@ -2,14 +2,14 @@
 
 class ApprovableCheckboxComponent < ViewComponent::Base
   STYLES = {
-    checkbox: %w[
+    checkbox_input: %w[
       appearance-none
       peer
       absolute
       size-full
       cursor-pointer
     ],
-    visual_checkbox: %w[
+    checkbox: %w[
       size-4
       rounded-sm
       border

--- a/app/components/approvable_checkbox_component.rb
+++ b/app/components/approvable_checkbox_component.rb
@@ -6,30 +6,41 @@ class ApprovableCheckboxComponent < ViewComponent::Base
       col-start-1
       row-start-1
       appearance-none
+
+      peer
+
+      absolute
+      inset-0
+      w-full
+      h-full
+      m-0
+      cursor-pointer
+      opacity-0
+      z-10
+    ],
+    visual_checkbox: %w[
+      col-start-1
+      row-start-1
+      w-4
+      h-4
       rounded-sm
       border
       border-gray-300
       bg-white
+      pointer-events-none
 
-      checked:border-primary
-      checked:bg-primary
+      peer-checked:border-primary
+      peer-checked:bg-primary
 
-      focus-visible:outline-2
-      focus-visible:outline-offset-0
-      focus-visible:outline-primary
+      peer-focus-visible:outline-2
+      peer-focus-visible:outline-offset-0
+      peer-focus-visible:outline-primary
 
-      disabled:border-gray-300
-      disabled:bg-gray-100
-      disabled:checked:bg-gray-100
+      peer-disabled:border-gray-300
+      peer-disabled:bg-gray-100
+      peer-disabled:checked:bg-gray-100
 
       forced-colors:appearance-auto
-
-      before:absolute
-      before:inset-[-4px]
-      before:content-['']
-      relative
-
-      peer
     ],
     icon: %w[
       text-base/4!

--- a/app/components/approvable_checkbox_component.rb
+++ b/app/components/approvable_checkbox_component.rb
@@ -10,10 +10,7 @@ class ApprovableCheckboxComponent < ViewComponent::Base
       cursor-pointer
     ],
     visual_checkbox: %w[
-      col-start-1
-      row-start-1
-      w-4
-      h-4
+      size-4
       rounded-sm
       border
       border-gray-300
@@ -37,8 +34,7 @@ class ApprovableCheckboxComponent < ViewComponent::Base
       text-base/4!
       text-white
       pointer-events-none
-      col-start-1
-      row-start-1
+      absolute
       opacity-0
       peer-checked:opacity-100
       peer-disabled:text-gray-300

--- a/app/components/approvable_checkbox_component.rb
+++ b/app/components/approvable_checkbox_component.rb
@@ -15,7 +15,6 @@ class ApprovableCheckboxComponent < ViewComponent::Base
       h-full
       m-0
       cursor-pointer
-      opacity-0
       z-10
     ],
     visual_checkbox: %w[

--- a/app/components/approvable_checkbox_component.rb
+++ b/app/components/approvable_checkbox_component.rb
@@ -11,6 +11,8 @@ class ApprovableCheckboxComponent < ViewComponent::Base
     ],
     checkbox: %w[
       size-4
+      col-start-1
+      row-start-1
       rounded-sm
       border
       border-gray-300
@@ -34,7 +36,8 @@ class ApprovableCheckboxComponent < ViewComponent::Base
       text-base/4!
       text-white
       pointer-events-none
-      absolute
+      col-start-1
+      row-start-1
       opacity-0
       peer-checked:opacity-100
       peer-disabled:text-gray-300

--- a/app/components/approvable_checkbox_component.rb
+++ b/app/components/approvable_checkbox_component.rb
@@ -24,6 +24,11 @@ class ApprovableCheckboxComponent < ViewComponent::Base
 
       forced-colors:appearance-auto
 
+      before:absolute
+      before:inset-[-4px]
+      before:content-['']
+      relative
+
       peer
     ],
     icon: %w[

--- a/spec/system/subject_spec.rb
+++ b/spec/system/subject_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe "Subject", type: :system do
     expect(page).to have_content("GAL 1")
 
     within('label', text: 'Curso aprobado?') do
-      checkbox = find('input[type="checkbox"]')
+      checkbox = find('input[type="checkbox"]', visible: false)
       expect(checkbox).to_not be_checked
     end
 
@@ -28,7 +28,7 @@ RSpec.describe "Subject", type: :system do
     end
 
     within('label', text: 'Curso aprobado?') do
-      checkbox = find('input[type="checkbox"]')
+      checkbox = find('input[type="checkbox"]', visible: false)
       checkbox.click
 
       expect(checkbox).to be_checked

--- a/spec/system/subject_spec.rb
+++ b/spec/system/subject_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe "Subject", type: :system do
     expect(page).to have_content("GAL 1")
 
     within('label', text: 'Curso aprobado?') do
-      checkbox = find('input[type="checkbox"]', visible: false)
+      checkbox = find('input[type="checkbox"]')
       expect(checkbox).to_not be_checked
     end
 
@@ -28,7 +28,7 @@ RSpec.describe "Subject", type: :system do
     end
 
     within('label', text: 'Curso aprobado?') do
-      checkbox = find('input[type="checkbox"]', visible: false)
+      checkbox = find('input[type="checkbox"]')
       checkbox.click
 
       expect(checkbox).to be_checked


### PR DESCRIPTION
## Problema
Debido al area actual de clickeo del checkbox de las subjects en el index page, se podia experimentar una navegacion accidentada a la show page de la subject cuando se intenta marcar/desmarcar los checkbox de curso/examen.

https://github.com/user-attachments/assets/17b3daf8-83ee-420c-ad5f-655221ac676d

## Anterior Solución (Pseudo-elemento. 1er commit)
Se implementó un área de clickeo expandida e invisible alrededor de cada checkbox usando pseudo-elementos sin cambiar la apariencia visual o posición de los checkboxes.

**Enfoque técnico:**
- Se agregó un pseudo-elemento `::before` invisible con `position: absolute` y `before:inset-[-8px]`
- El pseudo-elemento captura clicks en un área expandida de 22x22px y los delega al checkbox

### Comparación Visual
Las siguientes imágenes muestran diferentes tamaños de área de clickeo a modo de comparación  (las áreas en azul representan las regiones clickeable):

- **4px de padding** (`before:inset-[-4px]`): - **implementado**
<img width="809" height="116" alt="-4px" src="https://github.com/user-attachments/assets/2a6d4943-1e6f-4338-a8b2-8c1a5ac92488" />

- **6px de padding** (`before:inset-[-6px]`): 
<img width="800" height="122" alt="-6px" src="https://github.com/user-attachments/assets/2245a0e9-3f2a-4117-a8a4-27a3e3140d8c" />

- **8px de padding** (`before:inset-[-8px]`): 
<img width="804" height="120" alt="-8px" src="https://github.com/user-attachments/assets/e24dc0da-5b9c-4e33-b1f1-ed9c4077d55e" />

### Configuración
Para ajustar el tamaño del área de clickeo, se puede modificar el valor `before:inset-[-4px]`:
- `before:inset-[-Ypx]`: donde `Y` es la cantidad de px de padding

## Solución actual

Se reemplazó el enfoque de pseudo-elementos por el patrón usado por Material-UI, separando la funcionalidad y la presentación visual del checkbox.

**Enfoque técnico:**

- Input funcional expandido: El <input type="checkbox"> se posiciona de forma absoluta (absolute inset-0) para cubrir toda el área del contenedor (42px × 42px)
- Elemento visual separado: Un \<div> mantiene la apariencia original del checkbox (16px × 16px) con pointer-events-none
- Separación de responsabilidades: El input maneja la funcionalidad y captura clicks, el div maneja solo la visualización

### Area clickeable después de este cambio:


<img width="602" height="109" alt="Screenshot 2025-07-28 at 3 40 14 PM" src="https://github.com/user-attachments/assets/3e7cc3d5-7477-4dba-9c8c-c9110548e2c8" />
