### PR TITLE
Requerir la contraseña para administrar las passkeys

### DIFF
--- a/app/controllers/devise/reauthentications_controller.rb
+++ b/app/controllers/devise/reauthentications_controller.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+module Devise
+  # Asks a signed-in user to prove themselves again, and writes a grant once
+  # they do.
+  #
+  # The proof it checks on its own is the password, so it depends on
+  # `database_authenticatable`. Add another kind of proof by overriding
+  # `proof_verified?` and calling `super` to keep the password working.
+  class ReauthenticationsController < DeviseController
+    include Devise::Reauthentication
+
+    before_action :authenticate_scope!
+
+    def new; end
+
+    def create
+      if proof_verified?
+        grant_reauthentication!
+        redirect_to stored_location_for(resource_name) || after_reauthentication_path
+      else
+        set_flash_message! :alert, :reauthentication_failed, scope: :"devise.failure"
+        # Do not read the stored location here. Reading it deletes it, and the
+        # user's retry would then lose its destination.
+        redirect_to url_for(action: :new)
+      end
+    end
+
+    private
+
+    def proof_verified?
+      password.present? && verify_password
+    end
+
+    # Going through `valid_for_authentication?` rather than straight to
+    # `valid_password?` keeps `lockable` counting, so this page is not a way
+    # around `config.maximum_attempts`.
+    def verify_password
+      resource.valid_for_authentication? { resource.valid_password?(password) }
+    end
+
+    def password
+      params.dig(resource_name, :password)
+    end
+
+    # The default url to be used after a passed challenge, when nothing was
+    # stored. You can overwrite this method in your own
+    # ReauthenticationsController.
+    def after_reauthentication_path
+      signed_in_root_path(resource)
+    end
+
+    def authenticate_scope!
+      send(:"authenticate_#{resource_name}!", force: true)
+      self.resource = send(:"current_#{resource_name}")
+    end
+  end
+end

--- a/app/controllers/users/passkeys_controller.rb
+++ b/app/controllers/users/passkeys_controller.rb
@@ -1,10 +1,17 @@
 module Users
   class PasskeysController < Devise::PasskeysController
+    include Devise::Reauthenticatable
+
     prepend_before_action :ensure_feature_enabled!
+    before_action :require_reauthentication!, only: %i[index create destroy]
 
     def index; end
 
     private
+
+    def reauthentication_return_path
+      user_passkeys_path
+    end
 
     def after_update_path
       user_passkeys_path

--- a/app/views/devise/reauthentications/new.html.erb
+++ b/app/views/devise/reauthentications/new.html.erb
@@ -1,0 +1,17 @@
+<div class="flex flex-col justify-center items-center p-6 space-y-6">
+  <h2 class="text-3xl/9 text-neutral-700">Verifica tu identidad</h2>
+
+  <div class="w-full max-w-md space-y-6">
+    <%= render 'shared/alert' if flash[:alert] %>
+
+    <p class="text-gray-700">
+      Para administrar tus passkeys necesitamos confirmar que eres tú.
+    </p>
+
+    <%= form_with(model: resource, url: user_reauthentication_path, method: :post, class: "flex flex-col space-y-6") do |f| %>
+      <%= render PasswordFieldComponent.new(form: f, attribute: :password, label: "Contraseña", input_options: { required: true, autofocus: true, autocomplete: "current-password" }) %>
+
+      <%= render ButtonComponent.new(form: f, label: "Confirmar") %>
+    <% end %>
+  </div>
+</div>

--- a/config/initializers/reauthentication.rb
+++ b/config/initializers/reauthentication.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+# The setting and the Warden hook live here, not under `lib/`, because Zeitwerk
+# only loads a file when Ruby resolves a constant defined in it. Calling
+# `Devise.reauthentication_period` resolves no constant, and the hook defines
+# no constant at all.
+module Devise
+  # How long a re-authentication grant stays valid. The window slides forward
+  # on every gated request.
+  mattr_accessor :reauthentication_period
+  @@reauthentication_period = 15.minutes
+end
+
+# Signing in counts as proof, so a user who has just signed in is never
+# interrupted. This runs for every strategy, whatever it checks.
+Warden::Manager.after_authentication do |_record, warden, options|
+  warden.session(options[:scope])["reauthenticated_at"] = Time.now.to_i
+end

--- a/config/locales/devise.es.yml
+++ b/config/locales/devise.es.yml
@@ -12,6 +12,7 @@ es:
       last_attempt: "Tienes un intento más antes de que tu cuenta sea bloqueada."
       passkey_verification_failed: "Hubo un error agregando esta passkey."
       passkey_deletion_failed: "Hubo un error eliminando esta passkey."
+      reauthentication_failed: "No pudimos verificar tu identidad. Inténtalo de nuevo."
     mailer:
       reset_password_instructions:
         subject: "Instrucciones de cambio de contraseña"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -20,6 +20,8 @@ Rails.application.routes.draw do
     devise_scope :user do
       scope path: "usuarios", module: "users", as: "user" do
         resources :passkeys, only: [:index]
+        resource :reauthentication, only: [:new, :create],
+                                    path: "reautenticacion", controller: "/devise/reauthentications"
         resource :degrees, only: [:edit, :update], path: "carreras"
       end
     end

--- a/lib/devise/reauthenticatable.rb
+++ b/lib/devise/reauthenticatable.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+module Devise
+  # Interrupts a request when the user has not proved themselves recently.
+  #
+  # Each controller picks the actions it wants to gate:
+  #
+  #   include Devise::Reauthenticatable
+  #   before_action :require_reauthentication!, only: %i[index create destroy]
+  module Reauthenticatable
+    extend ActiveSupport::Concern
+    include Devise::Reauthentication
+
+    private
+
+    def require_reauthentication!
+      if reauthenticated?
+        grant_reauthentication! # slide the window
+        return
+      end
+
+      store_location_for(resource_name, reauthentication_return_path)
+      redirect_to new_user_reauthentication_path
+    end
+
+    def reauthentication_return_path
+      request.fullpath if request.get? || request.head?
+    end
+  end
+end

--- a/lib/devise/reauthentication.rb
+++ b/lib/devise/reauthentication.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module Devise
+  # Records that a user proved themselves recently, and answers whether that
+  # proof is still valid.
+  #
+  # This module knows nothing about how the user proved themselves. Include it
+  # in your own challenge controller and call +grant_reauthentication!+ once
+  # you have verified whatever proof you asked for.
+  module Reauthentication
+    def reauthenticated?
+      stamped_at = warden.session(resource_name)["reauthenticated_at"]
+
+      stamped_at.present? && Time.zone.at(stamped_at) > Devise.reauthentication_period.ago
+    end
+
+    def grant_reauthentication!
+      warden.session(resource_name)["reauthenticated_at"] = Time.now.to_i
+    end
+  end
+end

--- a/spec/requests/passkeys_controller_spec.rb
+++ b/spec/requests/passkeys_controller_spec.rb
@@ -1,0 +1,68 @@
+require 'rails_helper'
+
+RSpec.describe Users::PasskeysController, type: :request do
+  include ActiveSupport::Testing::TimeHelpers
+
+  let(:user) { create(:user) }
+  let(:passkey) do
+    user.passkeys.create!(external_id: 'external-id', name: 'A passkey', public_key: 'public-key', sign_count: 0)
+  end
+  ENV['ENABLE_PASSKEYS'] = 'true'
+
+  describe 'the re-authentication gate' do
+    before do
+      sign_in user
+
+      # Signing in writes a grant, so this request is never interrupted.
+      get user_passkeys_path
+    end
+
+    it 'lets a user who has just signed in through' do
+      expect(response).to have_http_status(:ok)
+    end
+
+    it 'challenges a user whose grant has expired on GET index' do
+      travel Devise.reauthentication_period + 1.minute
+
+      get user_passkeys_path
+
+      expect(response).to redirect_to(new_user_reauthentication_path)
+    end
+
+    it 'challenges a user whose grant has expired on POST create' do
+      travel Devise.reauthentication_period + 1.minute
+
+      expect do
+        post user_passkeys_path, params: { public_key_credential: '{}', name: 'A new passkey' }
+      end.not_to change(user.passkeys, :count)
+
+      expect(response).to redirect_to(new_user_reauthentication_path)
+    end
+
+    it 'challenges a user whose grant has expired on DELETE destroy' do
+      path = user_passkey_path(passkey)
+      travel Devise.reauthentication_period + 1.minute
+
+      expect do
+        delete path
+      end.not_to change(user.passkeys, :count)
+
+      expect(response).to redirect_to(new_user_reauthentication_path)
+    end
+
+    it 'slides the window forward on every gated request' do
+      travel 10.minutes
+      get user_passkeys_path
+      expect(response).to have_http_status(:ok)
+
+      # 20 minutes after signing in, but only 10 after the request above.
+      travel 10.minutes
+      get user_passkeys_path
+      expect(response).to have_http_status(:ok)
+
+      travel Devise.reauthentication_period + 1.minute
+      get user_passkeys_path
+      expect(response).to redirect_to(new_user_reauthentication_path)
+    end
+  end
+end

--- a/spec/requests/reauthentication_spec.rb
+++ b/spec/requests/reauthentication_spec.rb
@@ -1,0 +1,149 @@
+require 'rails_helper'
+
+RSpec.describe 'Re-authentication', type: :request do
+  include ActiveSupport::Testing::TimeHelpers
+
+  let(:password) { 'S3cr3tP@ssw0rd!' }
+  let(:user) { create(:user, password:) }
+  ENV['ENABLE_PASSKEYS'] = 'true'
+
+  describe 'GET #new' do
+    context 'when the user is signed out' do
+      it 'redirects to the sign-in page' do
+        get new_user_reauthentication_path
+
+        expect(response).to redirect_to(new_user_session_path)
+      end
+    end
+
+    context 'when the user is signed in' do
+      before do
+        sign_in user
+      end
+
+      it 'asks for the password' do
+        get new_user_reauthentication_path
+
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to include('Verifica tu identidad')
+        expect(response.body).to include('Contraseña')
+      end
+    end
+  end
+
+  describe 'POST #create' do
+    context 'when the user is signed out' do
+      it 'redirects to the sign-in page' do
+        post user_reauthentication_path, params: { user: { password: password } }
+
+        expect(response).to redirect_to(new_user_session_path)
+      end
+    end
+
+    context 'when the user is signed in' do
+      before do
+        sign_in user
+        get root_path
+      end
+
+      context 'when the right password is provided' do
+        context 'when there is a stored location to redirect to afterwards' do
+          before do
+            travel Devise.reauthentication_period + 1.minute
+            get user_passkeys_path
+          end
+
+          it 'writes a grant and redirects to the saved location' do
+            post user_reauthentication_path, params: { user: { password: password } }
+
+            expect(response).to redirect_to(user_passkeys_path)
+
+            # Further requests inside the reauthentication period don't
+            # require re-authentication
+            get user_passkeys_path
+            expect(response).to have_http_status(:ok)
+          end
+        end
+
+        context 'when the gate caught a passkey creation' do
+          before do
+            travel Devise.reauthentication_period + 1.minute
+            post user_passkeys_path, params: { name: 'A new passkey' }
+          end
+
+          it 'writes a grant and redirects back to the passkeys page' do
+            post user_reauthentication_path, params: { user: { password: password } }
+
+            expect(response).to redirect_to(user_passkeys_path)
+
+            # Further requests inside the reauthentication period don't
+            # require re-authentication
+            get user_passkeys_path
+            expect(response).to have_http_status(:ok)
+          end
+        end
+
+        context 'when the user reached the challenge page on their own' do
+          it 'writes a grant and falls back to the Devise layer default' do
+            post user_reauthentication_path, params: { user: { password: password } }
+
+            expect(response).to redirect_to(root_path)
+          end
+        end
+
+        context 'when the gate caught a passkey deletion' do
+          let(:passkey) do
+            user.passkeys.create!(external_id: 'external-id', name: 'A passkey', public_key: 'key', sign_count: 0)
+          end
+
+          before do
+            path = user_passkey_path(passkey)
+            travel Devise.reauthentication_period + 1.minute
+            delete path
+          end
+
+          it 'writes a grant and redirects back to the passkeys page' do
+            post user_reauthentication_path, params: { user: { password: password } }
+
+            expect(response).to redirect_to(user_passkeys_path)
+          end
+        end
+      end
+
+      context 'with the wrong password' do
+        context 'when there is a stored location to redirect to afterwards' do
+          before do
+            travel Devise.reauthentication_period + 1.minute
+            get user_passkeys_path
+          end
+
+          it 'fails and keeps the saved location' do
+            post user_reauthentication_path, params: { user: { password: 'not the password' } }
+
+            expect(response).to redirect_to(new_user_reauthentication_path)
+            expect(flash[:alert]).to eq I18n.t('devise.failure.reauthentication_failed')
+
+            # The retry still knows where the user was headed.
+            post user_reauthentication_path, params: { user: { password: password } }
+
+            expect(response).to redirect_to(user_passkeys_path)
+          end
+
+          it 'counts against the lockout' do
+            expect do
+              post user_reauthentication_path, params: { user: { password: 'not the password' } }
+            end.to change { user.reload.failed_attempts }.by(1)
+          end
+
+          it 'locks the account once the attempts run out' do
+            user.update!(failed_attempts: Devise.maximum_attempts - 1)
+
+            post user_reauthentication_path, params: { user: { password: 'not the password' } }
+
+            expect(user.reload).to be_access_locked
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/system/manage_passkeys_spec.rb
+++ b/spec/system/manage_passkeys_spec.rb
@@ -1,6 +1,8 @@
 require 'rails_helper'
 
 RSpec.describe 'Manage passkeys' do
+  include ActiveSupport::Testing::TimeHelpers
+
   let!(:user) { create(:user) }
   ENV['ENABLE_PASSKEYS'] = 'true'
 
@@ -44,7 +46,21 @@ RSpec.describe 'Manage passkeys' do
 
       visit edit_user_registration_path
 
+      # The grant the sign-in wrote expires, so the next visit is interrupted.
+      travel Devise.reauthentication_period + 1.minute
       click_on "Administrar Passkeys"
+
+      expect(page).to have_text "Verifica tu identidad"
+
+      fill_in "Contraseña", with: "wrong password"
+      click_on "Confirmar"
+
+      expect(page).to have_text "No pudimos verificar tu identidad"
+
+      fill_in "Contraseña", with: user.password
+      click_on "Confirmar"
+
+      expect(page).to have_text "Administra tus Passkeys"
 
       within("li", text: "My new passkey") do
         accept_confirm "¿Seguro que quieres borrar esta Passkey?" do


### PR DESCRIPTION
### Motivación

Hoy, para agregar una passkey, solo verificamos que haya una sesión iniciada. Cualquier sesión válida alcanza.

Esto es un riesgo. Si alguien roba una sesión, puede registrar su propia passkey. Esa passkey le da una entrada propia a la cuenta, y la conserva aunque la persona dueña cambie su contraseña.

### Detalles

Antes de entrar a la página de passkeys, ahora le pedimos la contraseña de nuevo. El approach es parecido al modo "sudo" que se usa en GitHub.

Iniciar sesión también cuenta como prueba, así que un usuario acaba de loguearse no va a tener que reautenticarse. Esto es así por 15 minutos – una vez pasados los 15 minutos, la sesión se considera "inactiva" y se va a requerir una contraseña para agregar una passkey. A su vez, cada request actualiza la sesión como "activa" por 15 minutos más. Estos 15 minutos son configurables.

Verificamos la contraseña usando `valid_for_authentication?` en vez de simplemente `valid_password?`, así los intentos fallidos suman a `lockable`.

El código queda separado en dos capas, pensando en extraerlo a su propia gema más adelante:

| Capa | Qué hace |
| --- | --- |
| `Devise::Reauthentication` y `Devise::Reauthenticatable` |  Llevan el registro de la última validación y deciden cuándo interrumpir. |
| `Devise::ReauthenticationsController` | Muestra la página y verifica la contraseña. |

`Devise::Reauthenticatable` no declara ningún `before_action`. Cada controlador elige qué acciones proteger; en nuestra app de momento solo protegemos `index`, `create` y `destroy` de `Users::PasskeysController`.

## TODO

- Permitir usar passkeys para reautenticarse
- Los usuarios que usan SSO no pueden reautenticarse porque se les setea una contraseña random. Hay que ver cómo resolvemos esos casos