### PR TITLE
Permitir sobrescribir `has_exam` desde `subject_overrides`

### DIFF
--- a/app/services/yml_loader.rb
+++ b/app/services/yml_loader.rb
@@ -93,7 +93,9 @@ class YmlLoader
 
       new_subject.create_course! unless new_subject.course
 
-      if subject["has_exam"]
+      has_exam = subject_overrides.fetch('has_exam', subject["has_exam"])
+
+      if has_exam
         new_subject.create_exam! unless new_subject.exam
       else
         raise "Subject #{code} no longer has an exam" if new_subject.exam

--- a/db/data/computacion/1997/subject_overrides.yml
+++ b/db/data/computacion/1997/subject_overrides.yml
@@ -525,6 +525,7 @@ CP31:
   category: 'inactive'
 '1511':
   category: 'inactive'
+  has_exam: true
 '1518':
   category: 'inactive'
 '1532':

--- a/spec/services/yml_loader_spec.rb
+++ b/spec/services/yml_loader_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe YmlLoader do
         expect(subject_group.credits_needed).to eq(70)
 
         # Subjects
-        expect(degree_plan.subjects.count).to eq(3)
+        expect(degree_plan.subjects.count).to eq(4)
         subject1 = degree_plan.subjects.find_by!(code: '101')
         expect(subject1.name).to eq('Cálculo I')
         expect(subject1.credits).to eq(14)
@@ -197,6 +197,18 @@ RSpec.describe YmlLoader do
           expect(existing_subject.group).to eq(existing_group)
           expect(existing_subject.current_semester).to be false
         end
+      end
+    end
+
+    context 'when subject_overrides overrides has_exam' do
+      let(:base_dir) { Rails.root.join("spec/support/mock_yamls/success") }
+
+      it 'uses the override to create an exam even when the scraped subject reports none' do
+        described_class.load
+
+        degree_plan = Degree.find(degree_id).degree_plans.find_by!(name: '2025')
+        subject = degree_plan.subjects.find_by!(code: '103')
+        expect(subject.exam).to be_present
       end
     end
 

--- a/spec/support/mock_yamls/success/test_degree/2025/scraped_subjects.yml
+++ b/spec/support/mock_yamls/success/test_degree/2025/scraped_subjects.yml
@@ -20,3 +20,8 @@
   name: SUBJECT WITH NO GROUP
   has_exam: false
   subject_groups: []
+'103':
+  code: '103'
+  name: SUBJECT WITH EXAM OVERRIDE
+  has_exam: false
+  subject_groups: []

--- a/spec/support/mock_yamls/success/test_degree/2025/subject_overrides.yml
+++ b/spec/support/mock_yamls/success/test_degree/2025/subject_overrides.yml
@@ -5,3 +5,5 @@
   openfing_id: testsubj
   short_name: TS1
   category: third_semester
+'103':
+  has_exam: true


### PR DESCRIPTION
### Motivación

Al correr la tarea `load_yaml` estábamos obteniendo el siguiente error:

```
RuntimeError: Subject 1511 no longer has an exam
app/services/yml_loader.rb:99 in block in YmlLoader#load_subjects
app/services/yml_loader.rb:67 in Hash#each
app/services/yml_loader.rb:67 in YmlLoader#load_subjects
app/services/yml_loader.rb:47 in block in YmlLoader#load_degree_plans
app/services/yml_loader.rb:41 in Array#each
```

### Causa

El scraper detecta que una materia tiene examen de dos formas: normalmente, Bedelías lista el examen como una entrada propia dentro del sistema de previaturas (con sus propias previaturas); o como fallback, si la materia no aparece en la lista, cuando otra materia declara el examen de esa materia como previatura.

`1511 - SISTEMAS OPERATIVOS` está inactiva, por lo que Bedelías no lista sus previaturas y el camino normal nunca se ejecuta. Su examen solo se conocía a través del fallback, gracias a que `1537 - SISTEMAS OPERATIVOS` necesitaba el examen de `1511`. Cuando `1537` [cambió esa previatura del examen a un `all` sobre `1511`](https://github.com/cedarcode/mi_carrera/commit/92bf7d53), el fallback también dejó de aplicar, por lo que `scraped_subjects.yml` ahora reporta `has_exam: false`.

Como el examen creado previamente seguía existiendo en la base, la carga levantaba el error `Subject 1511 no longer has an exam`.

### Solución

Agregamos soporte para sobrescribir `has_exam` desde `subject_overrides.yml`.
El loader ahora toma el valor del override cuando está presente y, si no, cae al valor scrapeado:

```ruby
has_exam = subject_overrides.fetch('has_exam', subject["has_exam"])
```

Y forzamos `has_exam: true` para `1511` en `db/data/computacion/1997/subject_overrides.yml`. Como el archivo de overrides no lo genera el scraper, esto es robusto ante que el scraper vuelva a generar el valor como `false`.