### PR TITLE
Sobrescribir `1511` de eléctrica para que tenga examen

### DIFF
--- a/db/data/computacion/1997/subject_overrides.yml
+++ b/db/data/computacion/1997/subject_overrides.yml
@@ -525,7 +525,6 @@ CP31:
   category: 'inactive'
 '1511':
   category: 'inactive'
-  has_exam: true
 '1518':
   category: 'inactive'
 '1532':

--- a/db/data/electrica/2023/subject_overrides.yml
+++ b/db/data/electrica/2023/subject_overrides.yml
@@ -546,6 +546,7 @@ MI2:
   category: 'inactive'
 "1511":
   category: 'inactive'
+  has_exam: true
 "5701":
   category: 'inactive'
 "5703":


### PR DESCRIPTION
Esto es un follow up de #1160 donde me confundí y modifiqué el `subject_overrides.yml` incorrecto 😅 