### PR TITLE
fix: 404 non-numeric ids on /grupos/:id instead of raising RecordNotFound

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -28,7 +28,7 @@ Rails.application.routes.draw do
 
     resource :profile, path: "perfil", only: :show
 
-    resources :subject_groups, path: "grupos", only: :show
+    resources :subject_groups, path: "grupos", only: :show, constraints: { id: /\d+/ }
 
     resources :approvables, only: [] do
       resource :approval, only: [:create, :destroy]

--- a/spec/requests/subject_groups_controller_spec.rb
+++ b/spec/requests/subject_groups_controller_spec.rb
@@ -1,0 +1,26 @@
+require 'rails_helper'
+
+RSpec.describe SubjectGroupsController, type: :request do
+  describe 'GET #show' do
+    it 'returns http success for a subject group in the current degree plan' do
+      subject_group = create(:subject_group)
+      cookies[:degree_plan_id] = subject_group.degree_plan_id.to_s
+
+      get subject_group_url(subject_group)
+
+      expect(response).to have_http_status(:success)
+    end
+
+    it 'returns 404 for a non-existent subject group id' do
+      get "/grupos/999999999"
+
+      expect(response).to have_http_status(:not_found)
+    end
+
+    it 'returns a routing 404 for a non-numeric id and does not reach the controller' do
+      get "/grupos/choices.js"
+
+      expect(response).to have_http_status(:not_found)
+    end
+  end
+end

--- a/spec/requests/subject_groups_controller_spec.rb
+++ b/spec/requests/subject_groups_controller_spec.rb
@@ -15,12 +15,15 @@ RSpec.describe SubjectGroupsController, type: :request do
       get "/grupos/999999999"
 
       expect(response).to have_http_status(:not_found)
+      expect(response.body).to include("ActiveRecord::RecordNotFound")
     end
 
     it 'returns a routing 404 for a non-numeric id and does not reach the controller' do
       get "/grupos/choices.js"
 
       expect(response).to have_http_status(:not_found)
+      expect(response.body).to include("Routing Error")
+      expect(response.body).not_to include("SubjectGroupsController")
     end
   end
 end

--- a/spec/routing/subject_groups_routing_spec.rb
+++ b/spec/routing/subject_groups_routing_spec.rb
@@ -1,0 +1,11 @@
+require 'rails_helper'
+
+RSpec.describe "routes for subject_groups", type: :routing do
+  it "routes a numeric id to subject_groups#show" do
+    expect(get: "/grupos/42").to route_to(controller: "subject_groups", action: "show", id: "42")
+  end
+
+  it "does not route a non-numeric id" do
+    expect(get: "/grupos/choices.js").not_to be_routable
+  end
+end


### PR DESCRIPTION
## Summary
- AppSignal alert: `Couldn't find SubjectGroup with 'id'="choices"` from `GET /grupos/choices.js` (app/controllers/subject_groups_controller.rb:3)
- Rails' router treats `.js` as a format extension, so `/grupos/choices.js` matched the `subject_groups#show` route with `id="choices"`, `format="js"`, reached `SubjectGroup.find("choices")`, and raised `ActiveRecord::RecordNotFound`
- AppSignal only ignores `ActionController::RoutingError` (see `config/appsignal.rb`), not `ActiveRecord::RecordNotFound`, so this reached the error tracker
- I looked for a real bug: `config/importmap.rb` pins `"choices.js"` to an **absolute** CDN URL, and there's no relative `choices.js` reference anywhere in the app's views/layouts/JS. This looks like bot/scanner traffic probing for a common filename against a valid route prefix, not a frontend bug
- Fix: constrain `:id` on the `subject_groups` route to digits, so non-numeric paths 404 at the routing layer (already filtered by AppSignal) instead of reaching the controller and raising

## Test plan
- [x] Added request specs in `spec/requests/subject_groups_controller_spec.rb` covering: valid id success, valid-but-nonexistent numeric id (still a clean 404), and non-numeric id like `choices.js` (routing 404)
- [x] `bundle exec rspec spec/requests spec/system/planned_subjects_spec.rb` — 38 examples, 0 failures
- [x] `bundle exec rubocop config/routes.rb spec/requests/subject_groups_controller_spec.rb` — no offenses

https://claude.ai/code/session_01QzWY6o8j4hZN2xFL3M5SWf