### PR TITLE
Dejar de fijar puerto Capybara

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -73,10 +73,9 @@ RSpec.configure do |config|
       # resulting in tests errors.
       # This flag disables that behavior.
       options.add_argument 'disable-backgrounding-occluded-windows'
-      Capybara.app_host = 'http://localhost:3030'
-      Capybara.server_host = 'localhost'
-      Capybara.server_port = 3030
     end
+    Capybara.server_host = "localhost"
+    WebAuthn.configuration.allowed_origins = ["http://#{Capybara.current_session.server.host}:#{Capybara.current_session.server.port}"]
   end
 
   [:system, :request].each do |type|


### PR DESCRIPTION
### Detalles:
- Se deja de fijar un puerto para correr los tests de sistema, evitando posibles conflictos al correr tests en paralelo.

Referencia: [PR comment](https://github.com/cedarcode/mi_carrera/pull/917#discussion_r2270767894)