### PR TITLE
fix: manejar UnknownFormat para que no llegue a AppSignal

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -5,6 +5,12 @@ class ApplicationController < ActionController::Base
   helper_method :current_student, :current_degree_plan
   rate_limit to: 20, within: 10.seconds
 
+  # The app only serves HTML. Rails already maps UnknownFormat to a 406, but letting it
+  # raise reports every scanner asking for JSON as an error. Answer the 406 ourselves.
+  rescue_from ActionController::UnknownFormat do
+    head :not_acceptable
+  end
+
   private
 
   def current_student

--- a/spec/requests/unknown_format_spec.rb
+++ b/spec/requests/unknown_format_spec.rb
@@ -1,0 +1,26 @@
+require 'rails_helper'
+
+RSpec.describe 'Unknown request formats', type: :request do
+  # AppSignal's Rack middleware sits inside ActionDispatch's exception handling, so it only
+  # reports errors that escape the action. Turning show_exceptions off makes that escape
+  # visible here: without the rescue_from, these raise instead of answering.
+  around do |example|
+    original = Rails.application.env_config['action_dispatch.show_exceptions']
+    Rails.application.env_config['action_dispatch.show_exceptions'] = :none
+    example.run
+  ensure
+    Rails.application.env_config['action_dispatch.show_exceptions'] = original
+  end
+
+  it 'answers 406 instead of raising when a client only accepts JSON' do
+    get root_url, headers: { 'Accept' => 'application/json' }
+
+    expect(response).to have_http_status(:not_acceptable)
+  end
+
+  it 'still answers HTML to a regular browser request' do
+    get root_url, headers: { 'Accept' => 'text/html' }
+
+    expect(response).to have_http_status(:ok)
+  end
+end


### PR DESCRIPTION
## Problema

AppSignal reporta `ActionController::UnknownFormat` de forma recurrente: la app sirve solo HTML y cualquier cliente que pide otro formato (scanners con `Accept: application/json`) hace que el render implícito levante la excepción. No afecta a usuarios — Rails ya devuelve 406 — pero la excepción escapa de la acción y el middleware de AppSignal la registra.

## Solución

`rescue_from ActionController::UnknownFormat` en `ApplicationController`. Mismo 406, manejado dentro del controller, para toda la app.

## Tests

`spec/requests/unknown_format_spec.rb`: 406 con `Accept: application/json`, 200 con `text/html`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
