### PR TITLE
Quitar footer y mover `Built by Cedarcode` al menu

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -55,11 +55,5 @@
         <%= yield %>
       </div>
     </main>
-    <footer class="fixed bottom-0 w-full bg-gray-100 px-3 py-1">
-      <span class="text-gray-500">
-        Built by
-      </span>
-      <a class="text-gray-800" href="https://cedarcode.com" target="_blank" >Cedarcode</a>
-    </footer>
   </body>
 </html>

--- a/app/views/shared/_menu.html.erb
+++ b/app/views/shared/_menu.html.erb
@@ -20,6 +20,13 @@
     <%= material_icon_outlined("rate_review") %>
     Opina de la app
   <% end %>
+
+  <div class="absolute bottom-0 pb-2">
+    <span class="text-gray-500">
+      Built by
+    </span>
+    <a class="text-gray-800" href="https://cedarcode.com" target="_blank" >Cedarcode</a>
+  </div>
 </div>
 
 <div data-navigation-drawer-target="overlay" data-action="click->navigation-drawer#toggle" class="fixed inset-0 bg-black/30 hidden z-40"></div>

--- a/app/views/shared/_menu.html.erb
+++ b/app/views/shared/_menu.html.erb
@@ -21,7 +21,7 @@
     Opina de la app
   <% end %>
 
-  <div class="absolute bottom-0 pb-2">
+  <div class="absolute bottom-0 pb-2 text-base">
     <span class="text-gray-500">
       Built by
     </span>


### PR DESCRIPTION
#### Why?

Queremos quitar el footer hace tiempo ya que consume espacio innecesariamente, en un principio ibamos a utilizar el footer para mostrar los creditos (#699) pero no nos convencio del todo; ahora que vamos a mostrar los créditos en una barra de progreso (#862) podemos quitar el footer sin problema