### PR TITLE
fix: corregir ActivityPrerequisite cuando está negada

### DIFF
--- a/app/models/activity_prerequisite.rb
+++ b/app/models/activity_prerequisite.rb
@@ -2,7 +2,7 @@ class ActivityPrerequisite < Prerequisite
   belongs_to :approvable_needed, class_name: "Approvable"
 
   def met?(approved_approvable_ids)
-    approvable_needed.available?(approved_approvable_ids)
+    approvable_needed.approved?(approved_approvable_ids)
   end
 end
 

--- a/spec/models/activity_prerequisite_spec.rb
+++ b/spec/models/activity_prerequisite_spec.rb
@@ -6,23 +6,31 @@ RSpec.describe ActivityPrerequisite, type: :model do
   end
 
   describe '#met?' do
-    context 'when the approvable needed is available' do
+    context 'when the approvable needed is approved' do
       it 'returns true' do
         subject_needed = create :subject, :with_exam
-        allow(subject_needed.exam).to receive(:available?).and_return(true)
         prerequisite = create :activity_prerequisite, approvable_needed: subject_needed.exam
 
-        expect(prerequisite.met?([])).to be_truthy
+        expect(prerequisite.met?([subject_needed.exam.id])).to be true
       end
     end
 
-    context 'when the approvable needed is not available' do
+    context 'when the approvable needed is not approved' do
       it 'returns false' do
         subject_needed = create :subject, :with_exam
-        allow(subject_needed.exam).to receive(:available?).and_return(false)
         prerequisite = create :activity_prerequisite, approvable_needed: subject_needed.exam
 
-        expect(prerequisite.met?([])).to be_falsey
+        expect(prerequisite.met?([])).to be false
+      end
+    end
+
+    context 'when nested under a NOT and the approvable needed is not approved' do
+      it 'is satisfied (regression: exam 1512 / Diseño Lógico)' do
+        subject_needed = create :subject
+        activity_prerequisite = build :activity_prerequisite, approvable_needed: subject_needed.course
+        not_prerequisite = create :not_prerequisite, operands_prerequisites: [activity_prerequisite]
+
+        expect(not_prerequisite.met?([])).to be true
       end
     end
   end


### PR DESCRIPTION
## Motivación

Al intentar marcar como aprobado el **examen de 1512 - Diseño Lógico** (carrera Ingeniería Eléctrica), una de sus previas nunca aparece como cumplida, por lo que el examen no se puede marcar como aprobado.

La previa del examen es:

- **Y** (todas las siguientes):
  - **No** haber aprobado/reprobado `2512 - Diseño Lógico (curso)`
  - Haber aprobado `1512 - Diseño Lógico (curso)`

El segundo operando funciona, pero el primero (negado) nunca se cumple.

## Causa raíz

La implementación actual de `ActivityPrerequisite#met?` usa `approvable_needed.available?`, que devuelve `true` cuando la materia objetivo **podría cursarse** (es decir, sus previas están cumplidas), no cuando efectivamente fue cursada/aprobada.

```ruby
def met?(approved_approvable_ids)
  approvable_needed.available?(approved_approvable_ids)
end
```

En el caso del examen 1512, el curso 2512 es una reválida cuya previa es `NOT (1512.all OR 1512P.all OR CP51.all OR SD10.all)`. Para un estudiante típico (que tiene el curso 1512 aprobado pero todavía no su examen):

- `course_2512.available?` evalúa el árbol y devuelve **true** (ninguna de las materias del OR está aprobada todavía como examen).
- `ActivityPrerequisite#met?` devuelve **true**.
- El `NOT` padre evalúa `none?(true) = false`.
- El `AND` exterior queda en **false** y el examen nunca se puede aprobar.

En otras palabras: siempre consideramos un activity prerequisite como `true`, y como en este caso está negado, da `false` siempre.

## Solución

Cambiar la semántica de `ActivityPrerequisite#met?` para que devuelva `true` cuando la actividad fue **aprobada** por el usuario, en lugar de cuando está disponible:

```ruby
def met?(approved_approvable_ids)
  approvable_needed.approved?(approved_approvable_ids)
end
```

### Caveat sobre "aprobado/reprobado"

El concepto de Bedelías "aprobado/reprobado" significa que el estudiante tiene un resultado registrado (pase o falle). `mi_carrera` solo registra aprobaciones, no reprobaciones, así que la nueva semántica es una aproximación conservadora:

- **Caso positivo** ("debe haber rendido X"): un estudiante que reprobó X sin volver a rendirlo no satisface la previa. No tenemos forma de saber que reprobó, así que es lo mejor que podemos hacer.
- **Caso negativo** ("no debe haber rendido X"): un estudiante que reprobó X sin volver a rendirlo se considera como que no lo rindió, consistente con el resto de la app.

El único uso real restante de esta previa es el caso negado de 1512: verifiqué con `grep` que en toda la data scrapeada (`db/data/`) sólo aparece en `electrica/2023/scraped_prerequisites.yml:6901`. Esta es la materia que motiva el fix, así que la nueva semántica calza perfecto con el único caso vivo.

### Alternativa considerada

Eliminar `ActivityPrerequisite` y mapear `course_activity` / `exam_activity` a `SubjectPrerequisite` en el loader. Es menos código pero perdemos el copy distintivo ("aprobado/reprobado X") y la fidelidad del modelo de datos respecto a lo que publica Bedelías. No vale la pena por una línea de comportamiento.

## Tests

- `spec/models/activity_prerequisite_spec.rb`: reescritos los tests existentes contra la nueva semántica y agregado un test de regresión que anida un `ActivityPrerequisite` bajo un `NOT` y asegura que se satisface cuando el estudiante no aprobó la actividad (exactamente el escenario 1512 / 2512).
- Suite completa de modelos: 159 ejemplos, 0 fallos.
- Rubocop limpio.

🤖 Generated with [Claude Code](https://claude.com/claude-code)