### PR TITLE
Marcar `1518` y `1532` (`SISTEMAS OPERATIVOS`) de Eléctrica como materias con examen

### DIFF
--- a/db/data/electrica/2023/subject_overrides.yml
+++ b/db/data/electrica/2023/subject_overrides.yml
@@ -484,10 +484,12 @@ MI2:
   category: 'inactive'
 "1518":
   category: 'inactive'
+  has_exam: true
 "1519":
   category: 'inactive'
 "1532":
   category: 'inactive'
+  has_exam: true
 "1536":
   category: 'inactive'
 "158Q":


### PR DESCRIPTION
### Motivación

`1518 - SISTEMAS OPERATIVOS` y `1532 - SISTEMAS OPERATIVOS` son materias inactivas del plan 2023 de Ingeniería Eléctrica, por lo que Bedelías no lista sus previaturas y el scraper solo conocía sus exámenes a través del fallback (otra materia que necesitaba el examen). En el scrapeo del 2026-06-22 (commit [`92bf7d53`](https://github.com/cedarcode/mi_carrera/commit/92bf7d53)) esas previaturas pasaron de `needs: exam` a `needs: all`, el fallback dejó de aplicar y `scraped_subjects.yml` pasó a reportar `has_exam: false`; como los exámenes creados previamente seguían en la base, la carga levantaba el error `Subject <código> ... no longer has an exam`.

### Detalles

Agregamos `has_exam: true` en el `subject_overrides.yml` de estas materias, usando el soporte para sobrescribir `has_exam` que agregamos en #1160.