### PR TITLE
Mostrar carrera y plan al fallar `load_yml` por una materia sin examen

### DIFF
--- a/app/services/yml_loader.rb
+++ b/app/services/yml_loader.rb
@@ -98,7 +98,7 @@ class YmlLoader
       if has_exam
         new_subject.create_exam! unless new_subject.exam
       else
-        raise "Subject #{code} no longer has an exam" if new_subject.exam
+        raise "Subject #{code} from #{degree.name} plan #{degree_plan.name} no longer has an exam" if new_subject.exam
       end
     end
   end

--- a/spec/services/yml_loader_spec.rb
+++ b/spec/services/yml_loader_spec.rb
@@ -226,7 +226,7 @@ RSpec.describe YmlLoader do
       end
 
       it 'raises an error' do
-        expect { described_class.load }.to raise_error('Subject 25 no longer has an exam')
+        expect { described_class.load }.to raise_error('Subject 25 from Test Degree plan 2025 no longer has an exam')
       end
     end
 


### PR DESCRIPTION
Cuando corremos `load_yml` y una materia deja de tener examen, el error ahora incluye el nombre de la carrera y del plan. Como ahora manejamos varias carreras, esto permite identificar rápidamente a cuál pertenece la materia que falla.