### PR TITLE
fix: parsear prefijo opcional de instituto en scraper de materias

### DIFF
--- a/lib/scraper/subjects_scraper.rb
+++ b/lib/scraper/subjects_scraper.rb
@@ -9,7 +9,9 @@ module Scraper
     # SRN14 - MATEMÁTICA DISCRETA I - créditos: 10
     # FF1-7 - CREDITOS ASIGNADOS POR REVALIDA - créditos: 7
     # FL2.6 - CREDITOS ASIGANDOS POR REVALIDA - créditos: 6
-    SUBJECT_CODE_NAME_CREDITS_REGEX = /\A((?:\w|\.|\-)+) - (.+) - (?:créditos): (\d+)(?: programa)?\z/
+    # CURE - DMA03 - GEOMETRÍA Y ÁLGEBRA LINEAL 1 - créditos: 12
+    # CENURLN - CIM22 - TOPOLOGÍA - créditos: 12
+    SUBJECT_CODE_NAME_CREDITS_REGEX = /\A(?:[A-Z]+ - )?((?:\w|\.|\-)+) - (.+) - (?:créditos): (\d+)(?: programa)?\z/
 
     def scrape
       logger.info "Starting to scrape subjects"

--- a/spec/lib/scraper/subjects_scraper_spec.rb
+++ b/spec/lib/scraper/subjects_scraper_spec.rb
@@ -5,57 +5,57 @@ RSpec.describe Scraper::SubjectsScraper, type: :lib do
   describe 'SUBJECT_CODE_NAME_CREDITS_REGEX' do
     subject(:regex) { described_class::SUBJECT_CODE_NAME_CREDITS_REGEX }
 
-    it 'parsea materia sin prefijo de instituto' do
+    it 'parses a subject without an institute prefix' do
       match = regex.match('SRN14 - MATEMÁTICA DISCRETA I - créditos: 10')
       expect(match.captures).to eq(['SRN14', 'MATEMÁTICA DISCRETA I', '10'])
     end
 
-    it 'parsea materia con código numérico' do
+    it 'parses a subject with a numeric code' do
       match = regex.match('1886 - TOPOLOGIA Y ANALISIS REAL - créditos: 10')
       expect(match.captures).to eq(['1886', 'TOPOLOGIA Y ANALISIS REAL', '10'])
     end
 
-    it 'parsea materia con guión en el código' do
+    it 'parses a subject whose code contains a dash' do
       match = regex.match('FF1-7 - CREDITOS ASIGNADOS POR REVALIDA - créditos: 7')
       expect(match.captures).to eq(['FF1-7', 'CREDITOS ASIGNADOS POR REVALIDA', '7'])
     end
 
-    it 'parsea materia con punto en el código' do
+    it 'parses a subject whose code contains a dot' do
       match = regex.match('FL2.6 - CREDITOS ASIGANDOS POR REVALIDA - créditos: 6')
       expect(match.captures).to eq(['FL2.6', 'CREDITOS ASIGANDOS POR REVALIDA', '6'])
     end
 
-    it 'parsea materia con sufijo " programa"' do
+    it 'parses a subject with a trailing " programa" suffix' do
       match = regex.match('SRN14 - MATEMÁTICA DISCRETA I - créditos: 10 programa')
       expect(match.captures).to eq(['SRN14', 'MATEMÁTICA DISCRETA I', '10'])
     end
 
-    it 'parsea materia con prefijo de instituto CURE' do
+    it 'parses a subject with a CURE institute prefix' do
       match = regex.match('CURE - DMA03 - GEOMETRÍA Y ÁLGEBRA LINEAL 1 - créditos: 12')
       expect(match.captures).to eq(['DMA03', 'GEOMETRÍA Y ÁLGEBRA LINEAL 1', '12'])
     end
 
-    it 'parsea materia con prefijo de instituto CUT y código de materia con letras' do
+    it 'parses a subject with a CUT institute prefix and an all-letter subject code' do
       match = regex.match('CUT - AL - GEOMETRÍA Y ÁLGEBRA LINEAL - créditos: 9')
       expect(match.captures).to eq(['AL', 'GEOMETRÍA Y ÁLGEBRA LINEAL', '9'])
     end
 
-    it 'parsea materia con prefijo de instituto CENURLN' do
+    it 'parses a subject with a CENURLN institute prefix' do
       match = regex.match('CENURLN - CIM22 - TOPOLOGÍA - créditos: 12')
       expect(match.captures).to eq(['CIM22', 'TOPOLOGÍA', '12'])
     end
 
-    it 'parsea materia con prefijo de instituto y nombre con guión interno' do
+    it 'parses a subject with an institute prefix and a name containing an inner dash' do
       match = regex.match('CENURLN - SRN45 - MATEMATICA INICIAL-OPTATIVA - créditos: 4')
       expect(match.captures).to eq(['SRN45', 'MATEMATICA INICIAL-OPTATIVA', '4'])
     end
 
-    it 'no confunde código de materia que parece nombre de instituto cuando no hay prefijo' do
+    it 'does not mistake an all-letter subject code for an institute prefix when no prefix is present' do
       match = regex.match('AL - GEOMETRÍA Y ÁLGEBRA LINEAL - créditos: 9')
       expect(match.captures).to eq(['AL', 'GEOMETRÍA Y ÁLGEBRA LINEAL', '9'])
     end
 
-    it 'parsea nombre con " - " interno y sin prefijo de instituto' do
+    it 'parses a name containing " - " when no institute prefix is present' do
       match = regex.match('IIQ56 - METODOS CUANTITATIVOS III - PAYSANDU - créditos: 8')
       expect(match.captures).to eq(['IIQ56', 'METODOS CUANTITATIVOS III - PAYSANDU', '8'])
     end

--- a/spec/lib/scraper/subjects_scraper_spec.rb
+++ b/spec/lib/scraper/subjects_scraper_spec.rb
@@ -1,0 +1,63 @@
+require 'rails_helper'
+require 'scraper/subjects_scraper'
+
+RSpec.describe Scraper::SubjectsScraper, type: :lib do
+  describe 'SUBJECT_CODE_NAME_CREDITS_REGEX' do
+    subject(:regex) { described_class::SUBJECT_CODE_NAME_CREDITS_REGEX }
+
+    it 'parsea materia sin prefijo de instituto' do
+      match = regex.match('SRN14 - MATEMÁTICA DISCRETA I - créditos: 10')
+      expect(match.captures).to eq(['SRN14', 'MATEMÁTICA DISCRETA I', '10'])
+    end
+
+    it 'parsea materia con código numérico' do
+      match = regex.match('1886 - TOPOLOGIA Y ANALISIS REAL - créditos: 10')
+      expect(match.captures).to eq(['1886', 'TOPOLOGIA Y ANALISIS REAL', '10'])
+    end
+
+    it 'parsea materia con guión en el código' do
+      match = regex.match('FF1-7 - CREDITOS ASIGNADOS POR REVALIDA - créditos: 7')
+      expect(match.captures).to eq(['FF1-7', 'CREDITOS ASIGNADOS POR REVALIDA', '7'])
+    end
+
+    it 'parsea materia con punto en el código' do
+      match = regex.match('FL2.6 - CREDITOS ASIGANDOS POR REVALIDA - créditos: 6')
+      expect(match.captures).to eq(['FL2.6', 'CREDITOS ASIGANDOS POR REVALIDA', '6'])
+    end
+
+    it 'parsea materia con sufijo " programa"' do
+      match = regex.match('SRN14 - MATEMÁTICA DISCRETA I - créditos: 10 programa')
+      expect(match.captures).to eq(['SRN14', 'MATEMÁTICA DISCRETA I', '10'])
+    end
+
+    it 'parsea materia con prefijo de instituto CURE' do
+      match = regex.match('CURE - DMA03 - GEOMETRÍA Y ÁLGEBRA LINEAL 1 - créditos: 12')
+      expect(match.captures).to eq(['DMA03', 'GEOMETRÍA Y ÁLGEBRA LINEAL 1', '12'])
+    end
+
+    it 'parsea materia con prefijo de instituto CUT y código de materia con letras' do
+      match = regex.match('CUT - AL - GEOMETRÍA Y ÁLGEBRA LINEAL - créditos: 9')
+      expect(match.captures).to eq(['AL', 'GEOMETRÍA Y ÁLGEBRA LINEAL', '9'])
+    end
+
+    it 'parsea materia con prefijo de instituto CENURLN' do
+      match = regex.match('CENURLN - CIM22 - TOPOLOGÍA - créditos: 12')
+      expect(match.captures).to eq(['CIM22', 'TOPOLOGÍA', '12'])
+    end
+
+    it 'parsea materia con prefijo de instituto y nombre con guión interno' do
+      match = regex.match('CENURLN - SRN45 - MATEMATICA INICIAL-OPTATIVA - créditos: 4')
+      expect(match.captures).to eq(['SRN45', 'MATEMATICA INICIAL-OPTATIVA', '4'])
+    end
+
+    it 'no confunde código de materia que parece nombre de instituto cuando no hay prefijo' do
+      match = regex.match('AL - GEOMETRÍA Y ÁLGEBRA LINEAL - créditos: 9')
+      expect(match.captures).to eq(['AL', 'GEOMETRÍA Y ÁLGEBRA LINEAL', '9'])
+    end
+
+    it 'parsea nombre con " - " interno y sin prefijo de instituto' do
+      match = regex.match('IIQ56 - METODOS CUANTITATIVOS III - PAYSANDU - créditos: 8')
+      expect(match.captures).to eq(['IIQ56', 'METODOS CUANTITATIVOS III - PAYSANDU', '8'])
+    end
+  end
+end


### PR DESCRIPTION
## Resumen

El [PR #1128](https://github.com/cedarcode/mi_carrera/pull/1128), generado automáticamente por la action que corre los lunes, contenía datos incorrectos en `db/data/computacion/2025/scraped_subjects.yml`: aparecían claves `CURE` y `CUT` con muchos `subject_groups` (incluso repetidos) y los códigos reales de materias (DMA03, AL, CIM22, etc.) quedaban incrustados dentro del campo `name`.

## Causa

Bedelias modificó el formato de las filas en la página de planes de estudio. Ahora, para materias dictadas en centros regionales, antepone el código del instituto al código y nombre de la materia:

- Antes: `DMA03 - GEOMETRÍA Y ÁLGEBRA LINEAL 1 - créditos: 12`
- Ahora: `CURE - DMA03 - GEOMETRÍA Y ÁLGEBRA LINEAL 1 - créditos: 12`

El prefijo es opcional: las materias sin centro regional siguen con el formato anterior (`1886 - TOPOLOGIA Y ANALISIS REAL - créditos: 10`).

El regex `SUBJECT_CODE_NAME_CREDITS_REGEX` en `lib/scraper/subjects_scraper.rb` no contemplaba ese prefijo, por lo que capturaba `CURE`/`CUT`/`CENURLN` como código de la materia. Como los institutos se repiten, todas esas materias terminaban acumuladas bajo la misma clave del hash `subjects`.

## Solución

Se agrega un grupo opcional (no captura) al inicio del regex para descartar el prefijo del instituto cuando aparece:

```ruby
SUBJECT_CODE_NAME_CREDITS_REGEX = /\A(?:[A-Z]+ - )?((?:\w|\.|\-)+) - (.+) - (?:créditos): (\d+)(?: programa)?\z/
```

El backtracking de Ruby maneja correctamente la ambigüedad: si el resto del texto no parsea como `código - nombre - créditos: N`, el grupo opcional no se aplica.

## Tests

Se agrega `spec/lib/scraper/subjects_scraper_spec.rb` cubriendo:
- Materias sin prefijo (códigos numéricos, con guión, con punto, con sufijo " programa").
- Materias con prefijo de instituto (CURE, CUT, CENURLN).
- Códigos de materia all-caps (AL) que sin prefijo deben seguir parseando bien.
- Nombres con `" - "` interno.

```
$ bundle exec rspec spec/lib/scraper/subjects_scraper_spec.rb
...........
11 examples, 0 failures
```

## Notas

- Queda como draft porque la verificación end-to-end definitiva requiere correr `rails scraper:subjects[computacion,2025]` contra el bedelias real. Si quieren, se puede hacer eso antes de marcarlo ready.
- Hay otro regex en `process_prerequisites_slice` (línea 104) — `/\A(\w+) - .*\z/` — que potencialmente sufre el mismo problema si la página de "Sistema de previaturas" también cambió. El PR #1128 no mostró cambios en `scraped_prerequisites.yml`, así que no lo toco en este PR, pero conviene verificarlo al re-ejecutar el scraper.

## Test plan

- [ ] Correr `bundle exec rspec spec/lib/scraper/subjects_scraper_spec.rb`
- [ ] Re-ejecutar el scraper contra computacion/2025 y verificar que `scraped_subjects.yml` ya no tiene claves `CURE`/`CUT`/`CENURLN`
- [ ] Verificar que `scraped_prerequisites.yml` queda correcto