### PR TITLE
Add authentication to access passkeys

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,6 +1,7 @@
 class ApplicationController < ActionController::Base
   helper_method :current_student
   rate_limit to: 20, within: 10.seconds
+  before_action :reset_passkey_authentication
 
   private
 
@@ -10,5 +11,9 @@ class ApplicationController < ActionController::Base
 
   def current_degree
     @current_degree ||= current_student.degree
+  end
+
+  def reset_passkey_authentication
+    session[:password_passkey_verification] = false
   end
 end

--- a/app/controllers/users/passkeys_controller.rb
+++ b/app/controllers/users/passkeys_controller.rb
@@ -2,6 +2,8 @@ module Users
   class PasskeysController < ApplicationController
     before_action :authenticate_user!
     before_action :ensure_feature_enabled!
+    before_action :verify_password, only: [:index]
+    skip_before_action :reset_passkey_authentication
 
     def index
       @create_passkey_options = WebAuthn::Credential.options_for_create(
@@ -49,10 +51,25 @@ module Users
       end
     end
 
+    def process_verification
+      if current_user.valid_password?(params[:password])
+        session[:password_passkey_verification] = true
+        redirect_to user_passkeys_path, notice: "Contraseña verificada correctamente."
+      else
+        redirect_to verify_password_user_passkeys_path, alert: "Contraseña incorrecta. por favor, intenta de nuevo."
+      end
+    end
+
     private
 
     def ensure_feature_enabled!
       redirect_to root_path if ENV['ENABLE_PASSKEYS'].blank?
+    end
+
+    def verify_password
+      unless session[:password_passkey_verification]
+        render :verify_password
+      end
     end
   end
 end

--- a/app/views/users/passkeys/verify_password.html.erb
+++ b/app/views/users/passkeys/verify_password.html.erb
@@ -5,7 +5,14 @@
     <%= render 'shared/alert' if flash[:alert] %>
 
     <%= f.label :password, "Contraseña", class: "text-sm/6 font-medium text-gray-700 with-error:text-red-600" %>
-    <%= f.password_field :password, class: "bg-white w-full rounded-md px-3 py-1.5 outline-1 outline-gray-300 focus:outline-2 focus:outline-indigo-600", required: true %>
+
+    <div class="relative w-full" data-controller="show-password">
+      <%= f.password_field :password, class: "bg-white w-full rounded-md px-3 py-1.5 outline-1 outline-gray-300 focus:outline-2 focus:outline-indigo-600 with-error:outline-red-500 with-error:focus:outline-red-600", data: { show_password_target: "password" }, required: true %>
+
+      <%= button_tag type: "button", class: "flex items-center absolute inset-y-0 right-0 px-3 focus:outline-indigo-600 cursor-pointer hover:text-indigo-700", data: { action: "show-password#toggle" } do %>
+        <span class="material-icons" data-show-password-target="icon">visibility</span>
+      <% end %>
+    </div>
 
     <%= render ButtonComponent.new(form: f, label: "Verificar") %>
   <% end %>

--- a/app/views/users/passkeys/verify_password.html.erb
+++ b/app/views/users/passkeys/verify_password.html.erb
@@ -1,0 +1,12 @@
+<div class="flex flex-col justify-center items-center p-6 space-y-6">
+  <h2 class="text-3xl/9 text-neutral-700">Ingresa tu Contraseña</h2>
+
+  <%= form_with url: process_verification_user_passkeys_path, method: :post, class: "flex flex-col w-full max-w-md space-y-6" do |f| %>
+    <%= render 'shared/alert' if flash[:alert] %>
+
+    <%= f.label :password, "Contraseña", class: "text-sm/6 font-medium text-gray-700 with-error:text-red-600" %>
+    <%= f.password_field :password, class: "bg-white w-full rounded-md px-3 py-1.5 outline-1 outline-gray-300 focus:outline-2 focus:outline-indigo-600", required: true %>
+
+    <%= render ButtonComponent.new(form: f, label: "Verificar") %>
+  <% end %>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -18,7 +18,12 @@ Rails.application.routes.draw do
     }
 
     scope path: "usuarios", module: "users", as: "user" do
-      resources :passkeys, only: [:index, :create, :destroy]
+      resources :passkeys, only: [:index, :create, :destroy] do
+        collection do
+          get :verify_password
+          post :process_verification
+        end
+      end
     end
 
     root to: "subjects#index"

--- a/spec/system/manage_passkeys_spec.rb
+++ b/spec/system/manage_passkeys_spec.rb
@@ -20,6 +20,16 @@ RSpec.describe 'Manage passkeys' do
 
       click_on "Administrar Passkeys"
 
+      expect(page).to have_text "Ingresa tu Contraseña"
+      fill_in "Contraseña", with: "Contraseña incorrecta!!!!!!!!"
+      click_on "Verificar"
+
+      expect(page).to have_text "Contraseña incorrecta. por favor, intenta de nuevo."
+
+      fill_in "Contraseña", with: user.password
+      click_on "Verificar"
+      expect(page).to have_text "Contraseña verificada correctamente."
+
       stub_create(fake_credentials)
 
       fill_in "Nombre", with: "My new passkey"
@@ -53,6 +63,10 @@ RSpec.describe 'Manage passkeys' do
       visit edit_user_registration_path
 
       click_on "Administrar Passkeys"
+
+      fill_in "Contraseña", with: user.password
+      click_on "Verificar"
+      expect(page).to have_text "Contraseña verificada correctamente."
 
       within("li", text: "My new passkey") do
         accept_confirm "¿Seguro que quieres borrar esta Passkey?" do


### PR DESCRIPTION
### Resumen:
- El usuario debe autenticarse con su contraseña para acceder a sus Passkeys 🔑 .

### Detalles:
- De momento se implementó guardar en la `session` un boolean `password_passkey_verification`:
  - en `true`: no le pide al usuario ingresar su contraseña  si quiere acceder a sus passkeys
  - en `false`: le pide al usuario ingresar su contraseña  si quiere acceder a sus passkeys

- Este boolean se setea en `false` en el `application_controller` en una `before_action`, con la excepción al acceder a las acciones del `passkeys_controller` (ya que una vez ingresada la contraseña la idea es que el usuario pueda manejar sus passkeys mientras esta en `usuarios/passkeys`)

### Pregunta:
- Al ser esta implementación probablemente "momentánea", capaz alguno conoce una mejor forma de implementar este mecanismo de acceso a las Passkeys. Capaz en otro PR se podria hacer que este acceso se mantenga por cierto tiempo y luego expire 🙂 