### PR TITLE
Mark '1512' as inactive

### DIFF
--- a/db/data/computacion/subject_overrides.yml
+++ b/db/data/computacion/subject_overrides.yml
@@ -1278,3 +1278,5 @@ R100:
   eva_id: '800'
 '1863':
   eva_id: '800'
+'1512':
+  category: 'inactive'


### PR DESCRIPTION
La activa es 2512.
Esto es para que deje de aparecer `1512` en el index, y además tenga el cartel de `inactiva`.

Referencia (Bedelías):
<img width="1348" height="390" alt="image" src="https://github.com/user-attachments/assets/ce752e76-ffd8-4f43-ab26-303fc974f96e" />

