### PR TITLE
Display credits in not planned subjects select

### DIFF
--- a/app/controllers/planner/not_planned_subjects_controller.rb
+++ b/app/controllers/planner/not_planned_subjects_controller.rb
@@ -11,7 +11,7 @@ module Planner
           id: category,
           choices: subjects.map do |subject|
             {
-              label: display_name(subject),
+              label: not_planned_subject_display_name(subject),
               value: subject.id,
             }
           end

--- a/app/helpers/subjects_helper.rb
+++ b/app/helpers/subjects_helper.rb
@@ -37,6 +37,10 @@ module SubjectsHelper
     "#{subject.code} - #{subject.short_name || subject.name}"
   end
 
+  def not_planned_subject_display_name(subject)
+    "#{subject.code} - #{subject.short_name || subject.name} (#{subject.credits} créditos)"
+  end
+
   def display_subject_prerequisite(subject_prerequisite)
     approvable = subject_prerequisite.approvable_needed
     "#{display_name(approvable.subject)} (#{approvable.is_exam ? "examen" : "curso"})"


### PR DESCRIPTION
Me pasó que al estar usando el planner tenía que estar abriendo otras tabs para ver los créditos de cada materia y saber cual elegir.
Si la gracia es justamente planificar, mostrar los créditos en el select me parece muy útil.

(Además ayuda a distinguir entre materias que se llaman muy parecido)


