### PR TITLE
fix: evitar race condition de nodo stale en transición a página FING del scraper

### DIFF
--- a/lib/scraper/base.rb
+++ b/lib/scraper/base.rb
@@ -71,7 +71,15 @@ module Scraper
       find('.ui-accordion-header', text: 'TECNOLOGÍA Y CIENCIAS DE LA NATURALEZA').click
       find('td', text: 'FING - FACULTAD DE INGENIERÍA', visible: false).click
 
-      find('span', text: ' - FING')
+      # Use XPath to match by text in a single atomic browser query. The
+      # equivalent `find('span', text: ' - FING')` routes through Capybara's
+      # filter_by_text JS, which iterates over candidate node IDs and reads
+      # textContent on each. If any candidate is detached mid-iteration (e.g.
+      # PrimeFaces AJAX swapping nodes), Chrome raises
+      # "Node with given id does not belong to the document" and the whole
+      # find aborts — see filter_by_text in
+      # capybara/selenium/extensions/find.rb.
+      find(:xpath, ".//span[contains(., ' - FING')]")
 
       wait_for_loading_widget_to_disappear
 


### PR DESCRIPTION
## Resumen

Este PR reemplaza el `find('span', text: ' - FING')` por un selector XPath equivalente para evitar un error transitorio de Chrome al cargar la página de calendario de FING durante el scraping.

Run que falló originalmente: [actions/runs/26017158597/job/76469730915](https://github.com/cedarcode/mi_carrera/actions/runs/26017158597/job/76469730915) (Ingeniería en Computación – Plan 1997, 3 reintentos consecutivos del CI fallaron con el mismo error).

## El síntoma

```
Selenium::WebDriver::Error::UnknownError: unknown error: unhandled inspector error:
{"code":-32000,"message":"Node with given id does not belong to the document"}
  ...
  capybara-3.40.0/lib/capybara/selenium/extensions/find.rb:45:in 'Capybara::Selenium::Find#filter_by_text'
  ...
  lib/scraper/base.rb:74:in 'Scraper::Base#select_degree_in_accordion'
```

## Causa raíz

`find('span', text: ' - FING')` no es un simple selector CSS. Internamente Capybara hace lo siguiente (`capybara/selenium/extensions/find.rb`):

```ruby
def find_by(format, selector, uses_visibility:, texts:, styles:, position:)
  els = find_context.find_elements(format, selector)        # 1) trae TODOS los <span> de la página
  ...
  if (els.size > 2) && !ENV['DISABLE_CAPYBARA_SELENIUM_OPTIMIZATIONS']
    els = filter_by_text(els, texts) unless texts.empty?    # 2) si hay >2, filtra por texto vía JS
    ...
  end
end

def filter_by_text(elements, texts)
  es_context.execute_script <<~JS, elements, texts
    var texts = arguments[1];
    return arguments[0].filter(function(el){
      var content = el.textContent.toLowerCase();           # 3) lee textContent de CADA nodo
      return texts.every(function(txt){ return content.indexOf(txt.toLowerCase()) != -1 });
    })
  JS
end
```

El flujo problemático es:

1. **Paso 1**: Selenium ejecuta `document.querySelectorAll('span')` y devuelve **referencias** (IDs internos de nodos DOM) a Capybara. La página de calendario de FING tiene **25 spans** (lo verifiqué con un probe local).
2. **Paso 2**: Como 25 > 2, Capybara dispara la optimización JS `filter_by_text`.
3. **Paso 3**: El JS recibe la lista de IDs de nodos y, dentro del filtro, accede a `el.textContent` de cada uno. Pero entre el paso 1 y el paso 3, **PrimeFaces puede haber hecho una actualización AJAX** (la pestaña de "Carreras" se renderiza dinámicamente después del click en FING) y haber **desconectado del DOM** alguno de los nodos que Capybara venía referenciando.
4. **Boom**: Chrome no encuentra ese nodo en el documento actual y aborta con `Node with given id does not belong to the document` (código `-32000` del DevTools Protocol). Es una condición de carrera.

Cosas importantes a notar:

- Es un error **fatal** para Capybara: no es el `StaleElementReferenceError` clásico que Capybara sabe reintentar. `filter_by_text` no tiene rescue para este error, así que el `find` aborta entero — no hay reintento automático aunque `Capybara.default_max_wait_time` todavía no se haya cumplido.
- Por la misma razón, los 3 reintentos del workflow (`nick-fields/retry@v4` con `max_attempts: 3`) fallaron consecutivamente: cada reintento es un proceso `rake` nuevo, pero la condición de carrera se reproducía bajo la misma carga de los runners de GitHub.
- El error es genuinamente intermitente: probé 30 corridas locales secuenciales con el código viejo y todas pasaron, porque mi máquina es más rápida que el runner cargado y la ventana de carrera no se abre. Pero el path queda igual de roto en la teoría — el screenshot del CI muestra que la página ya había transicionado a FING (el span existía), simplemente Capybara lo había referenciado un instante antes de que PrimeFaces lo reemplazara.

## El arreglo

Cambiar a XPath con el predicado de texto incluido en la propia query:

```ruby
find(:xpath, ".//span[contains(., ' - FING')]")
```

Por qué esto evita el bug:

- `find_xpath` en Capybara está definido así (`find.rb:6-8`):
  ```ruby
  def find_xpath(selector, ...)
    find_by(:xpath, selector, ..., texts: [], ...)   # texts queda fijo en []
  end
  ```
- Por lo tanto, en `find_by`, la línea `els = filter_by_text(els, texts) unless texts.empty?` **no se ejecuta nunca** para queries XPath.
- El motor XPath de Chrome evalúa `contains(., ' - FING')` de forma **atómica en el navegador**, en una sola operación, sin pasar referencias a nodos por encima del wire ni iterar desde Ruby. No hay ventana donde un nodo pueda quedar detached entre la query y el match de texto.
- El resultado es que el `find` localiza el mismo elemento que antes, pero por un camino que es inmune a este tipo de carrera.

## Otras opciones que descarté

| Opción | Por qué la descarté |
| --- | --- |
| `with_stale_node_retry { ... }` (rescatar y reintentar el `UnknownError`) | Trata el síntoma, no la causa. Sigue dependiendo del camino frágil de `filter_by_text`. |
| `ENV['DISABLE_CAPYBARA_SELENIUM_OPTIMIZATIONS'] = '1'` global | Desactiva la optimización JS de Capybara para todos los `find` con texto, no solo el problemático. Hace un round-trip de Ruby↔Selenium por cada elemento candidato → notablemente más lento, y arregla un caso usando un martillo muy grande. |
| Borrar la línea entera y depender de `find('.ui-column-filter')` | Funcionaría como sincronizador (`.ui-column-filter` solo existe en la página de calendario de FING), pero pierde la aserción explícita de que la transición pasó. Lo dejé en mi cabeza como plan B si XPath demostrara problemas. |

## Verificación local

Levanté un probe que solo ejecuta `Scraper::CurrentSemesterScraper#go_to_current_semester_subjects_page` (la función que llama a `select_degree_in_accordion`) y lo corrí en loop:

| Código | Corridas | Fallos |
| --- | --- | --- |
| `master` (con `filter_by_text`) | 30 secuenciales | 0 (no se reproduce localmente; ver caveat más abajo) |
| Este PR (XPath) | 30 secuenciales | 0 |

Distribución de tiempos casi idéntica entre las dos versiones (~9-13s por corrida), o sea sin penalidad de performance.

**Caveat honesto sobre la verificación local**: no logré reproducir el fallo en mi máquina porque la carrera es genuinamente rara (incluso un re-run del workflow original pasó sin cambios). Lo que sí pude verificar empíricamente:

1. La página de FING devuelve **25 spans** al `querySelectorAll('span')` (lo medí), lo cual es > 2 y por lo tanto **activa el camino de `filter_by_text` JS** — el mismo path que el stack trace del CI muestra como punto de falla.
2. El XPath form **omite completamente** ese path por construcción (ver código fuente del gem citado arriba).
3. Las 30 corridas con el código nuevo encuentran el span correctamente y la navegación procede igual.

O sea, la justificación es: el path que rompe en CI sigue activado localmente (mismo `>2` spans), pero la ventana de carrera no se abre en mi entorno; el cambio elimina el path por completo, no lo reemplaza por algo equivalente pero más lento.

## Cambios

- `lib/scraper/base.rb` — una sola línea cambiada en `Scraper::Base#select_degree_in_accordion`, más comentario explicando el motivo.