### PR TITLE
Cambiar el cache store de producción de `FileStore` a `MemoryStore`

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -45,8 +45,7 @@ Rails.application.configure do
   # Don't log any deprecations.
   config.active_support.report_deprecations = false
 
-  # Replace the default in-process memory cache store with a durable alternative.
-  # config.cache_store = :mem_cache_store
+  config.cache_store = :memory_store
 
   # Replace the default in-process and non-durable queuing backend for Active Job.
   # config.active_job.queue_adapter = :resque


### PR DESCRIPTION
## Motivación

Actualmente estamos usando FileStore (`config/environments/production.rb:49` tiene comentada la línea `config.cache_store` por lo que Rails fallbackea a `:file_store`) – así ha estado desde que se hizo `rails new`.

Además, tenemos configurado la aplicación para que rate limitee las requests (por defecto los límites son por controller e IP). Por lo que, debido a que el rate limiting escribe en la caché con cada solicitud web (hace un `open()` + `flock()` + `atomic_write` por request sobre `tmp/cache`), usar un almacenamiento basado en el sistema de archivos podría introduce cuellos de botella significativos en la I/O del disco. Una prueba de esto son los errores que recibimos el 25-07 en producción – al rededor de ~200 errores en un día:

```
Errno::EMFILE: Too many open files @ rb_sysopen - /rails/tmp/cache/B1C/3E0/rate-limit%3Asubjects%3A104.23.168.29
lib/active_support/cache/file_store.rb:150 in ActiveSupport::Cache::FileStore#lock_file
lib/active_support/cache/file_store.rb:228 in ActiveSupport::Cache::FileStore#modify_value
```

Esto, incluso, se vería agravado por los cambios mergeados en #1186 ya que ahora Rails usaría la IP de cada usuario como key del `rate_limit` en vez de las limitadas IPs de Cloudflare, por lo que más archivos se abrirían y se cerrarían.

## Detalles

Este PR cambia el `cache_store` para que use `:memory_store` en su lugar, que guarda todo en la memoria del proceso.
No especificamos `size:` porque el default de `MemoryStore` ya son 32 MB, más que suficiente considerando que con la ventana de 10 segundos del rate limit la caché no debería llega a superar ~1 MB en la práctica.